### PR TITLE
Fix Monkeytype check failing on usernames with special characters

### DIFF
--- a/user_scanner/gaming/monkeytype.py
+++ b/user_scanner/gaming/monkeytype.py
@@ -1,9 +1,11 @@
 from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
+from urllib.parse import quote
+
 
 def validate_monkeytype(user: str) -> int:
-
-    url = f"https://api.monkeytype.com/users/checkName/{user}"
+    safe_user = quote(user, safe="")
+    url = f"https://api.monkeytype.com/users/checkName/{safe_user}"
 
     headers = {
         "User-Agent": (
@@ -28,6 +30,16 @@ def validate_monkeytype(user: str) -> int:
                 return Result.available()
             elif available is False:
                 return Result.taken()
+
+        # Surface Monkeytype validation errors (e.g. special characters)
+        try:
+            data = response.json()
+            errors = data.get("validationErrors")
+            if errors:
+                return Result.error("; ".join(errors))
+        except Exception:
+            pass
+
         return Result.error("Invalid status code")
 
     return generic_validate(url, process, headers=headers)
@@ -42,4 +54,4 @@ if __name__ == "__main__":
     elif result == 0:
         print("Unavailable!")
     else:
-        print("Error occurred!")
+        print("Error occured!")


### PR DESCRIPTION
Fixes part of #115

Monkeytype username checks were returning a generic "Invalid status code"
when usernames contained unsupported characters (e.g. dots).

This change surfaces Monkeytype’s own validation error response instead,
providing a clear and accurate reason for the failure instead of a status error.