### PR TITLE
Enforce check for default config.json

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,10 @@
 from user_scanner.utils import updater_logic as ul
 
+def test_default_config():
+    configs = ul.load_config()
+    assert "auto_update_status" in configs
+    # Make sure config.json has "auto_update_status" set to true
+    assert configs["auto_update_status"]
 
 def test_config_json(tmp_path, monkeypatch):
     cfg = tmp_path / "config.json"


### PR DESCRIPTION
`config.json` can easily be modified (automatically) and accidentally commited it without the default values. There are two solutions:
1. Add a test to check if the configs are default (what this PR does).
2. Add a test to check if the config file doesn't exist (the `load_config` function theoretically creates a new one when executed).

If you prefer the second option, I can easily modify the test.