### PR TITLE
Refactor: Update show_url to direct profile links across user_scan modules (#256)

### DIFF
--- a/user_scanner/user_scan/adult/admireme_vip.py
+++ b/user_scanner/user_scan/adult/admireme_vip.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import Result, generic_validate
 
 def validate_admireme_vip(user):
     url = f"https://admireme.vip/{user}/"
-    show_url = "https://admireme.vip"
+    show_url = f"https://admireme.vip/{user}/"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/adult/adultforum.py
+++ b/user_scanner/user_scan/adult/adultforum.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import Result, generic_validate
 
 def validate_adultforum(user):
     url = f"https://adultforum.gr/{user}-glamour-escorts/"
-    show_url = "https://adultforum.gr"
+    show_url = f"https://adultforum.gr/{user}-glamour-escorts/"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/adult/adultism.py
+++ b/user_scanner/user_scan/adult/adultism.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_adultism(user):
     url = f"https://www.adultism.com/profile/{user}"
-    show_url = "https://www.adultism.com"
+    show_url = f"https://www.adultism.com/profile/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/adult/babepedia.py
+++ b/user_scanner/user_scan/adult/babepedia.py
@@ -2,7 +2,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_babepedia(user):
     url = f"https://www.babepedia.com/user/{user}"
-    show_url = "https://www.babepedia.com"
+    show_url = f"https://www.babepedia.com/user/{user}"
 
     def process(response):
         if response.status_code == 200 and "'s Profile</title>" in response.text:

--- a/user_scanner/user_scan/adult/bdsmlr.py
+++ b/user_scanner/user_scan/adult/bdsmlr.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 def validate_bdsmlr(user):
     user = user.replace(".", "")
     url = f"https://{user}.bdsmlr.com"
-    show_url = "https://bdsmlr.com"
+    show_url = f"https://{user}.bdsmlr.com"
 
     def process(response):
         if response.status_code == 200 and "login" in response.text:

--- a/user_scanner/user_scan/adult/bdsmsingles.py
+++ b/user_scanner/user_scan/adult/bdsmsingles.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_bdsmsingles(user):
     url = f"https://www.bdsmsingles.com/members/{user}/"
-    show_url = "https://www.bdsmsingles.com"
+    show_url = f"https://www.bdsmsingles.com/members/{user}/"
 
     def process(response):
         if response.status_code == 200 and "<title>Profile" in response.text:

--- a/user_scanner/user_scan/adult/bentbox.py
+++ b/user_scanner/user_scan/adult/bentbox.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_bentbox(user):
     url = f"https://bentbox.co/{user}"
-    show_url = "https://bentbox.co"
+    show_url = f"https://bentbox.co/{user}"
 
     def process(response):
         if response.status_code == 200 and "user_bar" in response.text:

--- a/user_scanner/user_scan/community/airliners.py
+++ b/user_scanner/user_scan/community/airliners.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_airliners(user):
     url = f"https://www.airliners.net/user/{user}/profile"
-    show_url = "https://www.airliners.net"
+    show_url = f"https://www.airliners.net/user/{user}/profile"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/community/archwiki.py
+++ b/user_scanner/user_scan/community/archwiki.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import Result, generic_validate
 
 def validate_archwiki(user):
     url = f"https://wiki.archlinux.org/api.php?action=query&format=json&list=users&ususers={user}&usprop=cancreate&formatversion=2"
-    show_url = "https://wiki.archlinux.org"
+    show_url = f"https://wiki.archlinux.org/title/User:{user}"
 
     def process(response):
         if '"userid":' in response.text:

--- a/user_scanner/user_scan/community/coderlegion.py
+++ b/user_scanner/user_scan/community/coderlegion.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_coderlegion(user):
     url = f"https://coderlegion.com/user/{user}"
-    show_url = "https://coderlegion.com"
+    show_url = f"https://coderlegion.com/user/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, timeout=15.0)

--- a/user_scanner/user_scan/community/hackernews.py
+++ b/user_scanner/user_scan/community/hackernews.py
@@ -11,7 +11,7 @@ def validate_hackernews(user: str) -> Result:
         return Result.error("Only use letters, numbers, underscores, and hyphens")
 
     url = f"https://news.ycombinator.com/user?id={user}"
-    show_url = "https://news.ycombinator.com"
+    show_url = f"https://news.ycombinator.com/user?id={user}"
 
     def process(response):
         if "No such user." in response.text:

--- a/user_scanner/user_scan/community/lemmy.py
+++ b/user_scanner/user_scan/community/lemmy.py
@@ -15,6 +15,6 @@ def validate_lemmy(user: str) -> Result:
         return Result.error("Only letters, numbers, and underscores allowed")
 
     url = f"https://lemmy.world/api/v3/user?username={user}"
-    show_url = "https://lemmy.world"
+    show_url = f"https://lemmy.world/u/{user}"
 
     return status_validate(url, [400, 404], 200, show_url=show_url, timeout=5.0)

--- a/user_scanner/user_scan/creator/ameblo.py
+++ b/user_scanner/user_scan/creator/ameblo.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_ameblo(user):
     url = f"https://ameblo.jp/{user}"
-    show_url = "https://ameblo.jp"
+    show_url = f"https://ameblo.jp/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/creator/devto.py
+++ b/user_scanner/user_scan/creator/devto.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_devto(user):
     url = f"https://dev.to/{user}"
-    show_url = "https://dev.to"
+    show_url = f"https://dev.to/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/creator/gumroad.py
+++ b/user_scanner/user_scan/creator/gumroad.py
@@ -10,5 +10,5 @@ def validate_gumroad(user: str) -> Result:
         )
 
     url = f"https://{user}.gumroad.com/"
