### PR TITLE
feat: add OpenStreetMap username validation module (#307)

### DIFF
--- a/user_scanner/user_scan/social/openstreetmap.py
+++ b/user_scanner/user_scan/social/openstreetmap.py
@@ -1,0 +1,18 @@
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_openstreetmap(user):
+    url = f"https://www.openstreetmap.org/user/{user}"
+    show_url = f"https://www.openstreetmap.org/user/{user}"
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available()
+        if "Mapper since" in response.text:
+            return Result.taken()
+        if "does not exist" in response.text:
+            return Result.available()
+        return Result.error()
+
+    return generic_validate(url, process, show_url=show_url, follow_redirects=True)


### PR DESCRIPTION
Closes #307
Adds a new username validation module for OpenStreetMap under user_scanner/user_scan/social/openstreetmap.py.

Technical Details
Site Name: OpenStreetMap
Base URL: https://www.openstreetmap.org/user/{username}
Category: social

**Validation Logic**
Uses generic_validate() with a process callback:

Returns Result.taken() if "Mapper since" is found in the response body (only present on real user profiles)
Returns Result.available() if HTTP status is 404
Returns Result.available() if "does not exist" is found in the response body (fallback)
Returns Result.error() for any unexpected response

**Testing**

Firefishy | Found | ✅ Found
thisdefinitelydoesnotexist99999 | Not Found | ✅ Not Found
<img width="775" height="417" alt="testopenscaneer" src="https://github.com/user-attachments/assets/edebf2e6-1300-49d9-8462-8a44b11ba476" />

Checklist

 [x]Used generic_validate() with a process callback
 [x]Avoided status_validate()
 [x]Matches structure and imports of existing social modules
 [x] No bot detection / CAPTCHA issues observed
 [x]Tested locally with known existing and non-existing accounts