### PR TITLE
fix: resolve WAF, redirect, and SSL verification errors on Freesound, Myspace, Last.fm, Elixir Forum, Cups7, and Daily.dev

### DIFF
--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -179,12 +179,12 @@ def run_user_full(username: str, configs: ScanConfig) -> List[Result]:
 _clients: Dict[tuple, httpx.Client] = {}
 _clients_lock = threading.Lock()
 
-def get_client(use_http2: bool, proxy_val: Optional[str]) -> httpx.Client:
-    key = (use_http2, proxy_val)
+def get_client(use_http2: bool, proxy_val: Optional[str], verify: bool = True) -> httpx.Client:
+    key = (use_http2, proxy_val, verify)
     if key not in _clients:
         with _clients_lock:
             if key not in _clients:
-                _clients[key] = httpx.Client(http2=use_http2, proxy=proxy_val, verify=True)
+                _clients[key] = httpx.Client(http2=use_http2, proxy=proxy_val, verify=verify)
     return _clients[key]
 
 
@@ -211,8 +211,9 @@ def make_request(url: str, **kwargs) -> httpx.Response:
 
     method = kwargs.pop("method", "GET")
     use_http2 = kwargs.pop("http2", False)
+    verify = kwargs.pop("verify", True)
 
-    client = get_client(use_http2, proxy_val)
+    client = get_client(use_http2, proxy_val, verify)
 
     max_retries = 0
     for attempt in range(max_retries + 1):

--- a/user_scanner/user_scan/dev/daily_dev.py
+++ b/user_scanner/user_scan/dev/daily_dev.py
@@ -26,14 +26,19 @@ def _extract_next_data(html: str) -> dict | None:
 
 
 def validate_daily_dev(user):
-    url = f"https://app.daily.dev/{user}"
-    show_url = f"https://app.daily.dev/{user}"
+    url = f"https://daily.dev/{user}"
+    show_url = url
 
     headers = {
         "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
     }
 
     def process(response):
+        if response.status_code == 404:
+            return Result.available()
+
         next_data = _extract_next_data(response.text)
         if next_data is None:
             return Result.error(
@@ -42,16 +47,25 @@ def validate_daily_dev(user):
 
         page_props = next_data.get("props", {}).get("pageProps", {})
         user_data = page_props.get("user")
+        user_stats = page_props.get("userStats", {})
 
-        if isinstance(user_data, dict):
-            if user_data.get("id") and user_data.get("name"):
-                return Result.taken()
+        if isinstance(user_data, dict) and user_data.get("id"):
+            extra = {}
+            if user_data.get("name"):
+                extra["name"] = user_data.get("name")
+            if user_data.get("bio"):
+                extra["bio"] = user_data.get("bio")
+            if user_data.get("reputation") is not None:
+                extra["reputation"] = user_data.get("reputation")
+            if user_data.get("createdAt"):
+                extra["joined"] = user_data.get("createdAt")
+            if isinstance(user_stats, dict):
+                if user_stats.get("numFollowers") is not None:
+                    extra["followers"] = user_stats.get("numFollowers")
+                if user_stats.get("numFollowing") is not None:
+                    extra["following"] = user_stats.get("numFollowing")
+            return Result.taken(extra=extra)
 
-        if page_props.get("noindex") is True:
-            return Result.available()
+        return Result.available()
 
-        return Result.error(
-            "Unexpected daily.dev payload shape, report it via GitHub issues."
-        )
-
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(url, process, show_url=show_url, headers=headers, follow_redirects=True)

--- a/user_scanner/user_scan/dev/elixir_forum.py
+++ b/user_scanner/user_scan/dev/elixir_forum.py
@@ -1,12 +1,15 @@
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_elixir_forum(user):
-    url = f"https://elixirforum.com/u/{user}.json"
-    show_url = f"https://elixirforum.com/u/{user}"
-    headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0"}
+    url = f"https://forum.elixirforum.com/u/{user}.json"
+    show_url = f"https://forum.elixirforum.com/u/{user}"
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
+    }
 
     try:
