### PR TITLE
added automatic version pulling from py toml to the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     self,
     nixpkgs,
   }: let
+    pyproject = fromTOML (builtins.readFile ./pyproject.toml);
     systems = [
       "x86_64-linux"
       "aarch64-linux"
@@ -21,7 +22,7 @@
       in {
         default = pkgs.python312Packages.buildPythonApplication {
           pname = "user-scanner";
-          version = "1.4.0.2";
+          version = pyproject.project.version;
 
           src = self;
 


### PR DESCRIPTION
found the function to pull from a toml. This should mean the only times that changes to the flake are required would be a change in file struct or dependancys 