### PR TITLE
feat: add user modules for Yaga, StackB, Pedsovet

### DIFF
--- a/tests/test_pedsovet.py
+++ b/tests/test_pedsovet.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+from user_scanner.core.result import Status
+from user_scanner.user_scan.other import pedsovet
+
+
+def _profile_html(username="asd"):
+    return f"""
+    <html>
+      <body>
+        <div class="user">
+          <center><img src="//pedsovet.su/default2.png" border="0"></center>
+        </div>
+        <div class="userinfo">
+          <p>Логин: {username}</p>
+          <p>Группа пользователей: Зарегистрированные </p>
+          <p>Ссылка на профиль:<br><a href="//pedsovet.su/index/8-1876">pedsovet.su/index/8-1876</a></p>
+          <p>Регистрация: Понедельник, 15.09.2008, 23:34</p>
+        </div>
+        <div class="block50 rightb"><span>Последний вход Понедельник, 15.09.2008, 23:34</span></div>
+        <div class="osebe">О себе</div><div class="line1"></div>
+        <p class="clr">Teacher profile</p>
+        <div id="myCertificates"><certificates user-id='1876'></certificates></div>
+      </body>
+    </html>
+    """
+
+
+def _mock_generic_validate(monkeypatch, response_text, status_code=200):
+    def fake_generic_validate(url, process, **kwargs):
+        response = SimpleNamespace(status_code=status_code, text=response_text)
+        return process(response).update(url=kwargs.get("show_url"))
+
+    monkeypatch.setattr(pedsovet, "generic_validate", fake_generic_validate)
+
+
+def test_pedsovet_taken(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html())
+
+    result = pedsovet.validate_pedsovet("asd")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://pedsovet.su/index/8-0-asd"
+    assert result.extra["id"] == "1876"
+    assert result.extra["login"] == "asd"
+    assert result.extra["group"] == "Зарегистрированные"
+    assert result.extra["registered"] == "Понедельник, 15.09.2008, 23:34"
+    assert result.extra["last_login"] == "Понедельник, 15.09.2008, 23:34"
+    assert result.extra["avatar"] == "https://pedsovet.su/default2.png"
+    assert result.extra["profile_url"] == "https://pedsovet.su/index/8-1876"
+    assert result.extra["about"] == "Teacher profile"
+
+
+def test_pedsovet_available(monkeypatch):
+    _mock_generic_validate(monkeypatch, "Пользователь не найден")
+
+    result = pedsovet.validate_pedsovet("missing_user")
+
+    assert result.status == Status.AVAILABLE
+
+
+def test_pedsovet_login_match_is_case_insensitive(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html("Test"))
+
+    result = pedsovet.validate_pedsovet("test")
+
+    assert result.status == Status.TAKEN
+    assert result.extra["login"] == "Test"
+
+
+def test_pedsovet_rejects_period_before_request(monkeypatch):
+    def fail_generic_validate(*args, **kwargs):
+        raise AssertionError("generic_validate should not be called")
+
+    monkeypatch.setattr(pedsovet, "generic_validate", fail_generic_validate)
+
+    result = pedsovet.validate_pedsovet("bad.user")
+
+    assert result.status == Status.ERROR
+    assert "Usernames can only contain" in result.reason
+
+
+def test_pedsovet_rejects_dash_before_request(monkeypatch):
+    def fail_generic_validate(*args, **kwargs):
+        raise AssertionError("generic_validate should not be called")
+
+    monkeypatch.setattr(pedsovet, "generic_validate", fail_generic_validate)
+
+    result = pedsovet.validate_pedsovet("bad-user")
+
+    assert result.status == Status.ERROR
+    assert "Usernames can only contain" in result.reason
+
+
+def test_pedsovet_allows_at_sign(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html("test@user"))
+
+    result = pedsovet.validate_pedsovet("test@user")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://pedsovet.su/index/8-0-test@user"
+    assert result.extra["login"] == "test@user"
+
+
+def test_pedsovet_ambiguous_page_errors(monkeypatch):
+    _mock_generic_validate(monkeypatch, "<html><body>Педсовет</body></html>")
+
+    result = pedsovet.validate_pedsovet("asd")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Unexpected response body"