-        response = make_request(url, headers=headers)
+        response = make_request(url, headers=headers, follow_redirects=True)
         if response.status_code == 200:
             data = response.json()
             u = data.get("user", {})
@@ -26,7 +29,7 @@ def validate_elixir_forum(user):
                     if "{size}" in avatar:
                         avatar = avatar.format(size=120)
                     if avatar.startswith("/"):
-                        avatar = "https://elixirforum.com" + avatar
+                        avatar = "https://forum.elixirforum.com" + avatar
                     extra["avatar"] = avatar
                     
                 return Result.taken(extra=extra, url=show_url)

--- a/user_scanner/user_scan/music/freesound.py
+++ b/user_scanner/user_scan/music/freesound.py
@@ -1,47 +1,61 @@
-from user_scanner.core.orchestrator import generic_validate, Result
-
+from user_scanner.core.orchestrator import generic_validate, Result, make_request
+import re
 
 def validate_freesound(user):
-    url = f"https://freesound.org/people/{user}/section/stats/?ajax=1"
-    show_url = f"https://freesound.org/people/{user}/"
+    main_url = f"https://freesound.org/people/{user}/"
+    show_url = main_url
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
 
     def process(response):
-        if response.status_code == 200 and "forum posts" in response.text.lower():
-            extra = {}
-            try:
-                import re as local_re
-                # 1. Sounds count
-                sounds_match = local_re.search(r'([0-9]+)\s+sounds', response.text)
-                if sounds_match:
-                    extra["sounds"] = int(sounds_match.group(1))
-                # 2. Packs count
-                packs_match = local_re.search(r'([0-9]+)\s+packs', response.text)
-                if packs_match:
-                    extra["packs"] = int(packs_match.group(1))
-                # 3. Audio duration minutes
-                duration_match = local_re.search(r'([0-9:]+)\s+minutes', response.text)
-                if duration_match:
-                    extra["duration"] = duration_match.group(1)
-                # 4. Average rating
-                rating_match = local_re.search(r'([0-9.]+)\s+average rating', response.text)
-                if rating_match:
-                    extra["average_rating"] = float(rating_match.group(1))
-                # 5. Downloads count
-                downloads_match = local_re.search(r'([0-9]+)\s+downloads', response.text)
-                if downloads_match:
-                    extra["downloads"] = int(downloads_match.group(1))
-                # 6. Forum posts
-                forum_match = local_re.search(r'([0-9]+)\s+forum posts', response.text)
-                if forum_match:
-                    extra["forum_posts"] = int(forum_match.group(1))
-            except Exception:
-                pass
-            return Result.taken(extra=extra)
-
         if response.status_code == 404 or "Page not found" in response.text:
             return Result.available()
 
-        return Result.error("Unexpected response body, report it via GitHub issues.")
+        final_url = str(response.url)
+        match = re.search(r'/people/([^/]+)', final_url)
+        if not match:
+            return Result.available()
+        canonical_user = match.group(1)
 
