### PR TITLE
fix: switch HuggingFace email check from GET to POST

### DIFF
--- a/user_scanner/email_scan/dev/huggingface.py
+++ b/user_scanner/email_scan/dev/huggingface.py
@@ -5,17 +5,17 @@ from user_scanner.core.result import Result
 async def _check(email: str) -> Result:
     url = "https://huggingface.co/api/check-user-email"
     show_url = "https://huggingface.co"
-    params = {'email': email}
+    payload = {'email': email}
+
     headers = {
         'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
         'Accept-Encoding': "identity",
         'referer': "https://huggingface.co/join",
-        'priority': "u=1, i"
     }
 
     async with httpx.AsyncClient(http2=True) as client:
         try:
-            response = await client.get(url, params=params, headers=headers, timeout=5)
+            response = await client.post(url, json=payload, headers=headers, timeout=5)
             res_text = response.text
             st_code = response.status_code
 


### PR DESCRIPTION
- Switch the HuggingFace email check request from **GET** to **POST** to match the current server behavior.
- Send the email payload as **JSON** in the request body instead of query parameters.
- Fix failures caused by the API change that resulted in incorrect requests and errors.
- Restore proper detection of **available** and **already existing** email responses.