### PR TITLE
feat: add username validation module for Zhihu

### DIFF
--- a/user_scanner/user_scan/social/zhihu.py
+++ b/user_scanner/user_scan/social/zhihu.py
@@ -1,0 +1,16 @@
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_zhihu(user):
+    url = f"https://api.zhihu.com/books/people/{user}/publications?offset=0&limit=5"
+    show_url = f"https://www.zhihu.com/people/{user}"
+
+    def process(response):
+        if response.status_code == 200 and "is_start" in response.text:
+            return Result.taken()
+        if "NotFoundException" in response.text or response.status_code == 404:
+            return Result.available()
+        return Result.error(f"Unexpected status: {response.status_code}")
+
+    return generic_validate(url, process, show_url=show_url)


### PR DESCRIPTION
Closes #293

## Summary
Adds `zhihu.py` username validation module for Zhihu social platform.

## Changes
- Added `user_scanner/user_scan/social/zhihu.py`

## Validation Logic
- Uses `generic_validate()` with a `process` callback
- Existing user: API returns `"is_start"` in response → `Result.taken()`
- Non-existing user: API returns `"NotFoundException"` → `Result.available()`

## Manual Testing
- Existing: `https://api.zhihu.com/books/people/excited-vczh/publications?offset=0&limit=5` → returns `"is_start": true`
- Non-existing: `https://api.zhihu.com/books/people/thisdoesnotexist999xyz/publications?offset=0&limit=5` → returns `"NotFoundException"`