### PR TITLE
Add Riot ID validation module (gaming)

### DIFF
--- a/user_scanner/user_scan/gaming/riot_id.py
+++ b/user_scanner/user_scan/gaming/riot_id.py
@@ -32,4 +32,11 @@ def validate_riot_id(user: str) -> Result:
 
         return Result.error(f"HTTP {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                      "(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+    }
+
+    return generic_validate(url, process, show_url=show_url, headers=headers)


### PR DESCRIPTION
## Summary

Adds a Riot ID module that checks if a Riot ID (Name#Tag) is registered across Riot Games titles (Valorant, LoL, TFT, LoR). Supersedes #24.

## How it works

1. **Validates format**: Requires exactly one `#` with non-empty name and tag (3-5 chars)
2. **Queries riotid-lookup.com API**: `GET /api/lookup?riotId={Name}%23{Tag}`
3. **Parses response**: `{"isTaken": true/false}`

| Response | Result |
|---|---|
| `{"isTaken": true}` | Taken |
| `{"isTaken": false}` | Available |
| Status 400 | Error (invalid format) |

## Why this approach?

The original #24 and first version of this PR used tracker.gg + `curl_cffi` to bypass Cloudflare. After feedback from @kaifcodec about Termux/ARM64 compatibility, several alternatives were tested:

| Endpoint | Result |
|---|---|
| tracker.gg API | Blocked by Cloudflare TLS fingerprinting |
| HenrikDev API | Requires API key since v4 |
| Cloudscraper + tracker.gg | Cannot bypass TLS fingerprinting |
| Riot official API | Requires production API key |
| **riotid-lookup.com** | **Works with httpx, no auth, ~1.1s avg** |

## Changes

- `user_scanner/user_scan/gaming/riot_id.py` — new module using `generic_validate()` + httpx
- No new dependency (uses existing httpx)

## Test plan

- `python3 -m user_scanner -u 'TenZ#00005' -m riot_id` → Found
- `python3 -m user_scanner -u 'xyzfake99#99999' -m riot_id` → Available
- `python3 -m user_scanner -u 'TenZ' -m riot_id` → Error (missing tag)
- `python3 -m user_scanner -u 'Test#1' -m riot_id` → Error (tag too short)