### PR TITLE
fix: increase internal timeouts to 15s in email_scan modules

### DIFF
--- a/user_scanner/email_scan/adult/babestation.py
+++ b/user_scanner/email_scan/adult/babestation.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code in [200, 404]:

--- a/user_scanner/email_scan/adult/fapfolder.py
+++ b/user_scanner/email_scan/adult/fapfolder.py
@@ -32,7 +32,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/adult/flirtbate.py
+++ b/user_scanner/email_scan/adult/flirtbate.py
@@ -20,7 +20,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 429:

--- a/user_scanner/email_scan/adult/lovescape.py
+++ b/user_scanner/email_scan/adult/lovescape.py
@@ -65,7 +65,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/adult/made_porn.py
+++ b/user_scanner/email_scan/adult/made_porn.py
@@ -18,7 +18,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
             data = response.json()
 

--- a/user_scanner/email_scan/adult/pornhub.py
+++ b/user_scanner/email_scan/adult/pornhub.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
         "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
     }
 
-    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=5.0) as client:
+    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=15.0) as client:
         try:
             landing_resp = await client.get(base_url, headers=headers)
             token_match = re.search(

--- a/user_scanner/email_scan/adult/sexvid.py
+++ b/user_scanner/email_scan/adult/sexvid.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
         'Content-Type': "application/x-www-form-urlencoded"
     }
 
-    async with httpx.AsyncClient(http2=False, timeout=5.0) as client:
+    async with httpx.AsyncClient(http2=False, timeout=15.0) as client:
         try:
             response = await client.post(url, data=payload, headers=headers)
             res_text = response.text

--- a/user_scanner/email_scan/adult/superporn.py
+++ b/user_scanner/email_scan/adult/superporn.py
@@ -19,7 +19,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=4.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/adult/thegay.py
+++ b/user_scanner/email_scan/adult/thegay.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/adult/xnxx.py
+++ b/user_scanner/email_scan/adult/xnxx.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
         'Accept-Language': "en-US,en;q=0.9"
     }
 
-    async with httpx.AsyncClient(http2=True, timeout=5.0) as client:
+    async with httpx.AsyncClient(http2=True, timeout=15.0) as client:
         try:
             response = await client.get(url, params=params, headers=headers)
 

--- a/user_scanner/email_scan/adult/xvideos.py
+++ b/user_scanner/email_scan/adult/xvideos.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
         'Accept-Language': "en-US,en;q=0.9"
     }
 
-    async with httpx.AsyncClient(http2=True, timeout=5.0) as client:
+    async with httpx.AsyncClient(http2=True, timeout=15.0) as client:
         try:
             response = await client.get(url, params=params, headers=headers)
 

--- a/user_scanner/email_scan/community/nextdoor.py
+++ b/user_scanner/email_scan/community/nextdoor.py
@@ -27,7 +27,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=6.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/community/stackoverflow.py
+++ b/user_scanner/email_scan/community/stackoverflow.py
@@ -3,7 +3,7 @@ from user_scanner.core.result import Result
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(http2=False, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=False, follow_redirects=True) as client:
         try:
             url = "https://stackoverflow.com/users/login"
             show_url = "https://stackoverflow.com"

--- a/user_scanner/email_scan/creator/adobe.py
+++ b/user_scanner/email_scan/creator/adobe.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             response.raise_for_status()

--- a/user_scanner/email_scan/creator/buymeacoffee.py
+++ b/user_scanner/email_scan/creator/buymeacoffee.py
@@ -28,7 +28,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/creator/flickr.py
+++ b/user_scanner/email_scan/creator/flickr.py
@@ -31,7 +31,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             body = response.text
 

--- a/user_scanner/email_scan/creator/gumroad.py
+++ b/user_scanner/email_scan/creator/gumroad.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 async def _check(email: str) -> Result:
     show_url = "https://gumroad.com"
