### PR TITLE
add: LinkedIn username validation (social category)

### DIFF
--- a/user_scanner/user_scan/social/linkedin.py
+++ b/user_scanner/user_scan/social/linkedin.py
@@ -1,0 +1,19 @@
+from user_scanner.core.orchestrator import status_validate
+from user_scanner.core.result import Result
+
+
+def validate_linkedin(user: str) -> Result:
+    # LinkedIn whitelists social media crawler bots for link previews,
+    # bypassing the anti-bot 999 response that blocks regular user agents.
+    # Note: bulk scanning may trigger rate limiting (999) after ~3 rapid requests.
+    url = f"https://www.linkedin.com/in/{user}"
+    show_url = "https://linkedin.com"
+
+    headers = {
+        "User-Agent": "Twitterbot/1.0",
+    }
+
+    return status_validate(
+        url, available=404, taken=[200, 301], show_url=show_url,
+        headers=headers, follow_redirects=False
+    )


### PR DESCRIPTION
## Summary

- Adds LinkedIn username validator that bypasses the HTTP 999 anti-bot block
- Uses `Twitterbot/1.0` User-Agent — LinkedIn whitelists social media crawler bots for link previews
- Existing profiles return 200/301, non-existing return 404

### How it works

LinkedIn aggressively blocks automated requests with HTTP 999. However, it whitelists crawler bots from social media platforms (Twitter, Facebook, Bing) to generate link previews when users share LinkedIn URLs. The `Twitterbot/1.0` User-Agent receives proper HTTP responses instead of 999.

### Tested with

- Known existing profiles → `[✔] Found`
- Non-existing profiles → `[✘] Not Found`
- Case insensitive (uppercase variants of same username) → `[✔] Found`
- Hyphens in usernames → Handled correctly
- Special characters, empty, numeric-only → `[!] Error`

### Rate limiting

In normal scan mode (1 request per module), no rate limiting observed. Bulk scanning (`-uf` with many usernames) may trigger 999 after ~3 rapid requests from the same IP.

Supersedes #107.

## Test plan

- [ ] `user-scanner -u williamhgates -m linkedin` → `[✔] Found`
- [ ] `user-scanner -u totalfakeuser2026 -m linkedin` → `[✘] Not Found`
- [ ] `user-scanner -u williamhgates` (full scan) → LinkedIn appears in social results