### PR TITLE
Fix: Result is printed when email validator isn't found

### DIFF
--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -15,7 +15,11 @@ def _worker_single(module: ModuleType, username: str) -> Result:
     site_name = get_site_name(module)
 
     if not func:
-        return Result.error(f"{site_name} has no validate_ function", site_name=site_name, username=username)
+        return Result.error(
+            f"{site_name} has no validate_ function",
+            site_name=site_name,
+            username=username,
+        )
 
     try:
         result: Result = func(username)
@@ -48,8 +52,7 @@ def run_user_category(category_path: Path, username: str) -> List[Result]:
         for result in exec_map:
             result.update(category=category_name)
             results.append(result)
-
-            print(result.get_console_output())
+            result.show()
 
     return results
 

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -61,6 +61,7 @@ class Result:
         for field in ("username", "site_name", "category", "is_email"):
             if field in kwargs and kwargs[field] is not None:
                 setattr(self, field, kwargs[field])
+        return self
 
     @classmethod
     def taken(cls, reason: str | Exception | None = None, **kwargs):
@@ -148,11 +149,18 @@ class Result:
 
     def get_console_output(self) -> str:
         site_name = self.site_name
-        username = self.username
         status_text = self.status.to_label(self.is_email)
+        username = ""
+        if self.username:
+            username = f"({self.username})"
 
         color = self.get_output_color()
         icon = self.get_output_icon()
 
         reason = f" ({self.get_reason()})" if self.has_reason() else ""
-        return f"  {color}{icon} {site_name} ({username}): {status_text}{reason}{Style.RESET_ALL}"
+        return f"  {color}{icon} {site_name} {username}: {status_text}{reason}{Style.RESET_ALL}"
+
+    def show(self):
+        """Prints the console output and returns itself for chaining"""
+        print(self.get_console_output())
+        return self


### PR DESCRIPTION
Basically, when executing `user_scanner -e <email> -m <specific-module>` and its validator function not being found, the program would silently exit (just for the email scanner, as the user scanner appears to work) . This is a simple fix for this issue.

Also, added `Result.show()` to simplify its printing and chaining.