### PR TITLE
fix: X and Youtube module's capitalization issue

### DIFF
--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -103,38 +103,32 @@ def run_user_full(username: str, configs: ScanConfig) -> List[Result]:
         display_name = cat_name.capitalize()
         for m in modules:
             all_modules.append(m)
-            module_to_cat[get_site_name(m)] = display_name
+            site_key = get_site_name(m).capitalize()
+            module_to_cat[site_key] = display_name
 
     with ThreadPoolExecutor(max_workers=60) as executor:
         exec_map = executor.map(
             lambda m: _worker_single(m, username, configs), all_modules
         )
         for result in exec_map:
-            site_name = result.site_name
-            cat_name = (
-                module_to_cat.get(site_name, "Unknown") if site_name else "Unknown"
-            )
+            cat_name = module_to_cat.get(result.site_name, "Unknown")
 
             result.update(category=cat_name)
             results.append(result)
 
-            if configs.only_found:
-                if result.is_found():
-                    if cat_name not in printed_categories:
-                        print(
-                            f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}"
-                        )
-                        printed_categories.add(cat_name)
-                    result.show(configs)
-            else:
-                if cat_name not in printed_categories:
-                    print(
-                        f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}"
-                    )
-                    printed_categories.add(cat_name)
-                result.show(configs)
+            if configs.only_found and not result.is_found():
+                continue
+
+            if cat_name not in printed_categories:
+                print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
+                printed_categories.add(cat_name)
+
+            result.show(configs)
 
     return results
+
+
+
 
 
 def make_request(url: str, **kwargs) -> httpx.Response:


### PR DESCRIPTION
## Description
Fixes the "Unknown Sites" categorization bug for modules like X (Twitter) and YouTube, and refactors the result-printing loop for better readability.

## Changes
- **Standardized Categorization**: Updated the module-to-category mapping to use `.capitalize()`, matching the worker's output and fixing lookup failures for specific site names.
- **Refactored Output Loop**: Simplified the logic in `run_user_full` by using a `continue` statement to skip non-found results, removing redundant code blocks.
- **Improved Consistency**: Ensured the site name used for category lookup exactly matches the `result.site_name` generated during execution.