### PR TITLE
fix(helpers.py): replace `made_porn` with `made.porn` in LOUD_MODULES

### DIFF
--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -22,7 +22,7 @@ LOUD_MODULES: Dict[str, List[str]] = {
         "instagram",
         "netflix",
         "sexvid",
-        "made_porn",
+        "made.porn",
         "flirtbate",
         "polarsteps",
         "babestation",


### PR DESCRIPTION
- Initially it was ignoring `made_porn` as no module found as `get_site_name()` function already coverts the `made_porn` to `made.porn`
- Now it correctly matches the module's name