### PR TITLE
refactor: edit the response parsing logic, fixes false negatives

### DIFF
--- a/user_scanner/email_scan/adult/pornhub.py
+++ b/user_scanner/email_scan/adult/pornhub.py
@@ -57,9 +57,9 @@ async def _check(email: str) -> Result:
                 if "delivery issues" in error_msg:
                     return Result.error(url=show_url, reason="The email is experiencing email delivery issues")
 
-            if status == "create_account_passed":
+            if status == "create_account_passed" and error_msg == "":
                 return Result.available(url=show_url)
-            elif "already in use" in error_msg.lower() or "already registered" in error_msg:
+            elif status == "create_account_failed" and "already registered" in error_msg:
                 return Result.taken(url=show_url)
             else:
                 return Result.error(f"Unexpected API response: {status}: {error_msg}")


### PR DESCRIPTION
Refactored the response parsing logic inside the Pornhub email scanning module to explicitly handle API field states, fixing edge cases where ambiguous payloads caused false negatives during validation.

- Updated the account availability check to strictly require `status == "create_account_passed"` alongside an empty `error_msg`, preventing false positives when errors coexist with a passed status flag.
- Tightened the account taken condition to verify `status == "create_account_failed"` explicitly alongside the target "already registered" error string, ensuring accurate reporting when an email already exists.