### PR TITLE
feat: add 12 new mobile API email_scan modules learning(8), news(1), other(1), social(2) and patreon email_scan module fix

### DIFF
--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -30,6 +30,13 @@ LOUD_MODULES: Dict[str, List[str]] = {
         "luarocks",
         "uniscore",
         "finch",
+        "slowly",
+        "heyjapan",
+        "bnrlanguages",
+        "bunpo",
+        "hellochinese",
+        "hanzii",
+        "programminghub",
     ],
 }
 

--- a/user_scanner/email_scan/creator/patreon.py
+++ b/user_scanner/email_scan/creator/patreon.py
@@ -19,21 +19,31 @@ async def _check(email: str) -> Result:
                 "\",\"allow_account_creation\":false},\"auth_context\":\"auth\",\"ru\":\"https://www.patreon.com/home\"},\"relationships\":{}}}"
 
             headers = {
-                'User-Agent': "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Mobile Safari/537.36",
-                'Accept-Encoding': "identity",
+                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+                'Accept-Encoding': "gzip, deflate, br, zstd",
+                'sec-ch-ua-platform': '"Linux"',
+                'sec-ch-ua': '"Brave";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
                 'content-type': "application/vnd.api+json",
-                'origin': "https://www.patreon.com"
+                'sec-ch-ua-mobile': "?0",
+                'sec-gpc': "1",
+                'accept-language': "en-US,en;q=0.7",
+                'origin': "https://www.patreon.com",
+                'sec-fetch-site': "same-origin",
+                'sec-fetch-mode': "cors",
+                'sec-fetch-dest': "empty",
+                'referer': "https://www.patreon.com/login"
             }
 
             response = await client.post(
                 url,
                 params=params,
                 content=payload,
-                headers=headers
+                headers=headers,
+                timeout=6.0
             )
 
             if response.status_code != 200:
