### PR TITLE
fix(stackoverflow.py): fix the empty response body error, now `follow_redirects=True`

### DIFF
--- a/user_scanner/email_scan/community/stackoverflow.py
+++ b/user_scanner/email_scan/community/stackoverflow.py
@@ -2,7 +2,7 @@ import httpx
 from user_scanner.core.result import Result
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(http2=False) as client:
+    async with httpx.AsyncClient(http2=False, follow_redirects=True) as client:
         try:
             url = "https://stackoverflow.com/users/login"
 


### PR DESCRIPTION
Fix empty response body caused by redirect response.
Enable follow_redirects to correctly handle StackOverflow flow.