-    return generic_validate(url, process, show_url=show_url)
+        stats_url = f"https://freesound.org/people/{canonical_user}/section/stats/?ajax=1"
+        try:
+            stats_resp = make_request(stats_url, headers=headers)
+            if stats_resp.status_code == 200:
+                extra = {}
+                text = stats_resp.text
+                
+                sounds_match = re.search(r'title="[^"]*uploaded\s+([0-9,]+)\s+sounds?"', text)
+                if sounds_match:
+                    extra["sounds"] = int(sounds_match.group(1).replace(",", ""))
+                    
+                packs_match = re.search(r'title="[^"]*created\s+([0-9,]+)\s+packs?"', text)
+                if packs_match:
+                    extra["packs"] = int(packs_match.group(1).replace(",", ""))
+                    
+                duration_match = re.search(r'title="[^"]*together account for\s+([^\s"]+\s+(?:hours|minutes|seconds|hour|minute|second))\s+of', text)
+                if duration_match:
+                    extra["duration"] = duration_match.group(1).strip()
+                    
+                rating_match = re.search(r'title="[^"]*average rating of\s+([0-9.]+)"', text)
+                if rating_match:
+                    extra["average_rating"] = float(rating_match.group(1))
+                    
+                downloads_match = re.search(r'title="[^"]*downloaded\s+([0-9,]+)\s+times"', text)
+                if downloads_match:
+                    extra["downloads"] = int(downloads_match.group(1).replace(",", ""))
+                    
+                forum_match = re.search(r'title="[^"]*written\s+([0-9,]+)\s+forum"', text)
+                if forum_match:
+                    extra["forum_posts"] = int(forum_match.group(1).replace(",", ""))
+                    
+                return Result.taken(extra=extra)
+        except Exception:
+            pass
 
+        return Result.taken()
+
+    return generic_validate(main_url, process, show_url=show_url, headers=headers, follow_redirects=True)

--- a/user_scanner/user_scan/music/lastfm.py
+++ b/user_scanner/user_scan/music/lastfm.py
@@ -38,5 +38,10 @@ def validate_lastfm(user):
         else:
             return Result.error(f"HTTP {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    return generic_validate(url, process, show_url=show_url, headers=headers)
 

--- a/user_scanner/user_scan/music/myspace.py
+++ b/user_scanner/user_scan/music/myspace.py
@@ -11,7 +11,7 @@ def validate_myspace(user: str) -> Result:
     }
     
     try:
-        response = make_request(url, headers=headers, follow_redirects=True)
+        response = make_request(url, headers=headers, follow_redirects=True, verify=False)
         
         if response.status_code == 200:
             return Result.taken(url=url)

--- a/user_scanner/user_scan/social/cups7.py
+++ b/user_scanner/user_scan/social/cups7.py
@@ -4,13 +4,25 @@ def validate_7cups(user):
     url = f"https://www.7cups.com/@{user}"
     show_url = url
 
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
     def process(response):
+        if response.status_code == 202 or "x-amzn-waf-action" in response.headers:
+            return Result.error("AWS WAF challenge triggered")
+
+        if response.status_code == 404:
+            return Result.available()
+
         if "Profile - 7 Cups" in response.text:
             return Result.taken()
 
         if "The content you're attempting to access could not be" in response.text:
             return Result.available()
 
-        return Result.error("Unexpected response body, report it via GitHub issues.")
+        return Result.error(f"Unexpected response status: {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url)
+    return generic_validate(url, process, show_url=show_url, headers=headers, follow_redirects=True)


### PR DESCRIPTION
- **orchestrator.py**: Added support for a custom `verify: bool` parameter in `make_request()` and `get_client()` functions. Included the verification boolean within the client cache indexing key to allow individual module validators to bypass SSL verification dynamically (e.g. for sites with misconfigured intermediate SSL certificates) while preserving standard security verification by default.
---

- **Freesound**: Fixed unexpected response errors caused by case-sensitivity redirects by retrieving canonical usernames first and using reliable regex patterns to parse stats from the ajax page.
- **Last.fm**: Updated module headers with a modern Chrome User-Agent to bypass custom WAF block codes (HTTP 600).
- **Myspace**: Added custom `verify` support to `orchestrator.py` to bypass SSL certificate validation failures.
- **Elixir Forum**: Updated request endpoint to canonical `forum.elixirforum.com` and enabled redirect following.
- **Cups7**: Handled AWS WAF challenge status (202) gracefully, returning detailed error messages instead of generic crash reports.
- **Daily.dev**: Synced request domain directly to `daily.dev`, enabled redirect following, fixed a false-negative bug where active users with `noindex` headers were flagged as not found, and added full stats extraction (reputation, followers, following, registration date).