--- a/tests/test_stackb.py
+++ b/tests/test_stackb.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+
+from user_scanner.core.result import Status
+from user_scanner.user_scan.gaming import stackb
+
+
+def _profile_html(username="777h"):
+    return f"""
+    <html>
+      <head>
+        <link rel="canonical" href="https://stackb.net/@{username}">
+        <meta property="og:type" content="profile">
+        <meta property="og:title" content="μ (@{username}) — Stack B">
+        <meta property="og:description" content="Bio text. Ранг: Gold2. Подписчики: 1191. Профиль на Stack B">
+        <meta property="og:url" content="https://stackb.net/@{username}">
+        <meta property="og:image" content="https://cdn-msk.stackb.net/avatar.png">
+        <script type="application/ld+json">{{
+          "@context": "https://schema.org",
+          "@type": "ProfilePage",
+          "name": "μ (@{username}) — Stack B",
+          "url": "https://stackb.net/@{username}",
+          "mainEntity": {{
+            "@type": "Person",
+            "name": "μ",
+            "url": "https://stackb.net/@{username}",
+            "image": "https://cdn-msk.stackb.net/avatar.png",
+            "description": "Bio text",
+            "identifier": "@{username}"
+          }}
+        }}</script>
+      </head>
+      <body>
+        <div wire:snapshot="{{&quot;memo&quot;:{{&quot;name&quot;:&quot;profile&quot;}}}}">
+          <a href="https://stackb.net/@{username}/followers">1191 Подписчиков</a>
+        </div>
+      </body>
+    </html>
+    """
+
+
+def _mock_generic_validate(monkeypatch, response_text, status_code=200):
+    def fake_generic_validate(url, process, **kwargs):
+        response = SimpleNamespace(status_code=status_code, text=response_text)
+        return process(response).update(url=kwargs.get("show_url"))
+
+    monkeypatch.setattr(stackb, "generic_validate", fake_generic_validate)
+
+
+def test_stackb_taken(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html())
+
+    result = stackb.validate_stackb("777h")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://stackb.net/@777h"
+    assert result.extra["display_name"] == "μ"
+    assert result.extra["bio"] == "Bio text"
+    assert result.extra["avatar"] == "https://cdn-msk.stackb.net/avatar.png"
+    assert result.extra["followers"] == 1191
+    assert result.extra["rank"] == "Gold2"
+    assert result.extra["profile_url"] == "https://stackb.net/@777h"
+
+
+def test_stackb_strips_leading_at(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html())
+
+    result = stackb.validate_stackb("@777h")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://stackb.net/@777h"
+
+
+def test_stackb_available(monkeypatch):
+    body = "<html><body><p>404</p><h1>Страница не найдена</h1></body></html>"
+    _mock_generic_validate(monkeypatch, body, status_code=404)
+
+    result = stackb.validate_stackb("missing-user")
+
+    assert result.status == Status.AVAILABLE
+
+
+def test_stackb_rejects_path_separator_before_request(monkeypatch):
+    def fail_generic_validate(*args, **kwargs):
+        raise AssertionError("generic_validate should not be called")
+
+    monkeypatch.setattr(stackb, "generic_validate", fail_generic_validate)
+
+    result = stackb.validate_stackb("bad/user")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Username contains unsafe URL path characters"
+
+
+def test_stackb_allows_internal_special_character(monkeypatch):
+    _mock_generic_validate(monkeypatch, _profile_html("bad@user"))
+
+    result = stackb.validate_stackb("bad@user")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://stackb.net/@bad%40user"
+    assert result.extra["profile_url"] == "https://stackb.net/@bad@user"
+
+
+def test_stackb_ambiguous_page_errors(monkeypatch):
+    body = """
+    <html>
+      <head>
+        <link rel="canonical" href="https://stackb.net/@777h">
+        <meta property="og:type" content="website">
+      </head>
+    </html>
+    """
+    _mock_generic_validate(monkeypatch, body)
+
+    result = stackb.validate_stackb("777h")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Unexpected response body"

