### PR TITLE
 Color the URL in white for better visibility

### DIFF
--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -156,12 +156,12 @@ class Result:
         username = ""
         if self.username:
             username = f"({self.username})"
-        
-        # Added logic to include URL in console output if show_url is True
-        url_display = f" [{self.url}]" if show_url and self.url else ""
-
         color = self.get_output_color()
         icon = self.get_output_icon()
+
+        # Added logic to include URL in console output if show_url is True
+        ## Color the URL in white for better visibility
+        url_display = f" {Fore.WHITE}[{self.url}]{color}" if show_url and self.url else ""
 
         reason = f" ({self.get_reason()})" if self.has_reason() else ""
         return f"  {color}{icon} {site_name}{url_display} {username}: {status_text}{reason}{Style.RESET_ALL}"


### PR DESCRIPTION
#247 improvement : Modify the output so that the URL (and the brackets surrounding it) appears in White, while the rest of the line keeps its status color.
<img width="643" height="383" alt="Capture d’écran 2026-02-27 à 17 15 27" src="https://github.com/user-attachments/assets/eee1f960-89a4-4e6e-a7a9-e2abdcd8ff80" />

