### PR TITLE
Feature: Add --only-found flag to filter console output for hits only

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -271,7 +271,7 @@ def main():
             fn = run_email_module_batch if is_email else run_user_module
             if modules:
                 for module in modules:
-                    results.extend(fn(module, target, show_url=args.verbose, only_found=args.only_found))
+                    results.extend(fn(module, target, show_url=args.verbose))
             else:
                 print(
                     R +
@@ -328,7 +328,15 @@ def main():
                 f.write(content)
 
         print(G + f"\n[+] Results saved to {args.output}" + Style.RESET_ALL)
+    total_found = len([r for r in results if r.is_found()])
 
+    if args.only_found:
+        if total_found == 0:
+            print(f"\n{R}[✘] No results found for the given target(s).{X}")
+        else:
+            print(f"\n{G}[✔] Total hits found:{X} {total_found}")
+    else:
+        print(f"\n{C}[i] Scan complete. Total hits:{X} {total_found}")
 
 if __name__ == "__main__":
     main()

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -96,6 +96,10 @@ def main():
         help="Validate proxies before scanning (tests against google.com)")
 
     parser.add_argument(
+        "--only-found", action="store_true",
+        help="Only show sites where the username/email was found")
+
+    parser.add_argument(
         "-U", "--update", action="store_true", help="Update the tool")
 
     parser.add_argument("--version", action="store_true", help="Print version")
@@ -267,7 +271,7 @@ def main():
             fn = run_email_module_batch if is_email else run_user_module
             if modules:
                 for module in modules:
-                    results.extend(fn(module, target, show_url=args.verbose))
+                    results.extend(fn(module, target, show_url=args.verbose, only_found=args.only_found))
             else:
                 print(
                     R +
@@ -279,7 +283,7 @@ def main():
             cat_path = load_categories(is_email).get(args.category)
             fn = run_email_category_batch if is_email else run_user_category
             if cat_path:
-                results.extend(fn(cat_path, target, show_url=args.verbose))
+                results.extend(fn(cat_path, target, show_url=args.verbose, only_found=args.only_found))
             else:
                 print(
                     R +
@@ -288,7 +292,7 @@ def main():
                 )
         else:
             fn = run_email_full_batch if is_email else run_user_full
-            results.extend(fn(target, show_url=args.verbose))
+            results.extend(fn(target, show_url=args.verbose, only_found=args.only_found))
 
     if args.output:
         content = formatter.into_csv(

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -1,8 +1,7 @@
 import asyncio
 from pathlib import Path
 from types import ModuleType
-from typing import List
-
+from typing import List, Optional, Set
 from colorama import Fore, Style
 
 from user_scanner.core.helpers import find_category, load_categories, load_modules
@@ -14,7 +13,7 @@ MAX_CONCURRENT_REQUESTS = 25
 
 async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore,
                         show_url: bool = False, only_found: bool = False,
-                        printed_cats: set = None) -> Result:
+                        printed_cats: Optional[Set] = None) -> Result:
     async with sem:
         module_name = module.__name__.split(".")[-1]
         func_name = f"validate_{module_name}"
@@ -55,7 +54,7 @@ async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore,
 
 
 async def _run_batch(modules: List[ModuleType], email: str, show_url: bool = False,
-                     only_found: bool = False, printed_cats: set = None) -> List[Result]:
+                     only_found: bool = False, printed_cats: Optional[Set] = None) -> List[Result]:
     sem = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
     tasks = []
     for module in modules:

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -12,7 +12,7 @@ from user_scanner.core.result import Result
 MAX_CONCURRENT_REQUESTS = 15
 
 
-async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore, show_url: bool = False) -> Result:
+async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore, show_url: bool = False, only_found: bool = False) -> Result:
     async with sem:
         module_name = module.__name__.split(".")[-1]
         func_name = f"validate_{module_name}"
@@ -27,7 +27,7 @@ async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore, 
 
         if not hasattr(module, func_name):
             return (
-                Result.error(f"Function {func_name} not found").update(**params).show(show_url=show_url)
+                Result.error(f"Function {func_name} not found").update(**params).show(show_url=show_url, only_found=only_found)
             )
 
         func = getattr(module, func_name)
