### PR TITLE
fix: prevent proxy credential leakage on disk (fixes #383)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 rm_cache.py
 result.json
 *.csv
+validated_proxies.txt

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -205,13 +205,7 @@ def main():
                     f"{G}[+] Found {len(working_proxies)} working proxies out of {len(all_proxies)}{X}"
                 )
 
-                # Save working proxies to temp file
-                temp_proxy_file = "validated_proxies.txt"
-                with open(temp_proxy_file, "w", encoding="utf-8") as f:
-                    for proxy in working_proxies:
-                        f.write(proxy + "\n")
-
-                set_proxy_manager(temp_proxy_file)
+                set_proxy_manager(proxies=working_proxies)
                 proxy_count = get_proxy_count()
                 print(f"{G}[+] Using {proxy_count} validated proxies{X}")
             else:

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -157,11 +157,28 @@ def validate_proxies(proxy_list: List[str], timeout: int = 5, max_workers: int =
 class ProxyManager:
     """Thread-safe proxy manager that loads and rotates proxies from a file."""
 
-    def __init__(self, proxy_file: str):
+    def __init__(self, proxy_file: Optional[str] = None, proxies: Optional[list[str]] = None):
         self.proxies: list[str] = []
         self.current_index = 0
         self.lock = threading.Lock()
-        self._load_proxies(proxy_file)
+        if proxies is not None:
+            self._load_proxies_from_list(proxies)
+        elif proxy_file is not None:
+            self._load_proxies(proxy_file)
+        else:
+            raise ValueError("Either proxy_file or proxies must be provided")
+
+    def _load_proxies_from_list(self, proxy_list: list[str]) -> None:
+        """Load proxies from a provided list. Keep explicit schemes, default to http:// when missing."""
+        for line in proxy_list:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                if "://" not in line:
+                    line = "http://" + line
+                self.proxies.append(line)
+
+        if not self.proxies:
+            raise ValueError("No valid proxies found in list")
 
     def _load_proxies(self, proxy_file: str) -> None:
         """Load proxies from a text file. Keep explicit schemes, default to http:// when missing."""
@@ -209,11 +226,11 @@ class ProxyManager:
 _proxy_manager: Optional[ProxyManager] = None
 
 
-def set_proxy_manager(proxy_file: Optional[str]) -> None:
-    """Initialize the global proxy manager with a proxy file."""
+def set_proxy_manager(proxy_file: Optional[str] = None, proxies: Optional[list[str]] = None) -> None:
+    """Initialize the global proxy manager with a proxy file or list."""
     global _proxy_manager
-    if proxy_file:
-        _proxy_manager = ProxyManager(proxy_file)
+    if proxy_file or proxies is not None:
+        _proxy_manager = ProxyManager(proxy_file=proxy_file, proxies=proxies)
     else:
         _proxy_manager = None
 


### PR DESCRIPTION
### Summary
This PR fixes issue #383 by preventing the tool from writing validated proxies containing credentials to a plaintext `validated_proxies.txt` file in the current working directory.

### Changes
* Updated `ProxyManager` in `user_scanner/core/helpers.py` to support initialization directly from an in-memory list of proxies.
* Updated `set_proxy_manager` to accept an in-memory `proxies` list instead of just a file path.
* Modified `user_scanner/__main__.py` to pass the `working_proxies` list directly to `set_proxy_manager` and removed the logic that wrote them to `validated_proxies.txt`.
* Added `validated_proxies.txt` to `.gitignore` to prevent accidental commits of any leftover proxy files.
* Fixed some unused import lint issues in `tests/test_zillow_module.py`.