### PR TITLE
feat: add global timeout and concurrency flags

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -20,5 +20,7 @@
 | `--validate-proxies`        | Validate proxies before scanning (tests against google.com) |
 | `-s, --stop STOP`           | Limit the number of permutations generated                  |
 | `-d, --delay DELAY`         | Delay (in seconds) between requests                         |
+| `-t, --timeout TIMEOUT`     | Override default request timeout in seconds                 |
+| `-C, --concurrency CONC`    | Override default concurrency limit                          |
 | `-f, --format {csv,json}`   | Select output format                                        |
 | `-o, --output OUTPUT`       | Save results to a file                                      |

--- a/tests/test_email_orchestrator.py
+++ b/tests/test_email_orchestrator.py
@@ -1,0 +1,10 @@
+def test_set_concurrency():
+    from user_scanner.core.email_orchestrator import set_concurrency
+    import user_scanner.core.email_orchestrator as email_orchestrator
+    
+    original_max = email_orchestrator.MAX_CONCURRENT_REQUESTS
+    set_concurrency(5)
+    assert email_orchestrator.MAX_CONCURRENT_REQUESTS == 5
+    
+    # restore
+    set_concurrency(original_max)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -426,3 +426,10 @@ def test_hudson_config_value():
     status = data.get("auto_hudson_prompt")
 
     assert status is True, f"FAIL: Actual config at {actual_path} has auto_hudson_prompt set to {status} (Expected: True)"
+
+def test_global_timeout():
+    from user_scanner.core.helpers import set_global_timeout, get_global_timeout
+    set_global_timeout(10.5)
+    assert get_global_timeout() == 10.5
+    set_global_timeout(None)
+    assert get_global_timeout() is None

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -49,3 +49,16 @@ def test_run_checks_category_threaded(monkeypatch, tmp_path):
     assert isinstance(results, list)
     assert len(results) == 1
     assert results[0].to_number() == 0  # TAKEN
+
+
+def test_set_concurrency():
+    from user_scanner.core.orchestrator import set_concurrency
+    import user_scanner.core.orchestrator as orchestrator
+    
+    original_max = orchestrator.MAX_CONCURRENT_REQUESTS
+    set_concurrency(10)
+    assert orchestrator.MAX_CONCURRENT_REQUESTS == 10
+    assert orchestrator._shared_executor._max_workers == 10
+    
+    # restore
+    set_concurrency(original_max)

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -101,6 +101,20 @@ def main():
     )
 
     parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        help="Override default request timeout in seconds",
+    )
+
+    parser.add_argument(
+        "-C",
+        "--concurrency",
+        type=int,
+        help="Override default concurrency limit (default: 60 for username, 25 for email scan)",
+    )
+
+    parser.add_argument(
         "-d", "--delay", type=float, default=0, help="Delay between requests"
     )
 
@@ -153,6 +167,16 @@ def main():
     parser.add_argument("--version", action="store_true", help="Print version")
 
     args = parser.parse_args()
+
+    if args.timeout is not None:
+        from user_scanner.core.helpers import set_global_timeout
+        set_global_timeout(args.timeout)
+
+    if args.concurrency is not None:
+        from user_scanner.core.email_orchestrator import set_concurrency as set_email_concurrency
+        from user_scanner.core.orchestrator import set_concurrency as set_user_concurrency
+        set_email_concurrency(args.concurrency)
+        set_user_concurrency(args.concurrency)
 
     if args.update:
         update_self()
@@ -311,6 +335,7 @@ def main():
         only_found=args.only_found,
         no_nsfw=args.no_nsfw,
         verbose=args.verbose,
+        timeout=args.timeout,
     )
 
     for i, target in enumerate(targets):

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -15,6 +15,7 @@ from user_scanner.core.helpers import (
     is_loud,
     load_categories,
     load_modules,
+    get_global_timeout,
 )
 from user_scanner.core.result import Result, Status
 
