### PR TITLE
fix(gumroad, girlslife): force Accept-Encoding: identity

### DIFF
--- a/user_scanner/email_scan/creator/gumroad.py
+++ b/user_scanner/email_scan/creator/gumroad.py
@@ -11,7 +11,7 @@ async def _check(email: str) -> Result:
             headers1 = {
                 'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
                 'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
+                'Accept-Encoding': "identity",
                 'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"',
                 'sec-ch-ua-mobile': "?0",
                 'sec-ch-ua-platform': '"Linux"',
@@ -45,7 +45,7 @@ async def _check(email: str) -> Result:
             headers2 = {
                 'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
                 'Accept': "text/html, application/xhtml+xml",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
+                'Accept-Encoding': "identity",
                 'Content-Type': "application/json",
                 'sec-ch-ua-platform': '"Linux"',
                 'x-csrf-token': csrf_token,

--- a/user_scanner/email_scan/entertainment/girlslife.py
+++ b/user_scanner/email_scan/entertainment/girlslife.py
@@ -9,7 +9,7 @@ async def _check(email: str) -> Result:
     headers = {
         'User-Agent': "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36",
         'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        'Accept-Encoding': "gzip, deflate, br, zstd",
+        'Accept-Encoding': "identity",
         'sec-ch-ua': '"Brave";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
         'sec-ch-ua-mobile': "?1",
         'sec-ch-ua-platform': '"Android"',


### PR DESCRIPTION
Both modules advertised `Accept-Encoding: gzip, deflate, br, zstd`, but httpx ships only gzip/deflate decoders by default. When servers honored the header and replied with brotli or zstd, the response body came back as raw compressed bytes, breaking the nonce regex in girlslife and `response.json()` in gumroad:

* `Girlslife: Failed to parse response`
* `Gumroad: unexpected exception:`

Switching both to `Accept-Encoding: identity` keeps the response uncompressed, no extra deps required.

Verified locally with brotli/zstandard NOT installed (httpx decoders limited to `identity, gzip, deflate`): both modules return `Registered` / `Not Registered` cleanly.

Per your comment on the previous revision, scoped this to only the two confirmed-broken modules. Same pattern exists in a dozen other places (orchestrator, both `github.py`, foxnews, ama, dribbble, linktree, producthunt, launchpad, battlenet, snapchat, threads), but those are currently working since their upstream servers are falling back to gzip. Happy to follow up with a separate PR if any of those start failing.