@@ -38,33 +38,33 @@ async def _async_worker(module: ModuleType, email: str, sem: asyncio.Semaphore, 
         except Exception as e:
             result = Result.error(e)
 
-        return result.update(**params).show(show_url=show_url)
+        return result.update(**params).show(show_url=show_url, only_found=only_found)
 
 
-async def _run_batch(modules: List[ModuleType], email: str, show_url: bool = False) -> List[Result]:
+async def _run_batch(modules: List[ModuleType], email: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     sem = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
     tasks = []
     for module in modules:
-        tasks.append(_async_worker(module, email, sem, show_url=show_url))
+        tasks.append(_async_worker(module, email, sem, show_url=show_url, only_found=only_found))
 
     if not tasks:
         return []
     return list(await asyncio.gather(*tasks))
 
 
-def run_email_module_batch(module: ModuleType, email: str, show_url: bool = False) -> List[Result]:
-    return asyncio.run(_run_batch([module], email, show_url=show_url))
+def run_email_module_batch(module: ModuleType, email: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
+    return asyncio.run(_run_batch([module], email, show_url=show_url, only_found=only_found))
 
 
-def run_email_category_batch(category_path: Path, email: str, show_url: bool = False) -> List[Result]:
+def run_email_category_batch(category_path: Path, email: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     cat_name = category_path.stem.capitalize()
     print(f"\n{Fore.MAGENTA}== {cat_name} SITES =={Style.RESET_ALL}")
 
     modules = load_modules(category_path)
-    return asyncio.run(_run_batch(modules, email, show_url=show_url))
+    return asyncio.run(_run_batch(modules, email, show_url=show_url, only_found=only_found))
 
 
-def run_email_full_batch(email: str, show_url: bool = False) -> List[Result]:
+def run_email_full_batch(email: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     categories = load_categories(is_email=True)
     all_results = []
 
@@ -72,7 +72,7 @@ def run_email_full_batch(email: str, show_url: bool = False) -> List[Result]:
         print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
 
         modules = load_modules(cat_path)
-        cat_results = asyncio.run(_run_batch(modules, email, show_url=show_url))
+        cat_results = asyncio.run(_run_batch(modules, email, show_url=show_url, only_found=only_found))
         all_results.extend(cat_results)
 
     return all_results

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -36,6 +36,7 @@ def run_user_module(module: ModuleType, username: str, show_url: bool = False, o
     if category:
         result.update(category=category)
 
+    # Use the result.show logic which handles the only_found filtering
     result.show(show_url=show_url, only_found=only_found)
 
     return [result]
@@ -43,17 +44,28 @@ def run_user_module(module: ModuleType, username: str, show_url: bool = False, o
 
 def run_user_category(category_path: Path, username: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     category_name = category_path.stem.capitalize()
-    print(f"\n{Fore.MAGENTA}== {category_name} SITES =={Style.RESET_ALL}")
-
     results = []
     modules = load_modules(category_path)
+    header_printed = False 
 
     with ThreadPoolExecutor(max_workers=20) as executor:
+        # map returns results as they are finished, allowing for "streaming" output
         exec_map = executor.map(lambda m: _worker_single(m, username), modules)
         for result in exec_map:
             result.update(category=category_name)
             results.append(result)
-            result.show(show_url=show_url, only_found=only_found)
+
+            if only_found:
+                if result.is_found():
+                    if not header_printed:
+                        print(f"\n{Fore.MAGENTA}== {category_name.upper()} SITES =={Style.RESET_ALL}")
+                        header_printed = True
+                    result.show(show_url=show_url, only_found=only_found)
+            else:
+                if not header_printed:
+                    print(f"\n{Fore.MAGENTA}== {category_name.upper()} SITES =={Style.RESET_ALL}")
+                    header_printed = True
+                result.show(show_url=show_url, only_found=only_found)
 
     return results
 
@@ -73,21 +85,29 @@ def run_user_full(username: str, show_url: bool = False, only_found: bool = Fals
             module_to_cat[get_site_name(m)] = display_name
 
     with ThreadPoolExecutor(max_workers=60) as executor:
-        exec_map = executor.map(
-            lambda m: _worker_single(m, username), all_modules)
+        exec_map = executor.map(lambda m: _worker_single(m, username), all_modules)
         for result in exec_map:
             site_name = result.site_name
             cat_name = module_to_cat.get(site_name, "Unknown") if site_name else "Unknown"
 
-            if cat_name not in printed_categories:
-                print(f"\n{Fore.MAGENTA}== {cat_name} SITES =={Style.RESET_ALL}")
-                printed_categories.add(cat_name)
-
             result.update(category=cat_name)
             results.append(result)
-            result.show(show_url=show_url, only_found=only_found)
+
+            if only_found:
+                if result.is_found():
+                    if cat_name not in printed_categories:
+                        print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
+                        printed_categories.add(cat_name)
+                    result.show(show_url=show_url, only_found=only_found)
+            else:
+                if cat_name not in printed_categories:
+                    print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
+                    printed_categories.add(cat_name)
+                result.show(show_url=show_url, only_found=only_found)
 
     return results
+
+
 
 
 def make_request(url: str, **kwargs) -> httpx.Response:

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -29,19 +29,19 @@ def _worker_single(module: ModuleType, username: str) -> Result:
         return Result.error(e, site_name=site_name, username=username)
 
 
-def run_user_module(module: ModuleType, username: str, show_url: bool = False) -> List[Result]:
+def run_user_module(module: ModuleType, username: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     result = _worker_single(module, username)
 
     category = find_category(module)
     if category:
         result.update(category=category)
 
-    print(result.get_console_output(show_url=show_url))
+    result.show(show_url=show_url, only_found=only_found)
 
     return [result]
 
 
-def run_user_category(category_path: Path, username: str, show_url: bool = False) -> List[Result]:
+def run_user_category(category_path: Path, username: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     category_name = category_path.stem.capitalize()
     print(f"\n{Fore.MAGENTA}== {category_name} SITES =={Style.RESET_ALL}")
 
@@ -53,12 +53,12 @@ def run_user_category(category_path: Path, username: str, show_url: bool = False
         for result in exec_map:
             result.update(category=category_name)
             results.append(result)
-            result.show(show_url=show_url)
+            result.show(show_url=show_url, only_found=only_found)
 
     return results
 
 
-def run_user_full(username: str, show_url: bool = False) -> List[Result]:
+def run_user_full(username: str, show_url: bool = False, only_found: bool = False) -> List[Result]:
     results = []
     all_modules = []
     categories = list(load_categories().items())
@@ -85,7 +85,7 @@ def run_user_full(username: str, show_url: bool = False) -> List[Result]:
 
             result.update(category=cat_name)
             results.append(result)
-            result.show(show_url=show_url)
+            result.show(show_url=show_url, only_found=only_found)
 
     return results
 

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -166,6 +166,11 @@ class Result:
         reason = f" ({self.get_reason()})" if self.has_reason() else ""
         return f"  {color}{icon} {site_name}{url_display} {username}: {status_text}{reason}{Style.RESET_ALL}"
 
+    def is_found(self) -> bool:
+        """Returns True if the target was found or registered (Status.TAKEN)"""
+        return self.status == Status.TAKEN
+
+
     def show(self, show_url=False, only_found=False):
         """Prints the console output and returns itself for chaining.
         If only_found is True, only results with Status.TAKEN are printed."""

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -166,8 +166,11 @@ class Result:
         reason = f" ({self.get_reason()})" if self.has_reason() else ""
         return f"  {color}{icon} {site_name}{url_display} {username}: {status_text}{reason}{Style.RESET_ALL}"
 
-    def show(self, show_url=False):
-        """Prints the console output and returns itself for chaining"""
+    def show(self, show_url=False, only_found=False):
+        """Prints the console output and returns itself for chaining.
+        If only_found is True, only results with Status.TAKEN are printed."""
         # Updated show() to accept and pass the show_url flag
+        if only_found and self.status != Status.TAKEN:
+            return self
         print(self.get_console_output(show_url=show_url))
         return self

--- a/user_scanner/user_scan/social/anonup.py
+++ b/user_scanner/user_scan/social/anonup.py
@@ -1,19 +1,18 @@
-from user_scanner.core.orchestrator import status_validate
+from user_scanner.core.orchestrator import generic_validate, Result
+
 
 def validate_anonup(user):
     url = f"https://anonup.com/@{user}"
     show_url = "https://anonup.com"
 
-    return status_validate(url, 302, 200, show_url=show_url)
+    def process(response):
 
+        if "Show followings" in response.text:
+            return Result.taken()
 
-if __name__ == "__main__":
-    user = input("Username?: ").strip()
-    result = validate_anonup(user)
+        if "Page not found!" in response.text or response.status_code == 302:
+            return Result.available()
 
-    if result == 1:
-        print("Available!")
-    elif result == 0:
-        print("Unavailable!")
-    else:
-        print("Error occurred!")
+        return Result.error(f"Unexpected response body!")
+
+    return generic_validate(url, process, show_url=show_url)

--- a/user_scanner/user_scan/social/anonup.py
+++ b/user_scanner/user_scan/social/anonup.py
@@ -14,6 +14,6 @@ def validate_anonup(user):
         if "Page not found!" in response.text or response.status_code == 302:
             return Result.available()
 
-        return Result.error(f"Unexpected response body!")
+        return Result.error("Unexpected response body!")
 
     return generic_validate(url, process, show_url=show_url)


### PR DESCRIPTION
### Tasks
- [X] Add `--only-found` to the `argparse` logic in `__main__.py`.
- [X] Update `Result` class in `result.py` with a helper method (e.g., `is_found()`) to check if `self.status.value == 0`.
- [X] Modify `orchestrator.py` (User) and `email_orchestrator.py` (Email) to wrap the `result.show()` or `print` calls in a conditional check.
- [X] Ensure the flag is passed correctly through the asynchronous worker in `email_orchestrator.py`.

### Example Usage
```bash
# Should only show sites where 'target' has an account
user-scanner -e target@email.com --only-found
user-scanner -e target@email.com -v --only-found -c dev

```
---

Additional additions:
- Found counter
- Headers only Printed is found=True
- only_found not passed to single module checks

Closes #236 