### PR TITLE
Preserve explicit proxy schemes when loading proxy files

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -269,6 +269,21 @@ socks5://socks-proxy.example.com:1080""")
     assert manager.proxies[1].startswith("socks5://")
 
 
+def test_proxy_manager_preserves_explicit_schemes(tmp_path):
+    proxy_file = tmp_path / "test_proxies.txt"
+    proxy_file.write_text("""socks4://legacy-proxy.example.com:1080
+socks5h://onion-proxy.example.com:9050
+https://secure-proxy.example.com:443""")
+
+    manager = helpers.ProxyManager(str(proxy_file))
+
+    assert manager.proxies == [
+        "socks4://legacy-proxy.example.com:1080",
+        "socks5h://onion-proxy.example.com:9050",
+        "https://secure-proxy.example.com:443",
+    ]
+
+
 def test_proxy_manager_no_poxy_file(tmp_path):
     with pytest.raises(FileNotFoundError) as exc_info:
         helpers.ProxyManager("no_proxy_file.txt")

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -155,14 +155,15 @@ class ProxyManager:
         self._load_proxies(proxy_file)
 
     def _load_proxies(self, proxy_file: str) -> None:
-        """Load proxies from a text file. Supports http://, https://, and socks5:// proxies."""
+        """Load proxies from a text file. Keep explicit schemes, default to http:// when missing."""
         try:
             with open(proxy_file, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#"):
-                        # Add protocol if not present
-                        if not line.startswith(("http://", "https://", "socks5://")):
+                        # Keep explicit schemes (http://, socks5://, socks5h://, etc.).
+                        # Only prepend http:// when no scheme is provided.
+                        if "://" not in line:
                             line = "http://" + line
                         self.proxies.append(line)
 


### PR DESCRIPTION
## What changed
- Updated `ProxyManager._load_proxies` to preserve any explicit proxy scheme instead of only preserving `http://`, `https://`, and `socks5://`.
- Kept the existing behavior of prepending `http://` when a proxy entry has no scheme.
- Added a regression test (`test_proxy_manager_preserves_explicit_schemes`) covering `socks4://`, `socks5h://`, and `https://` entries.

## Why
- The previous loader could mangle valid proxy strings that already included an explicit but non-whitelisted scheme (for example, `socks5h://...`) by prefixing `http://`.
- Preserving explicit schemes makes proxy-file handling more robust while keeping backward compatibility for bare `host:port` lines.

## Testing
- ✅ `source .venv/bin/activate && pytest -q` (126 passed)