-    show_url = "https://gumroad.com"
+    show_url = f"https://{user}.gumroad.com"
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/creator/hashnode.py
+++ b/user_scanner/user_scan/creator/hashnode.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_hashnode(user):
     url = "https://hashnode.com/utility/ajax/check-username"
-    show_url = "https://hashnode.com"
+    show_url = f"https://hashnode.com/@{user}"
 
     payload = {"username": user, "name": "Dummy Dummy"}
 

--- a/user_scanner/user_scan/creator/itch_io.py
+++ b/user_scanner/user_scan/creator/itch_io.py
@@ -16,6 +16,6 @@ def validate_itch_io(user: str) -> Result:
         )
 
     url = f"https://itch.io/profile/{user}"
-    show_url = "https://itch.io"
+    show_url = f"https://itch.io/profile/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/creator/kaggle.py
+++ b/user_scanner/user_scan/creator/kaggle.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_kaggle(user):
     url = f"https://www.kaggle.com/{user}"
-    show_url = "https://kaggle.com"
+    show_url = f"https://www.kaggle.com/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/creator/medium.py
+++ b/user_scanner/user_scan/creator/medium.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_medium(user):
     url = f"https://medium.com/@{user}"
-    show_url = "https://medium.com"
+    show_url = f"https://medium.com/@{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/creator/patreon.py
+++ b/user_scanner/user_scan/creator/patreon.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_patreon(user):
     url = f"https://www.patreon.com/{user}"
-    show_url = "https://patreon.com"
+    show_url = f"https://www.patreon.com/{user}"
 
     return status_validate(
         url, 404, 200, show_url=show_url, timeout=15.0, follow_redirects=True

--- a/user_scanner/user_scan/creator/producthunt.py
+++ b/user_scanner/user_scan/creator/producthunt.py
@@ -13,7 +13,7 @@ def validate_producthunt(user: str) -> Result:
         return Result.error("Only use letters, numbers, and underscores.")
 
     url = f"https://www.producthunt.com/@{user}"
-    show_url = "https://producthunt.com"
+    show_url = f"https://www.producthunt.com/@{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/creator/substack.py
+++ b/user_scanner/user_scan/creator/substack.py
@@ -14,7 +14,7 @@ def validate_substack(user: str) -> Result:
         return Result.error("Usernames can only contain lowercase letters and numbers")
 
     url = f"https://{user}.substack.com"
-    show_url = "https://substack.com"
+    show_url = f"https://{user}.substack.com"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/creator/twitch.py
+++ b/user_scanner/user_scan/creator/twitch.py
@@ -17,7 +17,7 @@ def validate_twitch(user: str) -> Result:
         )
 
     url = "https://gql.twitch.tv/gql"
