### PR TITLE
Add huggingface username validation support (dev category)

### DIFF
--- a/user_scanner/dev/huggingface.py
+++ b/user_scanner/dev/huggingface.py
@@ -1,0 +1,19 @@
+from user_scanner.core.orchestrator import status_validate
+
+
+def validate_huggingface(user):
+    url = f"https://huggingface.co/{user}"
+
+    return status_validate(url, 404, 200, follow_redirects=True)
+
+
+if __name__ == "__main__":
+    user = input("Username?: ").strip()
+    result = validate_huggingface(user)
+
+    if result == 1:
+        print("Available!")
+    elif result == 0:
+        print("Unavailable!")
+    else:
+        print("Error occurred!")


### PR DESCRIPTION
This PR adds huggingface username validation to the dev category.


- Uses the pattern https://huggingface.co/<username> for profile URLs
- Treats HTTP 404 as available and HTTP 200 as taken


Closes https://github.com/kaifcodec/user-scanner/issues/72