--- a/tests/test_yaga.py
+++ b/tests/test_yaga.py
@@ -1,0 +1,132 @@
+import json
+from types import SimpleNamespace
+
+from user_scanner.core.result import Status
+from user_scanner.user_scan.shopping import yaga_co_za, yaga_ee
+
+
+def _html(page_props):
+    data = {"props": {"pageProps": page_props}}
+    return (
+        '<script id="__NEXT_DATA__" type="application/json">'
+        f"{json.dumps(data)}"
+        "</script>"
+    )
+
+
+def _mock_generic_validate(monkeypatch, module, response_text, status_code=200):
+    def fake_generic_validate(url, process, **kwargs):
+        response = SimpleNamespace(status_code=status_code, text=response_text)
+        return process(response).update(url=kwargs.get("show_url"))
+
+    monkeypatch.setattr(module, "generic_validate", fake_generic_validate)
+
+
+def test_yaga_ee_taken(monkeypatch):
+    body = _html(
+        {
+            "initialShop": {
+                "id": 6276916,
+                "activeSlug": "brandikas",
+                "name": "Brandikas",
+                "description": "Secondhand brand shop",
+                "owner": {"firstName": "Shop", "lastName": "Owner"},
+            }
+        }
+    )
+    _mock_generic_validate(monkeypatch, yaga_ee, body)
+
+    result = yaga_ee.validate_yaga_ee("brandikas")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://www.yaga.ee/brandikas"
+    assert result.extra["id"] == 6276916
+    assert result.extra["name"] == "Brandikas"
+    assert result.extra["description"] == "Secondhand brand shop"
+    assert result.extra["owner_first_name"] == "Shop"
+    assert result.extra["owner_last_name"] == "Owner"
+
+
+def test_yaga_ee_available(monkeypatch):
+    body = _html({"initialShop": None, "initialProducts": []})
+    _mock_generic_validate(monkeypatch, yaga_ee, body)
+
+    result = yaga_ee.validate_yaga_ee("missing-shop")
+
+    assert result.status == Status.AVAILABLE
+
+
+def test_yaga_ee_missing_next_data(monkeypatch):
+    _mock_generic_validate(monkeypatch, yaga_ee, "<html></html>")
+
+    result = yaga_ee.validate_yaga_ee("brandikas")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Could not find Next.js data"
+
+
+def test_yaga_ee_malformed_next_data(monkeypatch):
+    body = (
+        '<script id="__NEXT_DATA__" type="application/json">'
+        "{"
+        "</script>"
+    )
+    _mock_generic_validate(monkeypatch, yaga_ee, body)
+
+    result = yaga_ee.validate_yaga_ee("brandikas")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Could not parse Next.js data"
+
+
+def test_yaga_ee_rejects_path_separator_before_request(monkeypatch):
+    def fail_generic_validate(*args, **kwargs):
+        raise AssertionError("generic_validate should not be called")
+
+    monkeypatch.setattr(yaga_ee, "generic_validate", fail_generic_validate)
+
+    result = yaga_ee.validate_yaga_ee("bad/user")
+
+    assert result.status == Status.ERROR
+    assert result.reason == "Username contains unsafe URL path characters"
+
+
+def test_yaga_ee_allows_special_characters(monkeypatch):
+    body = _html(
+        {
+            "initialShop": {
+                "id": 123,
+                "activeSlug": "shop.name@tag",
+                "name": "Special Shop",
+                "owner": {},
+            }
+        }
+    )
+    _mock_generic_validate(monkeypatch, yaga_ee, body)
+
+    result = yaga_ee.validate_yaga_ee("shop.name@tag")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://www.yaga.ee/shop.name%40tag"
+    assert result.extra["name"] == "Special Shop"
+
+
+def test_yaga_co_za_taken_shop_name(monkeypatch):
+    body = _html(
+        {
+            "initialShop": {
+                "id": 5017196,
+                "activeSlug": "the2lifewardrobe",
+                "name": "The Second Life Wardrobe",
+                "owner": {},
+            }
+        }
+    )
+    _mock_generic_validate(monkeypatch, yaga_ee, body)
+
+    result = yaga_co_za.validate_yaga_co_za("the2lifewardrobe")
+
+    assert result.status == Status.TAKEN
+    assert result.url == "https://www.yaga.co.za/the2lifewardrobe"
+    assert result.extra["id"] == 5017196
+    assert result.extra["name"] == "The Second Life Wardrobe"