-    async with httpx.AsyncClient(http2=False, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=False, follow_redirects=True) as client:
         try:
             url1 = "https://gumroad.com/users/forgot_password/new"
             headers1 = {

--- a/user_scanner/email_scan/creator/kick.py
+++ b/user_scanner/email_scan/creator/kick.py
@@ -27,7 +27,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             # Check for generic perimeter blocks

--- a/user_scanner/email_scan/creator/patreon.py
+++ b/user_scanner/email_scan/creator/patreon.py
@@ -3,7 +3,7 @@ from user_scanner.core.result import Result
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(http2=False) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=False) as client:
         try:
             url = "https://www.patreon.com/api/auth"
             show_url = "https://patreon.com"
@@ -39,7 +39,7 @@ async def _check(email: str) -> Result:
                 params=params,
                 content=payload,
                 headers=headers,
-                timeout=6.0
+                timeout=15.0
             )
 
             if response.status_code != 200:

--- a/user_scanner/email_scan/crm/axonaut.py
+++ b/user_scanner/email_scan/crm/axonaut.py
@@ -13,7 +13,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
             response = await client.get(
                 f'https://axonaut.com/onboarding/?email={email}',
                 headers=headers

--- a/user_scanner/email_scan/crm/hubspot.py
+++ b/user_scanner/email_scan/crm/hubspot.py
@@ -14,7 +14,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             payload = {
                 "email": email,
                 "password": "",

--- a/user_scanner/email_scan/crm/insightly.py
+++ b/user_scanner/email_scan/crm/insightly.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             payload = {'emailaddress': email}
 
             response = await client.post(

--- a/user_scanner/email_scan/crm/zoho.py
+++ b/user_scanner/email_scan/crm/zoho.py
@@ -14,7 +14,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             await client.get("https://accounts.zoho.com/signin", headers=headers)
             csrf_cookie = client.cookies.get("iamcsr")
 

--- a/user_scanner/email_scan/dev/codecademy.py
+++ b/user_scanner/email_scan/dev/codecademy.py
@@ -15,7 +15,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=4.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             init_res = await client.get("https://www.codecademy.com/register", headers=headers)
 
             csrf_match = re.search(

--- a/user_scanner/email_scan/dev/codewars.py
+++ b/user_scanner/email_scan/dev/codewars.py
@@ -32,7 +32,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             response = await client.post(url, params=params, data=payload, headers=headers)
             html = response.text
 

--- a/user_scanner/email_scan/dev/devrant.py
+++ b/user_scanner/email_scan/dev/devrant.py
@@ -26,7 +26,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post('https://devrant.com/api/users', headers=headers, data=payload)
 
             if response.status_code != 200:

--- a/user_scanner/email_scan/dev/envato.py
+++ b/user_scanner/email_scan/dev/envato.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 204:

--- a/user_scanner/email_scan/dev/github.py
+++ b/user_scanner/email_scan/dev/github.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 async def _check(email: str) -> Result:
     show_url = "https://github.com"
-    async with httpx.AsyncClient(http2=True, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=True) as client:
         try:
             url1 = "https://github.com/signup"
             headers1 = {

--- a/user_scanner/email_scan/dev/howtogeek.py
+++ b/user_scanner/email_scan/dev/howtogeek.py
@@ -20,7 +20,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/dev/huggingface.py
+++ b/user_scanner/email_scan/dev/huggingface.py
@@ -13,9 +13,9 @@ async def _check(email: str) -> Result:
         'referer': "https://huggingface.co/join",
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=5)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
             res_text = response.text
             st_code = response.status_code
 

--- a/user_scanner/email_scan/dev/wix.py
+++ b/user_scanner/email_scan/dev/wix.py
@@ -25,7 +25,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 200:

--- a/user_scanner/email_scan/dev/wordpress.py
+++ b/user_scanner/email_scan/dev/wordpress.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code != 200:

--- a/user_scanner/email_scan/dev/xda.py
+++ b/user_scanner/email_scan/dev/xda.py
@@ -18,7 +18,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
             data = response.json()
             exists = data.get("userExists")

--- a/user_scanner/email_scan/entertainment/anilist.py
+++ b/user_scanner/email_scan/entertainment/anilist.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 429:

--- a/user_scanner/email_scan/entertainment/appletv.py
+++ b/user_scanner/email_scan/entertainment/appletv.py
@@ -23,7 +23,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url,
                 params=params,

--- a/user_scanner/email_scan/entertainment/girlslife.py
+++ b/user_scanner/email_scan/entertainment/girlslife.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             # GET the page to extract the required _wpnonce
             init_res = await client.get(url, headers=headers)
             if init_res.status_code != 200:

--- a/user_scanner/email_scan/entertainment/hoichoi.py
+++ b/user_scanner/email_scan/entertainment/hoichoi.py
@@ -36,9 +36,9 @@ async def _check(email: str) -> Result:
         'x-bypass-proxy': "true"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/entertainment/justwatch.py
+++ b/user_scanner/email_scan/entertainment/justwatch.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url,
                 params=params,

--- a/user_scanner/email_scan/entertainment/letterboxd.py
+++ b/user_scanner/email_scan/entertainment/letterboxd.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             await client.get(home_url, headers={'User-Agent': headers['User-Agent']})
             csrf_token = client.cookies.get("com.xk72.webparts.csrf")
 

--- a/user_scanner/email_scan/entertainment/myanimelist.py
+++ b/user_scanner/email_scan/entertainment/myanimelist.py
@@ -25,7 +25,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/entertainment/nebula_tv.py
+++ b/user_scanner/email_scan/entertainment/nebula_tv.py
@@ -27,7 +27,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/entertainment/netflix.py
+++ b/user_scanner/email_scan/entertainment/netflix.py
@@ -13,7 +13,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             await client.get("https://www.netflix.com/", headers=headers)
 
             flwssn = client.cookies.get("flwssn")

--- a/user_scanner/email_scan/entertainment/stremio.py
+++ b/user_scanner/email_scan/entertainment/stremio.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 200:

--- a/user_scanner/email_scan/fitness/finch.py
+++ b/user_scanner/email_scan/fitness/finch.py
@@ -28,7 +28,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, json=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/fitness/fitnessblender.py
+++ b/user_scanner/email_scan/fitness/fitnessblender.py
@@ -20,7 +20,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=20.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             # Step 1: Visit homepage to get cookies (XSRF-TOKEN and FB_SESSION)
             # Laravel sets these in the Set-Cookie header
             r_init = await client.get(base_url, headers=headers)

--- a/user_scanner/email_scan/fitness/myfitnesspal.py
+++ b/user_scanner/email_scan/fitness/myfitnesspal.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/gaming/addictinggames.py
+++ b/user_scanner/email_scan/gaming/addictinggames.py
@@ -27,7 +27,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=6.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, content=json.dumps(payload), headers=headers)
             body = response.text
 

--- a/user_scanner/email_scan/gaming/chess_com.py
+++ b/user_scanner/email_scan/gaming/chess_com.py
@@ -3,7 +3,7 @@ from user_scanner.core.result import Result
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
             url = "https://www.chess.com/rpc/chesscom.authentication.v1.EmailValidationService/Validate"
             show_url = "https://chess.com"

--- a/user_scanner/email_scan/gaming/crazygames.py
+++ b/user_scanner/email_scan/gaming/crazygames.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, content=json.dumps(payload), headers=headers)
             data = response.json()
 

--- a/user_scanner/email_scan/hosting/bunny.py
+++ b/user_scanner/email_scan/hosting/bunny.py
@@ -37,7 +37,7 @@ async def _check(email: str) -> Result:
 
     try:
         # Enforcing http2=True to prevent protocol/handshake drops
-        async with httpx.AsyncClient(timeout=6.0, http2=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/hosting/neocities.py
+++ b/user_scanner/email_scan/hosting/neocities.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/hosting/render.py
+++ b/user_scanner/email_scan/hosting/render.py
@@ -34,7 +34,7 @@ async def _check(email: str) -> Result:
         "accept-language": "en-US,en;q=0.9"
     }
 
-    async with httpx.AsyncClient(http2=True, timeout=4.0) as client:
+    async with httpx.AsyncClient(http2=True, timeout=15.0) as client:
         try:
             response = await client.post(url, json=payload, headers=headers)
 

--- a/user_scanner/email_scan/jobs/freelancer.py
+++ b/user_scanner/email_scan/jobs/freelancer.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 409 and "EMAIL_ALREADY_IN_USE" in response.text:

--- a/user_scanner/email_scan/learning/alison.py
+++ b/user_scanner/email_scan/learning/alison.py
@@ -15,7 +15,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             init_res = await client.get(url, headers=headers)
 
             token_match = re.search(

--- a/user_scanner/email_scan/learning/allen.py
+++ b/user_scanner/email_scan/learning/allen.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/learning/babbel.py
+++ b/user_scanner/email_scan/learning/babbel.py
@@ -46,9 +46,9 @@ async def _check(email: str) -> Result:
         'content-type': "application/json; charset=UTF-8"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/bnrlanguages.py
+++ b/user_scanner/email_scan/learning/bnrlanguages.py
@@ -30,9 +30,9 @@ async def _check(email: str) -> Result:
         'X-Firebase-Locale': "en_US"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/bunpo.py
+++ b/user_scanner/email_scan/learning/bunpo.py
@@ -28,9 +28,9 @@ async def _check(email: str) -> Result:
         'X-Client-Version': "Android/Fallback/X23000000/FirebaseCore-Android"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/cakeapp.py
+++ b/user_scanner/email_scan/learning/cakeapp.py
@@ -21,9 +21,9 @@ async def _check(email: str) -> Result:
         'Accept-Encoding': "gzip"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+            response = await client.get(url, params=params, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/coursera.py
+++ b/user_scanner/email_scan/learning/coursera.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=6.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, json={}, headers=headers)
             data = response.json()
 

--- a/user_scanner/email_scan/learning/duolingo.py
+++ b/user_scanner/email_scan/learning/duolingo.py
@@ -13,7 +13,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             response = await client.get(
                 f"https://www.duolingo.com/2017-06-30/users?email={email}",
                 headers=headers

--- a/user_scanner/email_scan/learning/hanzii.py
+++ b/user_scanner/email_scan/learning/hanzii.py
@@ -18,9 +18,9 @@ async def _check(email: str) -> Result:
         'priority': "u=1, i"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/hellochinese.py
+++ b/user_scanner/email_scan/learning/hellochinese.py
@@ -43,10 +43,10 @@ async def _check(email: str) -> Result:
         'Env': json.dumps(env_data)
     }
 
-    async with httpx.AsyncClient(http2=False) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=False) as client:
         try:
             # Form-encoded POST request
-            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, data=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/heyjapan.py
+++ b/user_scanner/email_scan/learning/heyjapan.py
@@ -16,9 +16,9 @@ async def _check(email: str) -> Result:
         'Content-Type': "application/json"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/programminghub.py
+++ b/user_scanner/email_scan/learning/programminghub.py
@@ -19,9 +19,9 @@ async def _check(email: str) -> Result:
         'content-type': "application/json; charset=UTF-8"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/talkpal.py
+++ b/user_scanner/email_scan/learning/talkpal.py
@@ -20,9 +20,9 @@ async def _check(email: str) -> Result:
         'priority': "u=1, i"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/learning/vedantu.py
+++ b/user_scanner/email_scan/learning/vedantu.py
@@ -30,7 +30,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url, 
                 content=json.dumps(payload), 

--- a/user_scanner/email_scan/music/deezer.py
+++ b/user_scanner/email_scan/music/deezer.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             handshake_params = {
                 'method': "deezer.getUserData",
                 'input': "3",

--- a/user_scanner/email_scan/music/gaana.py
+++ b/user_scanner/email_scan/music/gaana.py
@@ -25,7 +25,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             
             if response.status_code == 403:

--- a/user_scanner/email_scan/music/mixcloud.py
+++ b/user_scanner/email_scan/music/mixcloud.py
@@ -18,7 +18,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
 
             payload = {
                 'email': email,

--- a/user_scanner/email_scan/music/spotify.py
+++ b/user_scanner/email_scan/music/spotify.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(http2=False, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=False, follow_redirects=True) as client:
         try:
             get_url = "https://www.spotify.com/in-en/signup"
             show_url = "https://spotify.com"

--- a/user_scanner/email_scan/news/aljazeera.py
+++ b/user_scanner/email_scan/news/aljazeera.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, content=json.dumps(payload), headers=headers)
             data = response.json()
 

--- a/user_scanner/email_scan/news/bbc.py
+++ b/user_scanner/email_scan/news/bbc.py
@@ -15,7 +15,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             response = await client.get(login_url, headers=headers)
 
             nonce_match = re.search(

--- a/user_scanner/email_scan/news/cnn.py
+++ b/user_scanner/email_scan/news/cnn.py
@@ -26,7 +26,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             body = response.text
 

--- a/user_scanner/email_scan/news/flipboard.py
+++ b/user_scanner/email_scan/news/flipboard.py
@@ -24,9 +24,9 @@ async def _check(email: str) -> Result:
         'Accept-Encoding': "gzip"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+            response = await client.get(url, params=params, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/news/foxnews.py
+++ b/user_scanner/email_scan/news/foxnews.py
@@ -21,7 +21,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=7.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 429:

--- a/user_scanner/email_scan/news/globaltimes.py
+++ b/user_scanner/email_scan/news/globaltimes.py
@@ -24,7 +24,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             data = response.json()
             message = data.get("msg", "")

--- a/user_scanner/email_scan/news/indiatimes.py
+++ b/user_scanner/email_scan/news/indiatimes.py
@@ -23,7 +23,7 @@ async def _check(email: str) -> Result:
 
     try:
 
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             response.raise_for_status()

--- a/user_scanner/email_scan/news/nytimes.py
+++ b/user_scanner/email_scan/news/nytimes.py
@@ -23,7 +23,7 @@ async def _check(email: str) -> Result:
 
     try:
         # NYT likes HTTP/2, helps avoid getting flagged as a bot
-        async with httpx.AsyncClient(timeout=12.0, follow_redirects=True, http2=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, http2=True) as client:
 
             init_res = await client.get(login_url, headers=headers)
 

--- a/user_scanner/email_scan/other/ama.py
+++ b/user_scanner/email_scan/other/ama.py
@@ -33,7 +33,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, json=payload, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/other/anydo.py
+++ b/user_scanner/email_scan/other/anydo.py
@@ -19,7 +19,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url,
                 content=json.dumps(payload),

--- a/user_scanner/email_scan/other/deviantart.py
+++ b/user_scanner/email_scan/other/deviantart.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             r_home = await client.get(show_url, headers=headers)
             if r_home.status_code == 403:
                 return Result.error("Caught by WAF or IP Block (403) during Handshake 1")

--- a/user_scanner/email_scan/other/dollarfix.py
+++ b/user_scanner/email_scan/other/dollarfix.py
@@ -40,9 +40,9 @@ async def _check(email: str) -> Result:
         'content-type': "application/json; charset=utf-8"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/other/dragongroot.py
+++ b/user_scanner/email_scan/other/dragongroot.py
@@ -17,9 +17,9 @@ async def _check(email: str) -> Result:
         'Content-Type': "application/json"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/other/eventbrite.py
+++ b/user_scanner/email_scan/other/eventbrite.py
@@ -15,7 +15,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             await client.get("https://www.eventbrite.com/signin/", headers=headers)
 
             csrf_token = client.cookies.get("csrftoken")

--- a/user_scanner/email_scan/other/firefox.py
+++ b/user_scanner/email_scan/other/firefox.py
@@ -10,7 +10,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/other/moz.py
+++ b/user_scanner/email_scan/other/moz.py
@@ -36,7 +36,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
 
             if response.status_code == 429:

--- a/user_scanner/email_scan/other/numsify.py
+++ b/user_scanner/email_scan/other/numsify.py
@@ -19,9 +19,9 @@ async def _check(email: str) -> Result:
         'authorization': "Bearer null",
         'x-app-version': "1.4.53+73"
     }
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)
             data = response.json()

--- a/user_scanner/email_scan/other/office365.py
+++ b/user_scanner/email_scan/other/office365.py
@@ -17,7 +17,7 @@ async def _check(email: str) -> Result:
         return "".join(random.choice(string.digits) for _ in range(length))
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
 
             r = await client.get(
                 f"{base_url}/{email}?Protocol=Autodiscoverv1",

--- a/user_scanner/email_scan/other/screener.py
+++ b/user_scanner/email_scan/other/screener.py
@@ -18,7 +18,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=6.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             init_res = await client.get(url, headers=headers)
 
             if init_res.status_code == 403:

--- a/user_scanner/email_scan/shopping/amazon.py
+++ b/user_scanner/email_scan/shopping/amazon.py
@@ -71,7 +71,7 @@ async def _check(email: str) -> Result:
 
     try:
         async with httpx.AsyncClient(
-            timeout=10.0, follow_redirects=True, headers=headers
+            timeout=15.0, follow_redirects=True, headers=headers
         ) as client:
             # 1. Load the sign-in page and extract form fields + action URL
             resp = await client.get(signin_url)

--- a/user_scanner/email_scan/shopping/etsy.py
+++ b/user_scanner/email_scan/shopping/etsy.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 403:

--- a/user_scanner/email_scan/shopping/flipkart.py
+++ b/user_scanner/email_scan/shopping/flipkart.py
@@ -29,7 +29,7 @@ async def _check(email: str) -> Result:
         }
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
             response = await client.post(url, json=payload, headers=headers)
 

--- a/user_scanner/email_scan/shopping/naturabuy.py
+++ b/user_scanner/email_scan/shopping/naturabuy.py
@@ -20,7 +20,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 'https://www.naturabuy.fr/includes/ajax/register.php',
                 headers=headers,

--- a/user_scanner/email_scan/shopping/vivino.py
+++ b/user_scanner/email_scan/shopping/vivino.py
@@ -14,7 +14,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             await client.get("https://www.vivino.com/", headers=headers)
 
             payload = {

--- a/user_scanner/email_scan/shopping/walmart.py
+++ b/user_scanner/email_scan/shopping/walmart.py
@@ -76,7 +76,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
             # Step 1: Request the login page to initialize cookie sessions and bypass 412 errors
             # MUST use the identical User-Agent to avoid session mismatches causing 412 errors.
             await client.get(headers['wm_page_url'], headers={

--- a/user_scanner/email_scan/social/facebook.py
+++ b/user_scanner/email_scan/social/facebook.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 async def _check(email: str) -> Result:
     show_url = "https://facebook.com"
-    async with httpx.AsyncClient(http2=True, follow_redirects=False) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=False) as client:
         try:
             url1 = "https://m.facebook.com/login/"
             headers1 = {

--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -10,14 +10,14 @@ async def _check(email: str) -> Result:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     }
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, headers=headers)
             if response.status_code == 200:
                 extra = {"avatar_url": f"https://www.gravatar.com/avatar/{email_hash}"}
                 # Optionally attempt to load public profile data for enriched metadata
                 profile_url = f"https://en.gravatar.com/{email_hash}.json"
                 try:
-                    profile_resp = await client.get(profile_url, headers=headers, timeout=3.0)
+                    profile_resp = await client.get(profile_url, headers=headers, timeout=15.0)
                     if profile_resp.status_code == 200:
                         data = profile_resp.json()
                         entry = data.get("entry", [{}])[0]
@@ -40,7 +40,7 @@ async def _check(email: str) -> Result:
                     extra = {"avatar_url": f"https://www.gravatar.com/avatar/{email_md5}"}
                     profile_url_md5 = f"https://en.gravatar.com/{email_md5}.json"
                     try:
-                        profile_resp = await client.get(profile_url_md5, headers=headers, timeout=3.0)
+                        profile_resp = await client.get(profile_url_md5, headers=headers, timeout=15.0)
                         if profile_resp.status_code == 200:
                             data = profile_resp.json()
                             entry = data.get("entry", [{}])[0]

--- a/user_scanner/email_scan/social/instagram.py
+++ b/user_scanner/email_scan/social/instagram.py
@@ -9,7 +9,7 @@ async def _check(email: str) -> Result:
 
     try:
         async with httpx.AsyncClient(
-            headers={"user-agent": user_agent}, http2=True, timeout=10.0
+            headers={"user-agent": user_agent}, http2=True, timeout=15.0
         ) as client:
             res = await client.get("https://www.instagram.com/", follow_redirects=True)
 

--- a/user_scanner/email_scan/social/mastodon.py
+++ b/user_scanner/email_scan/social/mastodon.py
@@ -15,7 +15,7 @@ async def _check(email):
         "origin": "https://mastodon.social"
     }
 
-    async with httpx.AsyncClient(http2=True, headers=headers, follow_redirects=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True, headers=headers, follow_redirects=True) as client:
         try:
             initial_resp = await client.get(signup_url)
             if initial_resp.status_code not in [200, 302]:

--- a/user_scanner/email_scan/social/meeff.py
+++ b/user_scanner/email_scan/social/meeff.py
@@ -39,9 +39,9 @@ async def _check(email: str) -> Result:
         'Cookie': "locale=en"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/social/mewe.py
+++ b/user_scanner/email_scan/social/mewe.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url, 
                 content=json.dumps(payload), 

--- a/user_scanner/email_scan/social/pinterest.py
+++ b/user_scanner/email_scan/social/pinterest.py
@@ -41,7 +41,7 @@ async def _check(email: str) -> Result:
 
     try:
 
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, params=params, headers=headers)
 
             if response.status_code == 200:

--- a/user_scanner/email_scan/social/plurk.py
+++ b/user_scanner/email_scan/social/plurk.py
@@ -16,7 +16,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url,
                 headers=headers,

--- a/user_scanner/email_scan/social/slowly.py
+++ b/user_scanner/email_scan/social/slowly.py
@@ -67,9 +67,9 @@ async def _check(email: str) -> Result:
         'Content-Type': "application/json"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
-            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+            response = await client.post(url, json=payload, headers=headers, timeout=15.0)
 
             if response.status_code == 429:
                 return Result.error("Rate limited", url=show_url)

--- a/user_scanner/email_scan/social/x.py
+++ b/user_scanner/email_scan/social/x.py
@@ -18,7 +18,7 @@ async def _check(email):
         "priority": "u=1, i"
     }
 
-    async with httpx.AsyncClient(http2=True) as client:
+    async with httpx.AsyncClient(timeout=15.0, http2=True) as client:
         try:
             response = await client.get(url, params=params, headers=headers)
 

--- a/user_scanner/email_scan/sports/espn.py
+++ b/user_scanner/email_scan/sports/espn.py
@@ -19,7 +19,7 @@ async def _check(email: str) -> Result:
     payload = {"email": email}
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 url,
                 params=params,

--- a/user_scanner/email_scan/sports/marca.py
+++ b/user_scanner/email_scan/sports/marca.py
@@ -15,7 +15,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.get(url, headers=headers)
 
             if response.status_code in [200, 404, 400]:

--- a/user_scanner/email_scan/sports/nba.py
+++ b/user_scanner/email_scan/sports/nba.py
@@ -22,7 +22,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             status = response.status_code
 

--- a/user_scanner/email_scan/travel/emirates.py
+++ b/user_scanner/email_scan/travel/emirates.py
@@ -31,7 +31,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, params=params, content=json.dumps(payload), headers=headers)
             status = response.status_code
 

--- a/user_scanner/email_scan/travel/komoot.py
+++ b/user_scanner/email_scan/travel/komoot.py
@@ -31,7 +31,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, content=json.dumps(payload), headers=headers)
             status = response.status_code
 

--- a/user_scanner/email_scan/travel/polarsteps.py
+++ b/user_scanner/email_scan/travel/polarsteps.py
@@ -23,7 +23,7 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(url, data=payload, headers=headers)
 
             if response.status_code == 403:


### PR DESCRIPTION
The scanner was experiencing frequent 'Connection timed out' and 'unexpected exception' errors during email checks.

* The original modules defined internal timeouts (e.g. 4.0s or 5.0s) which were too strict when the orchestrator fired concurrent requests, causing false positive connection drops.
* We explicitly defined and increased the internal httpx.AsyncClient timeout to 15.0s across all email_scan modules.
* This ensures each module has enough time to complete the TCP handshake and DNS resolution during heavy concurrency, resolving the false positive connection errors without needing to throttle the orchestrator's concurrency limit.

**Note:** This may make the `email_scan` slightly slower, but the trade-off is acceptable as modern website validation requires 2 to 3 nested requests to capture all important cookies and tokens. However, a new flag will be introduced in the next PR to control this timeout.