### PR TITLE
fix(amazon): false negative fix

### DIFF
--- a/user_scanner/email_scan/shopping/amazon.py
+++ b/user_scanner/email_scan/shopping/amazon.py
@@ -115,9 +115,7 @@ async def _check(email: str) -> Result:
                 )
 
             if _is_captcha(resp.text):
-                return Result.error(
-                    "CAPTCHA triggered (IP may be flagged)", url=show_url
-                )
+                return Result.taken(url=show_url)
 
             # 3. If Amazon asks for a password, the email is registered
             if 'id="auth-password-missing-alert"' in resp.text:


### PR DESCRIPTION
- Amazon likely introduced a new security update where a CAPTCHA token becomes mandatory only when the email is registered. Because of this, `Result.error()` has been replaced with `Result.taken()` for that specific case.
- Tested with both registered and unregistered emails, and the logic works correctly.