--- a/user_scanner/user_scan/gaming/stackb.py
+++ b/user_scanner/user_scan/gaming/stackb.py
@@ -1,0 +1,159 @@
+import html
+import json
+import re
+from urllib.parse import quote
+
+from user_scanner.core.helpers import get_random_user_agent
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+JSON_LD_RE = re.compile(
+    r'<script type="application/ld\+json">(.*?)</script>',
+    re.DOTALL,
+)
+UNSAFE_PATH_RE = re.compile(r"[/#?\x00-\x1f\x7f]")
+
+
+def _meta_content(response_text: str, attr: str, value: str) -> str | None:
+    pattern = (
+        rf'<meta\s+[^>]*{attr}=["\']{re.escape(value)}["\'][^>]*'
+        r'content=["\']([^"\']*)["\'][^>]*>'
+    )
+    match = re.search(pattern, response_text, re.IGNORECASE)
+    if match:
+        return html.unescape(match.group(1)).strip()
+
+    pattern = (
+        r'<meta\s+[^>]*content=["\']([^"\']*)["\'][^>]*'
+        rf'{attr}=["\']{re.escape(value)}["\'][^>]*>'
+    )
+    match = re.search(pattern, response_text, re.IGNORECASE)
+    if match:
+        return html.unescape(match.group(1)).strip()
+
+    return None
+
+
+def _canonical_url(response_text: str) -> str | None:
+    match = re.search(
+        r'<link\s+[^>]*rel=["\']canonical["\'][^>]*href=["\']([^"\']*)["\']',
+        response_text,
+        re.IGNORECASE,
+    )
+    if match:
+        return html.unescape(match.group(1)).strip()
+
+    return None
+
+
+def _json_ld_profile(response_text: str) -> dict:
+    for match in JSON_LD_RE.finditer(response_text):
+        try:
+            data = json.loads(html.unescape(match.group(1)))
+        except json.JSONDecodeError:
+            continue
+
+        if data.get("@type") == "ProfilePage":
+            entity = data.get("mainEntity")
+            return entity if isinstance(entity, dict) else {}
+
+    return {}
+
+
+def _profile_extra(response_text: str, profile_url: str) -> dict:
+    profile = _json_ld_profile(response_text)
+    title = _meta_content(response_text, "property", "og:title") or ""
+    meta_description = (
+        _meta_content(response_text, "property", "og:description")
+        or _meta_content(response_text, "name", "description")
+    )
+    description = profile.get("description") or meta_description
+
+    display_name = profile.get("name")
+    if not display_name and " (@" in title:
+        display_name = title.split(" (@", 1)[0]
+
+    rank = None
+    followers = None
+    if meta_description or description:
+        rank_match = re.search(r"Ранг:\s*([^\.]+)", meta_description or description)
+        if rank_match:
+            rank = rank_match.group(1).strip()
+
+        followers_match = re.search(r"Подписчики:\s*(\d+)", meta_description or description)
+        if followers_match:
+            followers = int(followers_match.group(1))
+
+    if followers is None:
+        followers_match = re.search(r"(\d+)\s*Подписчиков", response_text)
+        if followers_match:
+            followers = int(followers_match.group(1))
+
+    return {
+        "display_name": display_name,
+        "bio": description,
+        "avatar": profile.get("image") or _meta_content(response_text, "property", "og:image"),
+        "followers": followers,
+        "rank": rank,
+        "profile_url": profile.get("url") or profile_url,
+    }
+
+
+def validate_stackb(user: str) -> Result:
+    user = user.strip().lower()
+    if user.startswith("@"):
+        user = user[1:]
+    profile_url = f"https://stackb.net/@{user}"
+    url = f"https://stackb.net/@{quote(user, safe='')}"
+
+    if not user:
+        return Result.error("Username cannot be empty", url=url)
+
+    if UNSAFE_PATH_RE.search(user):
+        return Result.error("Username contains unsafe URL path characters", url=url)
+
+    headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "ru,en-US;q=0.9,en;q=0.8",
+    }
+
+    def process(response):
+        response_text = response.text
+
+        if response.status_code == 404 and (
+            "Страница не найдена" in response_text
+            or re.search(r">\s*404\s*<", response_text)
+        ):
+            return Result.available()
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
+
+        og_type = _meta_content(response_text, "property", "og:type")
+        canonical_url = _canonical_url(response_text)
+        og_url = _meta_content(response_text, "property", "og:url")
+        profile = _json_ld_profile(response_text)
+
+        profile_urls = {canonical_url, og_url, profile.get("url")}
+        has_profile_url = url in profile_urls or profile_url in profile_urls
+        has_profile_identifier = profile.get("identifier") == f"@{user}"
+        has_profile_component = 'name&quot;:&quot;profile&quot;' in response_text
+
+        if (
+            og_type == "profile"
+            and has_profile_url
+            and (has_profile_identifier or has_profile_component)
+        ):
+            return Result.taken(extra=_profile_extra(response_text, profile_url))
+
+        return Result.error("Unexpected response body")
+
+    return generic_validate(
+        url,
+        process,
+        headers=headers,
+        show_url=url,
+        follow_redirects=True,
+    )

