### PR TITLE
Enhance proxy support for email scanning and optimize proxy validation

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -118,7 +118,7 @@ def main():
     parser.add_argument(
         "--validate-proxies",
         action="store_true",
-        help="Validate proxies before scanning (tests against google.com)",
+        help="Validate proxies before scanning (tests against gstatic.com/generate_204)",
     )
 
     parser.add_argument(

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import httpx
 from pathlib import Path
 from types import ModuleType
 from typing import List, Optional, Set
@@ -8,6 +9,7 @@ from colorama import Fore, Style
 from user_scanner.core.helpers import (
     ScanConfig,
     find_category,
+    get_proxy,
     get_scan_func,
     get_site_name,
     is_loud,
@@ -15,6 +17,28 @@ from user_scanner.core.helpers import (
     load_modules,
 )
 from user_scanner.core.result import Result, Status
+
+# Monkey-patch httpx clients to automatically use proxies for email scans
+_original_async_client_init = httpx.AsyncClient.__init__
+_original_client_init = httpx.Client.__init__
+
+def _patched_async_client_init(self, *args, **kwargs):
+    if "proxy" not in kwargs and "proxies" not in kwargs:
+        proxy = get_proxy()
+        if proxy:
+            kwargs["proxy"] = proxy
+    _original_async_client_init(self, *args, **kwargs)
+
+def _patched_client_init(self, *args, **kwargs):
+    if "proxy" not in kwargs and "proxies" not in kwargs:
+        proxy = get_proxy()
+        if proxy:
+            kwargs["proxy"] = proxy
+    _original_client_init(self, *args, **kwargs)
+
+httpx.AsyncClient.__init__ = _patched_async_client_init
+httpx.Client.__init__ = _patched_client_init
+
 
 # Concurrency control
 MAX_CONCURRENT_REQUESTS = 25

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -36,8 +36,8 @@ def _patched_client_init(self, *args, **kwargs):
             kwargs["proxy"] = proxy
     _original_client_init(self, *args, **kwargs)
 
-httpx.AsyncClient.__init__ = _patched_async_client_init
-httpx.Client.__init__ = _patched_client_init
+httpx.AsyncClient.__init__ = _patched_async_client_init  # type: ignore[method-assign]
+httpx.Client.__init__ = _patched_client_init  # type: ignore[method-assign]
 
 
 # Concurrency control

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -126,8 +126,8 @@ def find_category(module: ModuleType) -> str | None:
 async def _validate_proxy_async(proxy: str, timeout: int) -> Optional[str]:
     try:
         async with httpx.AsyncClient(proxy=proxy, timeout=timeout) as client:
-            response = await client.get("https://www.google.com")
-            if response.status_code == 200:
+            response = await client.get("http://gstatic.com/generate_204")
+            if response.status_code in (200, 204):
                 return proxy
     except Exception:
         pass
@@ -150,7 +150,7 @@ async def _validate_proxies_batch(proxy_list: List[str], timeout: int, max_worke
     return working_proxies
 
 def validate_proxies(proxy_list: List[str], timeout: int = 5, max_workers: int = 50) -> List[str]:
-    """Validate proxies by testing them against google.com. Returns list of working proxies."""
+    """Validate proxies by testing them against gstatic.com/generate_204. Returns list of working proxies."""
     return asyncio.run(_validate_proxies_batch(proxy_list, timeout, max_workers))
 
 


### PR DESCRIPTION

This PR introduces two main proxy-related improvements:

-  **Global Proxy Support for Email Modules:**
   Automatically injects the user-provided proxy into `httpx.AsyncClient` and `httpx.Client` via `email_orchestrator.py`. This ensures that all existing and future email scan modules use proxies out of the box, entirely eliminating the need to refactor individual module codebases.
- **Optimized Proxy Validation:**
   Switched the proxy validation endpoint from `https://google.com` to `http://gstatic.com/generate_204`. This highly available endpoint returns a 0-byte `204 No Content` response, making proxy validation significantly faster and more bandwidth-efficient, especially when testing large proxy lists. 

- Monkey-patched `httpx` client initialization in `core/email_orchestrator.py`.
- Updated `_validate_proxy_async` in `core/helpers.py` to ping the `generate_204` endpoint and accept `204`/`200` status codes.
- Updated the CLI help string for `--validate-proxies` in `__main__.py` to reflect the change.