-                return Result.error(f"Status {response.status_code}")
+                return Result.error(f"Status {response.status_code}, report it via GitHub issues")
 
             data = response.json()
             next_step = data.get("data", {}).get(
@@ -44,7 +54,7 @@ async def _check(email: str) -> Result:
             elif next_step == "signup":
                 return Result.available(url=show_url)
             else:
-                return Result.error("Unexpected auth step")
+                return Result.error("Unexpected auth step, report it via GitHub issues")
 
         except Exception as e:
             return Result.error(f"unexpected exception: {e}")

--- a/user_scanner/email_scan/learning/babbel.py
+++ b/user_scanner/email_scan/learning/babbel.py
@@ -1,0 +1,77 @@
+import httpx
+import random
+from datetime import datetime, timezone
+from user_scanner.core.result import Result
+
+
+def _generate_udid() -> str:
+    """Generate a 32-character uppercase hex string."""
+    return "".join(random.choices("0123456789ABCDEF", k=32))
+
+
+def _get_amz_date() -> str:
+    """Generate the x-amz-date timestamp."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.babbel.io/gamma/v2/en/users/"
+    show_url = "https://play.google.com/store/apps/details?id=com.babbel.mobile.android.en"
+
+    payload = {
+        "user": {
+            "email": email,
+            "locale": "",
+            "learn_language_alpha3": "QMS",
+            "registration_date": "",
+            "uuid": "",
+            "authentication_token": "",
+            "country_alpha3": "",
+            "email_validated": False,
+            "privacy_policy": False,
+            "terms_and_conditions": False,
+            "password": "",
+            "firstname": "nopi",
+            "signin_token": "",
+            "captcha": {}
+        }
+    }
+
+    headers = {
+        'User-Agent': "Babbel/22.4.0 (Android 30.0; Google Pixel 6; Google; Google; en_US)",
+        'Accept': "application/json",
+        'Accept-Encoding': "gzip",
+        'x-device-udid': _generate_udid(),
+        'x-amz-date': _get_amz_date(),
+        'content-type': "application/json; charset=UTF-8"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 422:
+                data = response.json()
+                messages = data.get("error", {}).get("messages", [])
+
+                for msg in messages:
+                    if msg.get("attribute") == "email" and "taken" in msg.get("details", []):
+                        return Result.taken(url=show_url)
+
+                # If we didn't find the email taken error, it's available
+                return Result.available(url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_babbel(email: str) -> Result:
+    """
+    Babbel email validator. Checks registration endpoint without sending an email.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/bnrlanguages.py
+++ b/user_scanner/email_scan/learning/bnrlanguages.py
@@ -1,0 +1,63 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getOobConfirmationCode"
+    # Provide the Google Play Store link as the display URL since there might not be a direct web app
+    show_url = "https://play.google.com/store/apps/details?id=com.breboucas.japonesparaviajar"
+
+    params = {
+        'key': "AIzaSyCLqZQ3hh3mAGxFRGgdBz33kV6mTGadwuU"
+    }
+
+    payload = {
+        "requestType": 1,
+        "email": email,
+        "androidInstallApp": False,
+        "canHandleCodeInApp": False,
+        "clientType": "CLIENT_TYPE_ANDROID"
+    }
+
+    headers = {
+        'User-Agent': "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 6 Build/TP1A.220624.021)",
+        'Connection': "Keep-Alive",
+        'Accept-Encoding': "gzip",
+        'Content-Type': "application/json",
+        'X-Android-Package': "com.breboucas.japonesparaviajar",
+        'Accept-Language': "en-US",
+        'X-Client-Version': "Android/Fallback/X23001000/FirebaseCore-Android",
+        'X-Firebase-Locale': "en_US"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                error_msg = data.get("error", {}).get("message", "")
+                if error_msg == "EMAIL_NOT_FOUND":
+                    return Result.available(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("kind") == "identitytoolkit#GetOobConfirmationCodeResponse":
+                    return Result.taken(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_bnrlanguages(email: str) -> Result:
+    """
+    BNR Languages (Learn Korean) email validator. Note: This will send a password reset email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/bunpo.py
+++ b/user_scanner/email_scan/learning/bunpo.py
@@ -1,0 +1,61 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getOobConfirmationCode"
+    show_url = "https://play.google.com/store/apps/details?id=com.bunpoapp"
+
+    params = {
+        'key': "AIzaSyAxg8aXqILmTAN_OOAGIRt0IL6nkQyj3p8"
+    }
+
+    payload = {
+        "requestType": 1,
+        "email": email,
+        "androidInstallApp": False,
+        "canHandleCodeInApp": False,
+        "clientType": "CLIENT_TYPE_ANDROID"
+    }
+
+    headers = {
+        'User-Agent': "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 6 Build/TP1A.220624.021)",
+        'Connection': "Keep-Alive",
+        'Accept-Encoding': "gzip",
+        'Content-Type': "application/json",
+        'X-Android-Package': "com.bunpoapp",
+        'Accept-Language': "en-, en-US",
+        'X-Client-Version': "Android/Fallback/X23000000/FirebaseCore-Android"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                error_msg = data.get("error", {}).get("message", "")
+                if error_msg == "EMAIL_NOT_FOUND":
+                    return Result.available(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("kind") == "identitytoolkit#GetOobConfirmationCodeResponse":
+                    return Result.taken(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_bunpo(email: str) -> Result:
+    """
+    Bunpo email validator. Note: This will send a password reset email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/cakeapp.py
+++ b/user_scanner/email_scan/learning/cakeapp.py
@@ -1,0 +1,56 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.cakeapp.me/gw/auth/email/validate"
+    show_url = "https://play.google.com/store/apps/details?id=me.mycake"
+
+    params = {
+        'timezone': "330",
+        'lang': "en",
+        'languageToLearn': "en",
+        'appVersion': "6.8.0",
+        'os': "android",
+        'osVersion': "11",
+        'email': email
+    }
+
+    headers = {
+        'User-Agent': "okhttp/4.12.0",
+        'Accept-Encoding': "gzip"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                result_status = data.get("result", "")
+
+                if result_status == "SUCCESS":
+                    inner_data = data.get("data", {})
+                    has_error = inner_data.get("hasError")
+
+                    if has_error is False:
+                        return Result.available(url=show_url)
+                    elif has_error is True and inner_data.get("errorType") == "DUPLICATED":
+                        return Result.taken(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_cakeapp(email: str) -> Result:
+    """
+    Cake App email validator. Checks email validation endpoint without sending an email.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/hanzii.py
+++ b/user_scanner/email_scan/learning/hanzii.py
@@ -1,0 +1,50 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.hanzii.net/api/password/reset"
+    show_url = "https://play.google.com/store/apps/details?id=com.eup.hanzii"
+
+    payload = {
+        "X-localization": "en",
+        "email": email
+    }
+
+    headers = {
+        'User-Agent': "com.eup.hanzii/768 (Linux; U; Android 13; en_US; Pixel 6; Build/TP1A.220624.021; Cronet/149.0.7827.102)",
+        'Accept-Encoding': "gzip, deflate",
+        'content-type': "application/json; charset=UTF-8",
+        'priority': "u=1, i"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 401:
+                data = response.json()
+                if data.get("error") == "Email is not exist" and data.get("code") == 401:
+                    return Result.available(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("message") == "Success":
+                    return Result.taken(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_hanzii(email: str) -> Result:
+    """
+    Hanzii email validator. Note: This will send a password reset email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/hellochinese.py
+++ b/user_scanner/email_scan/learning/hellochinese.py
@@ -1,0 +1,75 @@
+import httpx
+import json
+import random
+from datetime import datetime
+from user_scanner.core.result import Result
+
+
+def _generate_device_id() -> str:
+    """Generate a random 32-character hex string representing a device ID."""
+    return "".join(random.choices("0123456789abcdef", k=32))
+
+
+def _get_time_str() -> str:
+    """Generate the timestamp in the required format."""
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S +0530")
+
+
+async def _check(email: str) -> Result:
+    url = "http://api3.hellochinese.cc/v1/passport/forget_password"
+    show_url = "https://play.google.com/store/apps/details?id=com.hellochinese"
+
+    payload = {
+        'email': email
+    }
+
+    env_data = {
+        "appVer": "7.10.35",
+        "cid": None,
+        "device": "Pixel 6",
+        "deviceId": _generate_device_id(),
+        "lang": "en",
+        "locale": "en-US",
+        "network": "wifi",
+        "osVer": "13",
+        "platform": "android",
+        "time": _get_time_str()
+    }
+
+    headers = {
+        'User-Agent': "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 6 Build/TP1A.220624.021)",
+        'Connection': "Keep-Alive",
+        'Accept-Encoding': "gzip",
+        'Env': json.dumps(env_data)
+    }
+
+    async with httpx.AsyncClient(http2=False) as client:
+        try:
+            # Form-encoded POST request
+            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                code = data.get("code")
+
+                if code == 103:
+                    return Result.available(url=show_url)
+                elif code == 0:
+                    return Result.taken(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_hellochinese(email: str) -> Result:
+    """
+    HelloChinese email validator. Note: This will send a password reset email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/heyjapan.py
+++ b/user_scanner/email_scan/learning/heyjapan.py
@@ -1,0 +1,45 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://v2.heyjapan.net/password/passwordCode"
+    show_url = "https://heyjapan.net"
+
+    payload = {
+        "email": email
+    }
+
+    headers = {
+        'User-Agent': "okhttp/5.3.2",
+        'Accept-Encoding': "gzip",
+        'Content-Type': "application/json"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            data = response.json()
+            message = data.get("message", "")
+
+            if response.status_code == 200 and message == "Gửi mã khôi phục qua email thành công":
+                return Result.taken(url=show_url)
+
+            if response.status_code == 404 and message == "Email does not exist!":
+                return Result.available(url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_heyjapan(email: str) -> Result:
+    """
+    HeyJapan email validator. Note: This will send a restore code via email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/programminghub.py
+++ b/user_scanner/email_scan/learning/programminghub.py
@@ -1,0 +1,51 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api-prod.programminghub.io/v5/api/auth/recover/initiate"
+    show_url = "https://play.google.com/store/apps/details?id=com.prghub.pro"
+
+    payload = {
+        "client": "android",
+        "email": email
+    }
+
+    headers = {
+        'User-Agent': "okhttp/5.3.2",
+        'Accept-Encoding': "gzip",
+        'client': "android",
+        'locale': "en",
+        'content-type': "application/json; charset=UTF-8"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                if data.get("status") is False and data.get("message") == "You are not registered with us":
+                    return Result.available(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("status") is True and "user_id" in data.get("data", {}):
+                    return Result.taken(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_programminghub(email: str) -> Result:
+    """
+    Programming Hub email validator. Note: This will send a recovery email if it exists.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/news/flipboard.py
+++ b/user_scanner/email_scan/news/flipboard.py
@@ -39,7 +39,7 @@ async def _check(email: str) -> Result:
                 elif data.get("valid") is True:
                     return Result.available(url=show_url)
 
-            return Result.error(f"Unexpected JSON response from Flipboard, report it via GitHub issues", url=show_url)
+            return Result.error("Unexpected JSON response from Flipboard, report it via GitHub issues", url=show_url)
 
         except Exception as e:
             return Result.error(str(e), url=show_url)

--- a/user_scanner/email_scan/news/flipboard.py
+++ b/user_scanner/email_scan/news/flipboard.py
@@ -1,0 +1,52 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://fbprod.flipboard.com/v1/flipboard/checkEmail/0"
+    show_url = "https://flipboard.com"
+
+    params = {
+        'email': email,
+        'ver': "4.3.56.5508",
+        'device': "aphone-google-pixel-30",
+        'locale': "en_US",
+        'lang': "en",
+        'locale_cg': "en_US",
+        'screensize': "6.0",
+        'app': "flipboard",
+        'udid': "8610cbecde6c89b6b0cb5449f2cd9f13d1cba8f4",
+        'tuuid': "52987290-d242-48a8-b10c-7b87fd8c7424"
+    }
+
+    headers = {
+        'User-Agent': "Mozilla/5.0 (Linux; Android 13; Pixel 6 Build/TP1A.220624.021; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.163 Mobile Safari/537.36 Flipboard/4.3.56/5508,4.3.56.5508",
+        'Accept-Encoding': "gzip"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            data = response.json()
+
+            if data.get("success") is True:
+                if data.get("valid") is False:
+                    return Result.taken(url=show_url)
+                elif data.get("valid") is True:
+                    return Result.available(url=show_url)
+
+            return Result.error(f"Unexpected JSON response from Flipboard, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(str(e), url=show_url)
+
+
+async def validate_flipboard(email: str) -> Result:
+    """
+    Flipboard email validator.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/other/dollarfix.py
+++ b/user_scanner/email_scan/other/dollarfix.py
@@ -1,0 +1,71 @@
+import base64
+import secrets
+import httpx
+from user_scanner.core.result import Result
+
+
+def _generate_firebase_uuid() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(16)).decode("utf-8").rstrip("=").replace("-", "_")
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.dollarfix.com/core-userinfo/user_center/apkLogin"
+    show_url = "https://dollarfix.com"
+
+    payload = {
+        "password": "generic_password_123",
+        "verifiable_type": 1,
+        "user_name": email
+    }
+
+    uuid_val = _generate_firebase_uuid()
+    firebase_token = f"{uuid_val}:APA91bFmZorXu14j6IauzmcISJNDuPds2wd5VAO35UFBLNAnzE7NA242XqLF46kZqZ-k9Q5Io7COOA5WbWScOwOFYqCc_UxqIqfxH486OYDwh3iQslz6Xuk"
+
+    headers = {
+        'User-Agent': "okhttp/4.10.0",
+        'Accept': "application/json",
+        'Accept-Encoding': "gzip",
+        'client': "1",
+        'appversion': "1.8.9.1",
+        'phonemodel': "Pixel 6",
+        'phonesystem': "13",
+        'appid': "9205",
+        'appname': "DollarFix",
+        'headsn': "",
+        'token': "",
+        'uuid': uuid_val,
+        'firebasetoken': firebase_token,
+        'zone': "GMT+0:00",
+        'lang': "en",
+        'content-type': "application/json; charset=utf-8"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                msg = data.get("msg", "")
+
+                if msg in ["Incorrect password", "not set password"]:
+                    return Result.taken(url=show_url)
+                elif msg == "The user does not exist.":
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_dollarfix(email: str) -> Result:
+    """
+    DollarFix email validator.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/social/meeff.py
+++ b/user_scanner/email_scan/social/meeff.py
@@ -1,0 +1,70 @@
+import httpx
+import random
+import string
+from user_scanner.core.result import Result
+
+
+def _generate_android_id() -> str:
+    """Generate a random 16-character hex string representing an Android ID."""
+    return "".join(random.choices(string.hexdigits.lower(), k=16))
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.meeff.com/user/login/v4"
+    show_url = "https://play.google.com/store/apps/details?id=com.noyesrun.meeff.kr"
+
+    payload = {
+        "provider": "email",
+        "providerId": email,
+        "providerToken": "",  # dummy password
+        "os": "Android v11",
+        "platform": "android",
+        "device": "BRAND: VIVO, MODEL: VIVOY16, DEVICE: VIVOY16, PRODUCT: VIVOY16, DISPLAY: VIVOY!6_13_K.1098",
+        "pushToken": "",
+        "deviceUniqueId": _generate_android_id(),
+        "deviceLanguage": "en",
+        "deviceRegion": "US",
+        "simRegion": "",
+        "deviceGmtOffset": "+0530",
+        "deviceRooted": 0,
+        "deviceEmulator": 0,
+        "appVersion": "7.1.2",
+        "locale": "en"
+    }
+
+    headers = {
+        'User-Agent': "okhttp/5.3.2",
+        'Accept-Encoding': "gzip",
+        'content-type': "application/json; charset=utf-8",
+        'Cookie': "locale=en"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 401:
+                data = response.json()
+                error_msg = data.get("errorMessage", "")
+
+                if "hasn't been signed up yet" in error_msg:
+                    return Result.available(url=show_url)
+                elif "passwords do not match" in error_msg:
+                    return Result.taken(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_meeff(email: str) -> Result:
+    """
+    Meeff email validator. Checks login endpoint. 
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/social/slowly.py
+++ b/user_scanner/email_scan/social/slowly.py
@@ -1,0 +1,99 @@
+import httpx
+import json
+import secrets
+from user_scanner.core.result import Result
+
+
+def _generate_android_id() -> str:
+    return secrets.token_hex(8)
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.getslowly.com/auth/email/passcode"
+    show_url = "https://getslowly.com"
+
+    android_id = _generate_android_id()
+    device_info = {
+        "platform": "android",
+        "bundleId": "com.slowlyapp",
+        "device": "Pixel6",
+        "deviceType": "Handset",
+        "brand": "Google",
+        "system": "13",
+        "res": "1080x2400",
+        "ui_language": "en",
+        "deviceLocales": [{"isRTL": False, "languageTag": "en-US", "countryCode": "US", "languageCode": "en"}],
+        "currency": ["USD"],
+        "timezone": "America/New_York",
+        "jb": False,
+        "hook": False,
+        "adb": False,
+        "canMock": False,
+        "externalStorage": False,
+        "uuid": android_id,
+        "carrier": "",
+        "serial": "unknown",
+        "locationEnabled": False,
+        "isEmulator": False,
+        "fontScale": 1,
+        "pushPermission": "granted",
+        "networkType": "wifi",
+        "networkDetails": {
+            "isConnectionExpensive": False,
+            "txLinkSpeed": 866,
+            "rxLinkSpeed": -1,
+            "linkSpeed": 866,
+            "subnet": "255.255.255.0",
+            "ipAddress": "192.168.1.15",
+            "frequency": 5805,
+            "strength": 99,
+            "bssid": "00:11:22:33:44:55"
+        },
+        "rc_currency": "USD",
+        "rc_offerings": "plus_699_intro",
+        "version": "9.5.2"
+    }
+
+    payload = {
+        "email": email,
+        "device": json.dumps(device_info),
+        "checkpass": True
+    }
+
+    headers = {
+        'User-Agent': "okhttp/4.11.0",
+        'Accept': "application/json",
+        'Accept-Encoding': "gzip",
+        'Content-Type': "application/json"
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                if data.get("error") == "email_not_found":
+                    return Result.available(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+            
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("success") in ["email_sent", "email_already_sent"]:
+                    return Result.taken(url=show_url)
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(f"Unexpected response status: {response.status_code}, report it via GitHub issues", url=show_url)
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_slowly(email: str) -> Result:
+    """
+    Slowly email validator. Note: This will send an email passcode to the target if the email exists.
+    """
+    return await _check(email)


### PR DESCRIPTION
- Added 12 email_scan modules
  - 7 of them are loud modules, see: `helpers.py` 
  
- All of the modules added in this PR are mobile APIs (**not web**)
- Fixed the `pateron.py` email_scan module buy updating its headers, now server trusts the request.