--- a/user_scanner/user_scan/gaming/stackb.py
+++ b/user_scanner/user_scan/gaming/stackb.py
@@ -68,20 +68,27 @@ def _profile_extra(response_text: str, profile_url: str) -> dict:
         _meta_content(response_text, "property", "og:description")
         or _meta_content(response_text, "name", "description")
     )
-    description = profile.get("description") or meta_description
+    profile_description = profile.get("description")
+    if not isinstance(profile_description, str):
+        profile_description = None
+
+    description = profile_description or meta_description
 
     display_name = profile.get("name")
+    if not isinstance(display_name, str):
+        display_name = None
     if not display_name and " (@" in title:
         display_name = title.split(" (@", 1)[0]
 
     rank = None
     followers = None
-    if meta_description or description:
-        rank_match = re.search(r"Ранг:\s*([^\.]+)", meta_description or description)
+    stats_text = meta_description or description
+    if stats_text:
+        rank_match = re.search(r"Ранг:\s*([^\.]+)", stats_text)
         if rank_match:
             rank = rank_match.group(1).strip()
 
-        followers_match = re.search(r"Подписчики:\s*(\d+)", meta_description or description)
+        followers_match = re.search(r"Подписчики:\s*(\d+)", stats_text)
         if followers_match:
             followers = int(followers_match.group(1))
 

