### PR TITLE
refactor: use json module for result serialization in into_json

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -384,24 +384,27 @@ def main():
             else formatter.into_json(results)
         )
 
+    if args.output:
         if args.format == "json":
+            # Get the new data as a LIST of DICTS, not a string
+            new_items = formatter.get_json_data(results)
             data = []
-            try:
-                with open(args.output, "r", encoding="utf-8") as f:
-                    old = json.load(f)
-                    if isinstance(old, list) and all(isinstance(x, dict) for x in old):
-                        data = old
-            except Exception:
-                pass
 
-            new_items = json.loads(content)
-            if isinstance(new_items, list) and all(
-                isinstance(x, dict) for x in new_items
-            ):
-                data.extend(new_items)
+            # Try to load existing data
+            if os.path.exists(args.output):
+                try:
+                    with open(args.output, "r", encoding="utf-8") as f:
+                        old = json.load(f)
+                        if isinstance(old, list):
+                            data = old
+                except (json.JSONDecodeError, Exception):
+                    pass
 
+            # Merge and save
+            data.extend(new_items)
             with open(args.output, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
+
 
         if args.format == "csv":
             try:

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import re
 import sys
 import time

--- a/user_scanner/core/formatter.py
+++ b/user_scanner/core/formatter.py
@@ -15,8 +15,11 @@ def indentate(msg: str, indent: int):
 
 
 def into_json(results: List[Result]) -> str:
-    list_of_dicts = [result.to_json() for result in results]
-    return json.dumps(list_of_dicts, indent=2)
+    return json.dumps([r.to_dict() for r in results], indent=4)
+
+def get_json_data(results: List[Result]) -> list:
+    """Returns a list of dictionaries ready for JSON serialization."""
+    return [r.to_dict() for r in results]
 
 
 def into_csv(results: List[Result]) -> str:

--- a/user_scanner/core/formatter.py
+++ b/user_scanner/core/formatter.py
@@ -1,3 +1,4 @@
+import json
 from user_scanner.core.result import Result
 from typing import List
 
@@ -14,14 +15,8 @@ def indentate(msg: str, indent: int):
 
 
 def into_json(results: List[Result]) -> str:
-    res = "[\n"
-
-    for i, result in enumerate(results):
-        is_last = i == len(results) - 1
-        end = "" if is_last else ","
-        res += indentate(result.to_json().replace("\t", INDENT), 1) + end + "\n"
-
-    return res + "]"
+    list_of_dicts = [result.to_json() for result in results]
+    return json.dumps(list_of_dicts, indent=2)
 
 
 def into_csv(results: List[Result]) -> str:

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -141,6 +141,15 @@ class Result:
             "is_email": self.is_email,
         }
 
+    def to_dict(self) -> dict:
+        """Prepares the clean dictionary for JSON/Exporting."""
+        data = self.as_dict()
+
+        if self.is_email:
+            data["email"] = data.pop("username")
+        data.pop("is_email", None)
+        return data
+
     def debug(self) -> str:
         return DEBUG_MSG.format(**self.as_dict())
 


### PR DESCRIPTION
- Replace manual JSON string construction with json.dumps to prevent formatting errors
- Fix JSONDecodeError caused by improper delimiter handling or unescaped characters
- Ensure consistent indentation and valid JSON structure for scan results