### PR TITLE
Generalize categories

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -1,38 +1,20 @@
 import argparse
 import time
 import re
-from user_scanner.core.orchestrator import run_checks, load_modules , generate_permutations
+from user_scanner.core.orchestrator import run_checks, load_modules , generate_permutations, load_categories
 from colorama import Fore, Style
 from .cli import banner
 from .cli.banner import print_banner
 
-CATEGORY_MAPPING = {
-    "dev": "dev",
-    "social": "social",
-    "creator": "creator",
-    "community": "community",
-    "gaming": "gaming",
-    "donation": "donation"
-}
-
 MAX_PERMUTATIONS_LIMIT = 100 # To prevent excessive generation
 
 def list_modules(category=None):
-    from user_scanner import dev, social, creator, community, gaming, donation
-    packages = {
-        "dev": dev,
-        "social": social,
-        "creator": creator,
-        "community": community,
-        "gaming": gaming,
-        "donation": donation
-    }
-
-    categories_to_list = [category] if category else packages.keys()
+    categories = load_categories()
+    categories_to_list = [category] if category else categories.keys()
 
     for cat_name in categories_to_list:
-        package = packages[cat_name]
-        modules = load_modules(package)
+        path = categories[cat_name]
+        modules = load_modules(path)
         print(Fore.MAGENTA +
             f"\n== {cat_name.upper()} SITES =={Style.RESET_ALL}")
         for module in modules:
@@ -49,7 +31,7 @@ def main():
         "-u", "--username",  help="Username to scan across platforms"
     )
     parser.add_argument(
-        "-c", "--category", choices=CATEGORY_MAPPING.keys(),
+        "-c", "--category", choices=load_categories().keys(),
         help="Scan all platforms in a category"
     )
     parser.add_argument(
@@ -74,8 +56,7 @@ def main():
     )
     
     args = parser.parse_args()
-    
-    
+        
     if args.list:
         list_modules(args.category)
         return
@@ -114,23 +95,12 @@ def main():
     if args.module and "." in args.module:
         args.module = args.module.replace(".", "_")
 
-    from user_scanner import dev, social, creator, community, gaming, donation
-    
-    MODULE_MAPPING = {
-        "dev": dev,
-        "social": social,
-        "creator": creator,
-        "community": community,
-        "gaming": gaming,
-        "donation": donation
-    }
 
     if args.module:
         # Single module search across all categories
-        packages = [dev, social, creator, community, gaming, donation]
         found = False
-        for package in packages:
-            modules = load_modules(package)
+        for cat_path in load_categories().values():
+            modules = load_modules(cat_path)
             for module in modules:
                 site_name = module.__name__.split(".")[-1]
                 if site_name.lower() == args.module.lower():
@@ -145,7 +115,7 @@ def main():
                 Fore.RED + f"[!] Module '{args.module}' not found in any category." + Style.RESET_ALL)
     elif args.category:
         # Category-wise scan
-        category_package = MODULE_MAPPING.get(args.category)
+        category_package = load_categories().get(args.category)
         from user_scanner.core.orchestrator import run_checks_category
         
         for name in usernames:   # <-- permutation support here


### PR DESCRIPTION
Instead of having to manually insert each category in `__main__.py` and in `orchestator.py` when created, I made it so they are automatically loaded:

- Created `load_categories() -> Dict[str, Path]` that returns a dictionary of the names of each category with its path;
- Changed `load_modules(category_path: Path)` to accept the category path instead;