@@ -27,6 +28,11 @@ def _patched_async_client_init(self, *args, **kwargs):
         proxy = get_proxy()
         if proxy:
             kwargs["proxy"] = proxy
+            
+    global_timeout = get_global_timeout()
+    if global_timeout is not None:
+        kwargs["timeout"] = global_timeout
+        
     _original_async_client_init(self, *args, **kwargs)
 
 def _patched_client_init(self, *args, **kwargs):
@@ -34,6 +40,11 @@ def _patched_client_init(self, *args, **kwargs):
         proxy = get_proxy()
         if proxy:
             kwargs["proxy"] = proxy
+            
+    global_timeout = get_global_timeout()
+    if global_timeout is not None:
+        kwargs["timeout"] = global_timeout
+        
     _original_client_init(self, *args, **kwargs)
 
 httpx.AsyncClient.__init__ = _patched_async_client_init  # type: ignore[method-assign]
@@ -42,6 +53,10 @@ httpx.Client.__init__ = _patched_client_init  # type: ignore[method-assign]
 
 # Concurrency control
 MAX_CONCURRENT_REQUESTS = 25
+
+def set_concurrency(val: int):
+    global MAX_CONCURRENT_REQUESTS
+    MAX_CONCURRENT_REQUESTS = val
 
 async def _async_worker(
     module: ModuleType,

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -53,6 +53,16 @@ class ScanConfig:
     no_nsfw: bool = False
     only_found: bool = False
     verbose: bool = False
+    timeout: Optional[float] = None
+
+_global_timeout: Optional[float] = None
+
+def set_global_timeout(timeout: float) -> None:
+    global _global_timeout
+    _global_timeout = timeout
+
+def get_global_timeout() -> Optional[float]:
+    return _global_timeout
 
 
 def get_site_name(module) -> str:

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -18,12 +18,18 @@ from user_scanner.core.helpers import (
     is_loud,
     load_categories,
     load_modules,
+    get_global_timeout,
 )
 from user_scanner.core.result import Result
 
 
 MAX_CONCURRENT_REQUESTS = 60
 _shared_executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENT_REQUESTS)
+
+def set_concurrency(val: int):
+    global MAX_CONCURRENT_REQUESTS, _shared_executor
+    MAX_CONCURRENT_REQUESTS = val
+    _shared_executor = concurrent.futures.ThreadPoolExecutor(max_workers=val)
 
 async def _async_worker(
     module: ModuleType,
@@ -201,7 +207,10 @@ def make_request(url: str, **kwargs) -> httpx.Response:
     if "show_url" in kwargs:
         kwargs.pop("show_url", None)
 
-    if "timeout" not in kwargs:
+    global_timeout = get_global_timeout()
+    if global_timeout is not None:
+        kwargs["timeout"] = global_timeout
+    elif "timeout" not in kwargs:
         kwargs["timeout"] = 5.0
 
     if "proxy" not in kwargs:


### PR DESCRIPTION
## Description
This PR introduces two new global control flags to fine-tune the scanner's performance and network behavior across both `user_scan` and `email_scan` modules:
- `-t / --timeout`: Overrides default module timeouts.
- `-C / --concurrency`: Overrides the default concurrency limit (`60` for user, `25` for email).

## Key Changes
* **Argument Parsing**: Added `-t` and `-C` to `__main__.py`.
* **Global Configuration**: Integrated the flags into `ScanConfig` and global helper states.
* **Email Orchestrator**: Intercepts the `httpx.AsyncClient` initialization to dynamically inject the global timeout and modifies `MAX_CONCURRENT_REQUESTS` on the fly.
* **User Orchestrator**: Overrides timeouts via the `make_request` wrapper and safely recreates the `ThreadPoolExecutor` at startup based on the chosen concurrency.
* **Tests**: Added tests for the global helper state, orchestrator threadpool manipulation, and email orchestrator logic.
* **Documentation**: Updated `FLAGS.md`.