### PR TITLE
fix: add luarocks email_scan module to LOUD_MODLUES

### DIFF
--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -27,6 +27,7 @@ LOUD_MODULES: Dict[str, List[str]] = {
         "flipkart",
         "ama",
         "buymeacoffee",
+        "luarocks",
     ],
 }
 


### PR DESCRIPTION
- Tested Locally that on a registered email address on luarocks the validation sends a Password Reset email, so added it to `LOUD_MODULES`