### PR TITLE
Add Riot ID validation module (gaming)

### DIFF
--- a/user_scanner/user_scan/gaming/riot_id.py
+++ b/user_scanner/user_scan/gaming/riot_id.py
@@ -1,0 +1,42 @@
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_riot_id(user: str) -> Result:
+    """Check if a Riot ID (Name#Tag) is registered across Riot Games titles."""
+    show_url = "https://www.riotid-lookup.com"
+
+    user = user.strip()
+    if user.count("#") != 1:
+        return Result.error("Riot ID format required: Name#Tag (e.g. TenZ#00005)")
+
+    name, tag = user.split("#")
+    if not name or not tag:
+        return Result.error("Both name and tag are required (e.g. TenZ#00005)")
+
+    if not (3 <= len(tag) <= 5):
+        return Result.error("Tag must be 3-5 characters")
+
+    encoded = user.replace("#", "%23")
+    url = f"https://www.riotid-lookup.com/api/lookup?riotId={encoded}"
+
+    def process(response):
+        if response.status_code == 200:
+            data = response.json()
+            if data.get("isTaken"):
+                return Result.taken()
+            return Result.available()
+
+        if response.status_code == 400:
+            return Result.error("Invalid Riot ID format")
+
+        return Result.error(f"HTTP {response.status_code}")
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                      "(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+    }
+
+    return generic_validate(url, process, show_url=show_url, headers=headers)


### PR DESCRIPTION
## Summary

Adds a Riot ID module that checks if a Riot ID (Name#Tag) is registered across Riot Games titles (Valorant, LoL, TFT, LoR). Supersedes #24. Replaces #266 with a clean single commit as requested.

## How it works

1. **Validates format**: Requires exactly one `#` with non-empty name and tag (3-5 chars)
2. **Queries riotid-lookup.com API**: `GET /api/lookup?riotId={Name}%23{Tag}`
3. **Parses response**: `{"isTaken": true/false}`

| Response | Result |
|---|---|
| `{"isTaken": true}` | Taken |
| `{"isTaken": false}` | Available |
| Status 400 | Error (invalid format) |

## Why riotid-lookup.com?

Tested several alternatives before settling on this one:

| Endpoint | Result |
|---|---|
| tracker.gg API | Blocked by Cloudflare TLS fingerprinting |
| HenrikDev API | Requires API key since v4 |
| Cloudscraper + tracker.gg | Cannot bypass TLS fingerprinting |
| Riot official API | Requires production API key |
| **riotid-lookup.com** | **Works with httpx, no auth, ~1.1s avg** |

## Changes

- `user_scanner/user_scan/gaming/riot_id.py` — new module using `generic_validate()` + httpx
- No new dependency
- Tested on x86_64 (WSL) and ARM64 (Termux on Android)

## Test plan

- `python3 -m user_scanner -u 'TenZ#00005' -m riot_id` → Found
- `python3 -m user_scanner -u 'xyzfake99#99999' -m riot_id` → Available
- `python3 -m user_scanner -u 'TenZ' -m riot_id` → Error (missing tag)
- `python3 -m user_scanner -u 'Test#1' -m riot_id` → Error (tag too short)