-    show_url = "https://twitch.tv"
+    show_url = f"https://twitch.tv/{user}"
 
     payload = [
         {

--- a/user_scanner/user_scan/dev/arduino.py
+++ b/user_scanner/user_scan/dev/arduino.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_arduino(user):
     url = f"https://forum.arduino.cc/u/{user}.json"
-    show_url = "https://arduino.cc"
+    show_url = f"https://forum.arduino.cc/u/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/dev/asciinema.py
+++ b/user_scanner/user_scan/dev/asciinema.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_asciinema(user):
     url = f"https://asciinema.org/~{user}"
-    show_url = "https://asciinema.org"
+    show_url = f"https://asciinema.org/~{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/dev/atcoder.py
+++ b/user_scanner/user_scan/dev/atcoder.py
@@ -2,7 +2,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_atcoder(user):
     url = f"https://atcoder.jp/api/users/exists/?userScreenName={user}"
-    show_url = "https://atcoder.jp"
+    show_url = f"https://atcoder.jp/users/{user}"
 
     def process(response):
         if response.status_code == 200:

--- a/user_scanner/user_scan/dev/bitbucket.py
+++ b/user_scanner/user_scan/dev/bitbucket.py
@@ -16,7 +16,7 @@ def validate_bitbucket(user: str) -> Result:
         )
 
     url = f"https://bitbucket.org/{user}/"
-    show_url = "https://bitbucket.org"
+    show_url = f"https://bitbucket.org/{user}/"
 
     return status_validate(
         url, 404, [200, 302], show_url=show_url, follow_redirects=True

--- a/user_scanner/user_scan/dev/codeberg.py
+++ b/user_scanner/user_scan/dev/codeberg.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_codeberg(user):
     url = f"https://codeberg.org/{user}"
-    show_url = "https://codeberg.org"
+    show_url = f"https://codeberg.org/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/dev/cratesio.py
+++ b/user_scanner/user_scan/dev/cratesio.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_cratesio(user):
     url = f"https://crates.io/api/v1/users/{user}"
-    show_url = "https://crates.io"
+    show_url = f"https://crates.io/users/{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/dockerhub.py
+++ b/user_scanner/user_scan/dev/dockerhub.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_dockerhub(user):
     url = f"https://hub.docker.com/v2/users/{user}/"
-    show_url = "https://hub.docker.com"
+    show_url = f"https://hub.docker.com/u/{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/github.py
+++ b/user_scanner/user_scan/dev/github.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import Result, generic_validate
 
 def validate_github(user):
     url = f"https://github.com/signup_check/username?value={user}"
-    show_url = "https://github.com"
+    show_url = f"https://github.com/{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/gitlab.py
+++ b/user_scanner/user_scan/dev/gitlab.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_gitlab(user):
     url = f"https://gitlab.com/users/{user}/exists"
-    show_url = "https://gitlab.com"
+    show_url = f"https://gitlab.com/{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/huggingface.py
+++ b/user_scanner/user_scan/dev/huggingface.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_huggingface(user):
     url = f"https://huggingface.co/{user}"
-    show_url = "https://huggingface.co"
+    show_url = f"https://huggingface.co/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/dev/launchpad.py
+++ b/user_scanner/user_scan/dev/launchpad.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_launchpad(user):
     url = f"https://launchpad.net/~{user}"
-    show_url = "https://launchpad.net"
+    show_url = f"https://launchpad.net/~{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/leetcode.py
+++ b/user_scanner/user_scan/dev/leetcode.py
@@ -14,7 +14,7 @@ def validate_leetcode(user: str) -> Result:
         )
 
     url = f"https://leetcode.com/u/{user}/"
-    show_url = "https://leetcode.com"
+    show_url = f"https://leetcode.com/u/{user}/"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/dev/npmjs.py
+++ b/user_scanner/user_scan/dev/npmjs.py
@@ -11,7 +11,7 @@ def validate_npmjs(user):
         return Result.error("Username cannot contain uppercase letters.")
 
     url = f"https://www.npmjs.com/~{user}"
-    show_url = "https://npmjs.com"
+    show_url = f"https://www.npmjs.com/~{user}"
 
     return status_validate(
         url, 404, 200, show_url=show_url, timeout=3.0, follow_redirects=True

--- a/user_scanner/user_scan/dev/replit.py
+++ b/user_scanner/user_scan/dev/replit.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_replit(user):
     url = f"https://replit.com/@{user}"
-    show_url = "https://replit.com"
+    show_url = f"https://replit.com/@{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/dev/sourceforge.py
+++ b/user_scanner/user_scan/dev/sourceforge.py
@@ -14,6 +14,6 @@ def validate_sourceforge(user: str) -> Result:
         return Result.error("Only use lowercase letters, numbers, and dashes.")
 
     url = f"https://sourceforge.net/u/{user}/"
-    show_url = "https://sourceforge.net"
+    show_url = f"https://sourceforge.net/u/{user}/"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/donation/buymeacoffee.py
+++ b/user_scanner/user_scan/donation/buymeacoffee.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_buymeacoffee(user):
     url = f"https://buymeacoffee.com/{user}"
-    show_url = "https://buymeacoffee.com"
+    show_url = f"https://buymeacoffee.com/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/donation/donatealerts.py
+++ b/user_scanner/user_scan/donation/donatealerts.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_donation_alerts(user):
     url = f"https://www.donationalerts.com/api/v1/user/{user}/donationpagesettings"
-    show_url = "https://www.donationalerts.com"
+    show_url = f"https://www.donationalerts.com/r/{user}"
 
     return status_validate(url, 202, 200, show_url=show_url)

--- a/user_scanner/user_scan/donation/donatello.py
+++ b/user_scanner/user_scan/donation/donatello.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_donatello(user):
     url = f"https://donatello.to/{user}"
-    show_url = "https://donatello.to"
+    show_url = f"https://donatello.to/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/donation/liberapay.py
+++ b/user_scanner/user_scan/donation/liberapay.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_liberapay(user):
     url = f"https://en.liberapay.com/{user}"
-    show_url = "https://en.liberapay.com"
+    show_url = f"https://en.liberapay.com/{user}"
 
     headers = {
         "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",

--- a/user_scanner/user_scan/finance/destream.py
+++ b/user_scanner/user_scan/finance/destream.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_destream(user):
     url = f"https://api.destream.net/siteapi/v2/live/details/{user}"
-    show_url = "https://destream.net"
+    show_url = f"https://destream.net/live/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/gaming/apexlegends.py
+++ b/user_scanner/user_scan/gaming/apexlegends.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_apexlegends(user):
     url = f"https://api.tracker.gg/api/v2/apex/standard/profile/origin/{user}"
-    show_url = "https://apexlegends.com"
+    show_url = f"https://apex.tracker.gg/apex/profile/origin/{user}/overview"
 
     headers = {
         "Accept-Language": "en-US,en;q=0.5",

--- a/user_scanner/user_scan/gaming/battlenet.py
+++ b/user_scanner/user_scan/gaming/battlenet.py
@@ -30,7 +30,7 @@ def validate_battlenet(user: str) -> Result:
         return Result.error("Must start with letter, only letters and numbers allowed")
 
     url = f"https://overwatch.blizzard.com/en-us/search/account-by-name/{username}"
-    show_url = "https://battle.net"
+    show_url = f"https://overwatch.blizzard.com/en-us/search/account-by-name/{username}/"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/gaming/chess_com.py
+++ b/user_scanner/user_scan/gaming/chess_com.py
@@ -21,7 +21,7 @@ def validate_chess_com(user: str) -> Result:
         return Result.error("Username must start and end with a letter or number")
 
     url = f"https://www.chess.com/callback/user/valid?username={user}"
-    show_url = "https://chess.com"
+    show_url = f"https://www.chess.com/member/{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/gaming/lichess.py
+++ b/user_scanner/user_scan/gaming/lichess.py
@@ -21,7 +21,7 @@ def validate_lichess(user: str) -> Result:
         return Result.error("Username must end with a letter or a number")
 
     url = f"https://lichess.org/api/player/autocomplete?term={user}&exists=1"
-    show_url = "https://lichess.org"
+    show_url = f"https://lichess.org/@/{user}"
 
     def process(response):
         res_text = response.text.strip().lower()

--- a/user_scanner/user_scan/gaming/minecraft.py
+++ b/user_scanner/user_scan/gaming/minecraft.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_minecraft(user):
     url = f"https://api.mojang.com/minecraft/profile/lookup/name/{user}"
-    show_url = "https://mojang.com"
+    show_url = f"https://namemc.com/profile/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/gaming/monkeytype.py
+++ b/user_scanner/user_scan/gaming/monkeytype.py
@@ -8,7 +8,7 @@ from user_scanner.core.result import Result
 def validate_monkeytype(user: str) -> Result:
     safe_user = quote(user, safe="")
     url = f"https://api.monkeytype.com/users/checkName/{safe_user}"
-    show_url = "https://monkeytype.com"
+    show_url = f"https://monkeytype.com/profile/{safe_user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/gaming/osu.py
+++ b/user_scanner/user_scan/gaming/osu.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_osu(user):
     url = f"https://osu.ppy.sh/users/{user}"
-    show_url = "https://osu.ppy.sh"
+    show_url = f"https://osu.ppy.sh/users/{user}"
 
     return status_validate(
         url, 404, [200, 302], show_url=show_url, follow_redirects=True

--- a/user_scanner/user_scan/gaming/steam.py
+++ b/user_scanner/user_scan/gaming/steam.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 def validate_steam(user):
     url = f"https://steamcommunity.com/id/{user}/"
-    show_url = "https://steamcommunity.com"
+    show_url = f"https://steamcommunity.com/id/{user}/"
 
     def process(response):
         if response.status_code == 200:

--- a/user_scanner/user_scan/music/audiojungle.py
+++ b/user_scanner/user_scan/music/audiojungle.py
@@ -2,6 +2,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_audiojungle(user):
     url = f"https://audiojungle.net/user/{user}"
-    show_url = "https://audiojungle.net"
+    show_url = f"https://audiojungle.net/user/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/music/bandcamp.py
+++ b/user_scanner/user_scan/music/bandcamp.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_bandcamp(user):
     url = f"https://bandcamp.com/{user}"
-    show_url = "https://bandcamp.com"
+    show_url = f"https://bandcamp.com/{user}"
 
     def process(response):
         if response.status_code == 200 and " collection | Bandcamp</title>" in response.text:

--- a/user_scanner/user_scan/music/bandlab.py
+++ b/user_scanner/user_scan/music/bandlab.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_bandlab(user):
     url = f"https://www.bandlab.com/api/v1.3/users/{user}"
-    show_url = "https://www.bandlab.com"
+    show_url = f"https://www.bandlab.com/{user}"
 
     def process(response):
         if response.status_code == 200 and "about" in response.text:

--- a/user_scanner/user_scan/music/discogs.py
+++ b/user_scanner/user_scan/music/discogs.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_discogs(user):
     url = f"https://api.discogs.com/users/{user}"
-    show_url = "https://www.discogs.com"
+    show_url = f"https://www.discogs.com/user/{user}"
 
     def process(response):
         if response.status_code == 200 and "\"id\":" in response.text:

--- a/user_scanner/user_scan/music/freesound.py
+++ b/user_scanner/user_scan/music/freesound.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_freesound(user):
     url = f"https://freesound.org/people/{user}/section/stats/?ajax=1"
-    show_url = "https://freesound.org"
+    show_url = f"https://freesound.org/people/{user}/"
 
     def process(response):
         if response.status_code == 200 and "forum posts" in response.text.lower():

--- a/user_scanner/user_scan/music/gpodder_net.py
+++ b/user_scanner/user_scan/music/gpodder_net.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_gpodder_net(user):
     url = f"https://gpodder.net/user/{user}/"
-    show_url = "https://gpodder.net"
+    show_url = f"https://gpodder.net/user/{user}/"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/music/lastfm.py
+++ b/user_scanner/user_scan/music/lastfm.py
@@ -3,6 +3,6 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_lastfm(user):
     url = f"https://www.last.fm/user/{user}"
-    show_url = "https://www.last.fm"
+    show_url = f"https://www.last.fm/user/{user}"
 
     return status_validate(url, 404, 200, show_url=show_url)

--- a/user_scanner/user_scan/music/soundcloud.py
+++ b/user_scanner/user_scan/music/soundcloud.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 def validate_soundcloud(user):
     url = f"https://soundcloud.com/{user}"
-    show_url = "https://soundcloud.com"
+    show_url = f"https://soundcloud.com/{user}"
 
     def process(response):
         if response.status_code == 403:

--- a/user_scanner/user_scan/shopping/vinted.py
+++ b/user_scanner/user_scan/shopping/vinted.py
@@ -9,7 +9,7 @@ def validate_vinted(user: str):
     user = user.lower().strip()
 
     url = f"https://www.vinted.pt/member/general/search?search_text={user}"
-    show_url = "https://vinted.pt"
+    show_url = f"https://www.vinted.pt/member/general/search?search_text={user}"
 
     if not re.match(r"^[a-zA-Z0-9_.-]+$", user):
         return Result.error(

--- a/user_scanner/user_scan/social/anonup.py
+++ b/user_scanner/user_scan/social/anonup.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_anonup(user):
     url = f"https://anonup.com/@{user}"
-    show_url = "https://anonup.com"
+    show_url = f"https://anonup.com/@{user}"
 
     def process(response):
 

--- a/user_scanner/user_scan/social/bluesky.py
+++ b/user_scanner/user_scan/social/bluesky.py
@@ -6,7 +6,7 @@ from user_scanner.core.result import Result
 def validate_bluesky(user):
     handle = user if user.endswith(".bsky.social") else f"{user}.bsky.social"
     url = "https://bsky.social/xrpc/com.atproto.temp.checkHandleAvailability"
-    show_url = "https://bsky.social"
+    show_url = f"https://bsky.app/profile/{user}.bsky.social"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/social/instagram.py
+++ b/user_scanner/user_scan/social/instagram.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_instagram(user):
     url = "https://www.instagram.com/api/v1/users/web_profile_info/"
-    show_url = "https://instagram.com"
+    show_url = f"https://www.instagram.com/{user}/"
 
     params = {"username": user}
 

--- a/user_scanner/user_scan/social/linkedin.py
+++ b/user_scanner/user_scan/social/linkedin.py
@@ -7,7 +7,7 @@ def validate_linkedin(user: str) -> Result:
     # bypassing the anti-bot 999 response that blocks regular user agents.
     # Note: bulk scanning may trigger rate limiting (999) after ~3 rapid requests.
     url = f"https://www.linkedin.com/in/{user}"
-    show_url = "https://linkedin.com"
+    show_url = f"https://www.linkedin.com/in/{user}/"
 
     headers = {
         "User-Agent": "Twitterbot/1.0",

--- a/user_scanner/user_scan/social/mastodon.py
+++ b/user_scanner/user_scan/social/mastodon.py
@@ -17,7 +17,7 @@ def validate_mastodon(user: str) -> Result:
         return Result.error("Username must start and end with a letter or number")
 
     url = f"https://mastodon.social/api/v1/accounts/lookup?acct={user}"
-    show_url = "https://mastodon.social"
+    show_url = f"https://mastodon.social/@{user}"
 
     return status_validate(
         url, available=404, taken=200, show_url=show_url, follow_redirects=True

--- a/user_scanner/user_scan/social/minds.py
+++ b/user_scanner/user_scan/social/minds.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_minds(user):
     url = f"https://www.minds.com/api/v3/register/validate?username={user}"
-    show_url = "https://www.minds.com"
+    show_url = f"https://www.minds.com/{user}"
 
     def process(response):
         if response.status_code == 200 and '"valid":false' in response.text:

--- a/user_scanner/user_scan/social/pinterest.py
+++ b/user_scanner/user_scan/social/pinterest.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 def validate_pinterest(user):
     url = f"https://www.pinterest.com/{user}/"
-    show_url = "https://pinterest.com"
+    show_url = f"https://www.pinterest.com/{user}/"
 
     def process(response):
         if response.status_code == 200:

--- a/user_scanner/user_scan/social/reddit.py
+++ b/user_scanner/user_scan/social/reddit.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 def validate_reddit(user):
     url = f"https://www.reddit.com/user/{user}/"
-    show_url = "https://reddit.com"
+    show_url = f"https://www.reddit.com/user/{user}/"
 
     def process(response):
         if response.status_code == 200:

--- a/user_scanner/user_scan/social/snapchat.py
+++ b/user_scanner/user_scan/social/snapchat.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_snapchat(user):
     url = f"https://www.snapchat.com/@{user}"
-    show_url = "https://snapchat.com"
+    show_url = f"https://www.snapchat.com/@{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/social/telegram.py
+++ b/user_scanner/user_scan/social/telegram.py
@@ -6,7 +6,7 @@ from user_scanner.core.result import Result
 
 def validate_telegram(user: str) -> Result:
     url = f"https://t.me/{user}"
-    show_url = "https://t.me"
+    show_url = f"https://t.me/{user}"
 
     def process(r):
         if r.status_code == 200:

--- a/user_scanner/user_scan/social/threads.py
+++ b/user_scanner/user_scan/social/threads.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import status_validate
 
 def validate_threads(user):
     url = f"https://www.threads.net/api/v1/users/web_profile_info/?username={user}"
-    show_url = "https://threads.net"
+    show_url = f"https://www.threads.net/@{user}"
 
     headers = {
         "User-Agent": get_random_user_agent(),

--- a/user_scanner/user_scan/social/tiktok.py
+++ b/user_scanner/user_scan/social/tiktok.py
@@ -30,7 +30,7 @@ def validate_tiktok(user: str) -> Result:
     }
 
     url = f"https://www.tiktok.com/@{user}"
-    show_url = "https://tiktok.com"
+    show_url = f"https://www.tiktok.com/@{user}"
 
     def process(response) -> Result:
         if response.status_code == 200:

--- a/user_scanner/user_scan/social/x.py
+++ b/user_scanner/user_scan/social/x.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_x(user):
     url = "https://api.twitter.com/i/users/username_available.json"
-    show_url = "https://x.com"
+    show_url = f"https://x.com/{user}"
 
     params = {"username": user, "full_name": "John Doe", "email": "johndoe07@gmail.com"}
 

--- a/user_scanner/user_scan/social/youtube.py
+++ b/user_scanner/user_scan/social/youtube.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import Result, status_validate
 
 def validate_youtube(user) -> Result:
     url = f"https://m.youtube.com/@{user}"
-    show_url = "https://m.youtube.com"
+    show_url = f"https://youtube.com/@{user}"
     headers = {
         "User-Agent": get_random_user_agent(),
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",


### PR DESCRIPTION
Resolves #256 

## Description
This PR refactors `show_url` across the `user_scan` modules so that they return direct profile links instead of static root domains when a username is successfully found. 

### 📝 Sites Updated (74)
- **Creator**: devto, itch_io, substack, hashnode, gumroad, medium, kaggle, patreon, producthunt, ameblo, twitch
- **Donation**: donatealerts, liberapay, buymeacoffee, donatello
- **Music**: gpodder_net, bandcamp, discogs, lastfm, bandlab, soundcloud, audiojungle, freesound
- **Gaming**: lichess, osu, apexlegends, chess_com, monkeytype, minecraft, battlenet, steam
- **Social**: minds, youtube, mastodon, telegram, anilist, pinterest, x, threads, snapchat, albicla, anonup, instagram, linkedin, tiktok, bluesky, reddit
- **Dev**: bitbucket, atcoder, launchpad, codeberg, gitlab, dockerhub, cratesio, leetcode, huggingface, npmjs, github, replit, arduino, asciinema, sourceforge
- **Finance**: destream
- **Adult**: bdsmlr, adultforum, admireme_vip, bentbox, adultism, babepedia, bdsmsingles
- **Community**: lemmy, hackernews, coderlegion, archwiki, airliners
- **Political**: bitchute, newamerica, naturalnews, americanthinker

### ⏭️ Sites Skipped (4)
I explicitly verified and skipped the following 4 modules because their platforms do not support direct, public username-based URL routing for profiles:
- **roblox**: Profiles are only accessible via internal numeric IDs (e.g., `roblox.com/users/ID/profile`), not string usernames.
- **discord**: Discord does not have public web profiles for usernames.
- **stackoverflow**: Like Roblox, StackOverflow profiles rely strictly on internal auto-incremented `/users/<ID>/<name>` integers, which cannot be derived solely from the scanned string.
- **cropty**: No public-facing user profile view could be verified; appears to be strictly an internal API/wallet check.

## Testing
- Verified `pytest tests/` runs successfully without any f-string or syntax issues.
