### PR TITLE
fix(modules): archwiki scanners and core Accept-Encoding

### DIFF
--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -152,7 +152,7 @@ def make_request(url: str, **kwargs) -> httpx.Response:
         kwargs["headers"] = {
             "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Encoding": "gzip, deflate",
             "Accept-Language": "en-US,en;q=0.9",
             "sec-fetch-dest": "document",
         }

--- a/user_scanner/user_scan/community/archwiki.py
+++ b/user_scanner/user_scan/community/archwiki.py
@@ -6,10 +6,19 @@ def validate_archwiki(user):
     show_url = f"https://wiki.archlinux.org/title/User:{user}"
 
     def process(response):
-        if '"userid":' in response.text:
-            return Result.taken()
-        if '"missing":true' in response.text:
-            return Result.available()
-        return Result.error(f"Unexpected status: {response.status_code}")
-
+        try:
+            data = response.json()
+            users = data.get("query", {}).get("users", [])
+            if not users:
+                return Result.available()
+            
+            user_data = users[0]
+            if user_data.get("missing") is True:
+                return Result.available()
+            if "userid" in user_data:
+                return Result.taken()
+            
+            return Result.error("Unexpected user structure")
+        except Exception as e:
+            return Result.error(e)
     return generic_validate(url, process, show_url=show_url)


### PR DESCRIPTION
- Fixed `archwiki.py` module in user_scan
- Removed `brotli` from `user_scanner/core/orchestrator.py` default headers `Accept-Encoding`