### PR TITLE
Add HackerEarth username scanner module

### DIFF
--- a/user_scanner/user_scan/dev/hackerearth.py
+++ b/user_scanner/user_scan/dev/hackerearth.py
@@ -2,7 +2,7 @@ from user_scanner.core.orchestrator import status_validate, Result
 
 def validate_hackerearth(user: str) -> Result:
     url = f"https://www.hackerearth.com/@{user}"
-    show_url = "https://www.hackerearth.com"
+    show_url = url
 
     headers = {
         'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -13,11 +13,11 @@ def validate_hackerearth(user: str) -> Result:
 
     # HackerEarth returns 404 for non-existent users and 200 for existing users.
     return status_validate(
-        url, 
-        available=404, 
-        taken=200, 
-        show_url=show_url, 
-        headers=headers, 
+        url,
+        available=404,
+        taken=200,
+        show_url=show_url,
+        headers=headers,
         follow_redirects=True,
         timeout=10.0
     )


### PR DESCRIPTION
## Description
Added a synchronous username scanning module for HackerEarth using the status_validate orchestrator method. 

## Testing
- Tested locally. 'python3 -m user_scanner -u tourist -m hackerearth' returns 'Found'
- Tested locally. 'python3 -m user_scanner -u thisusermatchesnothing123 -m hackerearth' returns 'Not Found'