### PR TITLE
CSV formulas are neutralized

### DIFF
--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,5 +1,7 @@
+import pytest
+
 from user_scanner.core.helpers import ScanConfig
-from user_scanner.core.result import Result, Status, indent_text
+from user_scanner.core.result import Result, Status, _neutralize_csv_cell, indent_text
 
 
 def test_status_labels():
@@ -205,3 +207,28 @@ def test_indentate():
                 assert not line.startswith(" ")
             else:
                 assert line.startswith(" " * i)
+
+
+@pytest.mark.parametrize(
+    "raw", ["=1+1", "+1+1", "-1+1", "@SUM(A1)", "\t=cmd", "\r=cmd"]
+)
+def test_csv_cell_neutralizes_formula_triggers(raw):
+    neutralized = _neutralize_csv_cell(raw)
+    assert neutralized
+    assert neutralized.startswith("'")
+
+
+def test_to_csv_neutralizes_username_field():
+    result = Result.available(username='=HYPERLINK("http://evil")', site_name="smth")
+    csv_text = result.to_csv()
+    assert "'=HYPERLINK" in csv_text
+    assert csv_text.count("=HYPERLINK") == 1
+
+
+def test_to_csv_neutralizes_extra_value_with_dangerous_key():
+    result = Result.taken(
+        username="x", platform="tumblr", extra={"command": "=cmd|/c calc"}
+    )
+    csv_text = result.to_csv()
+    assert not csv_text.startswith("=cmd")
+    assert not csv_text.lstrip('"').startswith("=cmd")

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -384,8 +384,6 @@ def main():
             if args.format == "csv"
             else formatter.into_json(results)
         )
-
-    if args.output:
         if args.format == "json":
             # Get the new data as a LIST of DICTS, not a string
             new_items = formatter.get_json_data(results)

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -22,6 +22,16 @@ DEBUG_MSG = """Result {{
 CSV_FIELDS = ["username", "category", "site_name", "status", "url", "extra", "reason"]
 
 
+def _neutralize_csv_cell(value):
+    FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@", "\t", "\r", "\n")
+    if value is None:
+        return value
+    s = str(value)
+    if s.lstrip().startswith(FORMULA_TRIGGER_CHARS):
+        return "'" + s
+    return value
+
+
 def indent_text(msg: str, level: int, ignore_first: bool = False) -> str:
     if level <= 0 or not msg:
         return msg
@@ -190,6 +200,9 @@ class Result:
             data["extra"] = ""
 
         del data["is_email"]
+
+        data = {k: _neutralize_csv_cell(v) for k, v in data.items()}
+
         output = io.StringIO()
         writer = csv.DictWriter(output, fieldnames=CSV_FIELDS, lineterminator="")
         writer.writerow(data)


### PR DESCRIPTION
This PR, hopefully, fixes the security vulnerability stated in #381 ( fixes #381 ).
Its a simple fix by simply neutralizing each `Result` field before passing them into the CSV writer. It neutralized values starting in `("=", "+", "-", "@", "\t", "\r", "\n")` by adding `"'"` to the start.