### PR TITLE
Fix importlib.util AttributeError on Python 3.13

### DIFF
--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -1,5 +1,5 @@
 import importlib
-import importlib.util #this is the line I added to fix the issue
+import importlib.util
 from colorama import Fore, Style
 import threading
 from itertools import permutations


### PR DESCRIPTION
Error/bug: AttributeError: module 'importlib' has no attribute 'util'

Fix: added **import importlib.util** to orchestrator.py

This resolves the issue and restores compatibility

Tested and confirmed working on Kali Linux (Python 3.13).