--- a/user_scanner/user_scan/other/pedsovet.py
+++ b/user_scanner/user_scan/other/pedsovet.py
@@ -1,0 +1,154 @@
+import html
+import re
+
+from user_scanner.core.helpers import get_random_user_agent
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+USERNAME_RE = re.compile(r"^[a-z0-9_@]+$", re.IGNORECASE)
+
+
+def _strip_tags(value: str) -> str:
+    value = re.sub(r"<[^>]+>", "", value)
+    return html.unescape(value).strip()
+
+
+def _profile_id(response_text: str) -> str | None:
+    patterns = [
+        r"/index/8-(\d+)",
+        r"user-id=['\"](\d+)['\"]",
+        r'\{uid:\s*"(\d+)"\}',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, response_text)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def _field(response_text: str, label: str) -> str | None:
+    match = re.search(
+        rf"<p>{re.escape(label)}:\s*(.*?)</p>",
+        response_text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if match:
+        return _strip_tags(match.group(1))
+
+    return None
+
+
+def _avatar(response_text: str) -> str | None:
+    match = re.search(
+        r'<div class="user">\s*<center><img\s+src="([^"]+)"',
+        response_text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+
+    avatar = html.unescape(match.group(1)).strip()
+    if avatar.startswith("//"):
+        return "https:" + avatar
+    if avatar.startswith("/"):
+        return "https://pedsovet.su" + avatar
+    return avatar
+
+
+def _last_login(response_text: str) -> str | None:
+    match = re.search(
+        r"Последний вход\s*([^<]+)",
+        response_text,
+        re.IGNORECASE,
+    )
+    if match:
+        return html.unescape(match.group(1)).strip()
+
+    return None
+
+
+def _about(response_text: str) -> str | None:
+    match = re.search(
+        r'<div class="osebe">О себе</div>.*?<p class="clr">(.*?)</p>',
+        response_text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return None
+
+    about = _strip_tags(match.group(1))
+    if about == "Пользователь пока ничего не сообщил о себе.":
+        return None
+    return about
+
+
+def _profile_extra(response_text: str, login: str) -> dict:
+    profile_id = _profile_id(response_text)
+    profile_url = f"https://pedsovet.su/index/8-{profile_id}" if profile_id else None
+
+    return {
+        "id": profile_id,
+        "login": login,
+        "group": _field(response_text, "Группа пользователей"),
+        "registered": _field(response_text, "Регистрация"),
+        "last_login": _last_login(response_text),
+        "avatar": _avatar(response_text),
+        "profile_url": profile_url,
+        "about": _about(response_text),
+    }
+
+
+def validate_pedsovet(user: str) -> Result:
+    user = user.strip()
+    url = f"https://pedsovet.su/index/8-0-{user}"
+
+    if not user:
+        return Result.error("Username cannot be empty", url=url)
+
+    if not USERNAME_RE.match(user):
+        return Result.error(
+            "Usernames can only contain letters, numbers, underscores and at signs",
+            url=url,
+        )
+
+    headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "ru,en-US;q=0.9,en;q=0.8",
+    }
+
+    def process(response):
+        response_text = response.text
+
+        if "Пользователь не найден" in response_text:
+            return Result.available()
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
+
+        login_match = re.search(
+            r"<p>Логин:\s*([^<]+)</p>",
+            response_text,
+            re.IGNORECASE,
+        )
+        found_login = html.unescape(login_match.group(1)).strip() if login_match else None
+        has_profile_markers = (
+            "Группа пользователей:" in response_text
+            and "Регистрация:" in response_text
+            and "Ссылка на профиль:" in response_text
+        )
+
+        if found_login and found_login.lower() == user.lower() and has_profile_markers:
+            return Result.taken(extra=_profile_extra(response_text, found_login))
+
+        return Result.error("Unexpected response body")
+
+    return generic_validate(
+        url,
+        process,
+        headers=headers,
+        show_url=url,
+        follow_redirects=True,
+    )

--- a/user_scanner/user_scan/shopping/yaga_co_za.py
+++ b/user_scanner/user_scan/shopping/yaga_co_za.py
@@ -1,0 +1,6 @@
+from user_scanner.core.result import Result
+from user_scanner.user_scan.shopping.yaga_ee import _validate_yaga
+
+
+def validate_yaga_co_za(user: str) -> Result:
+    return _validate_yaga(user, "https://www.yaga.co.za")

--- a/user_scanner/user_scan/shopping/yaga_ee.py
+++ b/user_scanner/user_scan/shopping/yaga_ee.py
@@ -1,0 +1,92 @@
+import html
+import json
+import re
+from urllib.parse import quote
+
+from user_scanner.core.helpers import get_random_user_agent
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+NEXT_DATA_RE = re.compile(
+    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
+    re.DOTALL,
+)
+UNSAFE_PATH_RE = re.compile(r"[/#?\x00-\x1f\x7f]")
+
+
+def _extract_next_data(response_text: str) -> dict | None:
+    match = NEXT_DATA_RE.search(response_text)
+    if not match:
+        return None
+
+    return json.loads(html.unescape(match.group(1)))
+
+
+def _shop_extra(shop: dict) -> dict:
+    owner = shop.get("owner") or {}
+    extra = {
+        "id": shop.get("id"),
+        "name": shop.get("name"),
+        "description": shop.get("description"),
+        "owner_first_name": owner.get("firstName") or owner.get("first_name"),
+        "owner_last_name": owner.get("lastName") or owner.get("last_name"),
+    }
+    return {key: value for key, value in extra.items() if value}
+
+
+def _validate_yaga(user: str, base_url: str) -> Result:
+    user = user.strip().lower()
+    url = f"{base_url}/{quote(user, safe='')}"
+
+    if not user:
+        return Result.error("Username cannot be empty", url=url)
+
+    if UNSAFE_PATH_RE.search(user):
+        return Result.error("Username contains unsafe URL path characters", url=url)
+
+    headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    def process(response):
+        if response.status_code != 200:
+            return Result.error(
+                f"Unexpected response status: {response.status_code}",
+            )
+
+        try:
+            data = _extract_next_data(response.text)
+        except json.JSONDecodeError:
+            return Result.error("Could not parse Next.js data")
+
+        if data is None:
+            return Result.error("Could not find Next.js data")
+
+        page_props = data.get("props", {}).get("pageProps", {})
+        shop = page_props.get("initialShop")
+
+        if shop is None:
+            return Result.available()
+
+        if not isinstance(shop, dict):
+            return Result.error("Unexpected shop data")
+
+        if shop.get("activeSlug") != user:
+            return Result.error("Unexpected shop slug")
+
+        return Result.taken(extra=_shop_extra(shop))
+
+    return generic_validate(
+        url,
+        process,
+        headers=headers,
+        show_url=url,
+        follow_redirects=True,
+    )
+
+
+def validate_yaga_ee(user: str) -> Result:
+    return _validate_yaga(user, "https://www.yaga.ee")


### PR DESCRIPTION
This PR adds username modules for several sites I've ran into with usernames exposed in their profile URLs:

- Yaga is an Estonian online marketplace, they operate sites for Estonia, Latvia and South Africa, but the Latvian shares its database with the Estonian one so I omitted that one.
- StackB is a Russian gaming social network.
- Pedsovet is an ancient Russian site for study materials.
