### PR TITLE
feat: add RedTube email scan module

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-import re
 import sys
 import time
 
@@ -22,6 +21,7 @@ from user_scanner.core.helpers import (
     get_proxy_count,
     get_site_name,
     is_loud,
+    is_valid_email,
     load_categories,
     load_modules,
     set_proxy_manager,
@@ -233,7 +233,7 @@ def main():
             # Validate email formats
             valid_emails = []
             for email in emails:
-                if re.findall(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
+                if is_valid_email(email):
                     valid_emails.append(email)
                 else:
                     print(f"{Y}[!] Skipping invalid email format: {email}{X}")
@@ -280,7 +280,7 @@ def main():
             sys.exit(1)
     else:
         is_email = args.email is not None
-        if is_email and not re.findall(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", args.email):
+        if is_email and not is_valid_email(args.email):
             print(R + "[✘] Error: Invalid email format." + X)
             sys.exit(1)
 

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 import random
+import re
 import threading
 import functools
 import asyncio
@@ -14,6 +15,14 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 import httpx
+
+# Pragmatic RFC 5322 / email-validator-style syntax check: an unquoted
+# dot-atom local part, a dotted host name, and an alphabetic TLD. It does not
+# accept quoted local parts, IP-address literals, or internationalized (IDN)
+# domains — none of which the scanners target.
+_EMAIL_LOCAL = r"[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*"
+_EMAIL_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+EMAIL_RE = re.compile(rf"{_EMAIL_LOCAL}@(?:{_EMAIL_LABEL}\.)+[A-Za-z]{{2,63}}")
 
 LOUD_MODULES: Dict[str, List[str]] = {
     "user": [],
@@ -53,6 +62,15 @@ class ScanConfig:
     no_nsfw: bool = False
     only_found: bool = False
     verbose: bool = False
+
+
+def is_valid_email(email: str) -> bool:
+    if not email or len(email) > 254:
+        return False
+    local, _, domain = email.rpartition("@")
+    if len(local) > 64 or len(domain) > 253:
+        return False
+    return bool(EMAIL_RE.fullmatch(email))
 
 
 def get_site_name(module) -> str:

--- a/user_scanner/email_scan/adult/redtube.py
+++ b/user_scanner/email_scan/adult/redtube.py
@@ -1,0 +1,87 @@
+import httpx
+import re
+from user_scanner.core.helpers import is_valid_email
+from user_scanner.core.result import Result
+
+RATE_LIMITED_MSG = "Rate limited, wait for a few minutes"
+
+
+async def _check(email: str) -> Result:
+    base_url = "https://www.redtube.com"
+    show_url = "https://redtube.com"
+    register_url = f"{base_url}/register"
+    check_api = f"{base_url}/user/create_account_check"
+
+    headers = {
+        "user-agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
+        "x-requested-with": "XMLHttpRequest",
+        "origin": base_url,
+        "referer": register_url,
+        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+    }
+
+    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=15.0) as client:
+        try:
+            landing_resp = await client.get(register_url, headers=headers)
+            # The token is assigned to page_params.token and ends with a literal
+            # dot that is part of the value — capturing anything but the quotes
+            # keeps it intact (dropping the dot invalidates the token).
+            token_match = re.search(
+                r'page_params\.token\s*=\s*"([^"]+)"', landing_resp.text
+            )
+
+            if not token_match:
+                return Result.error("Failed to extract dynamic token from HTML")
+
+            token = token_match.group(1)
+
+            params = {"token": token}
+            payload = {
+                "token": token,
+                "check_what": "email",
+                "email": email,
+            }
+
+            response = await client.post(
+                check_api,
+                params=params,
+                headers=headers,
+                data=payload,
+            )
+
+            if response.status_code == 429:
+                return Result.error(RATE_LIMITED_MSG)
+
+            if response.status_code != 200:
+                return Result.error(f"HTTP Error: {response.status_code}")
+
+            data = response.json()
+
+            # An anti-abuse throttle answers with a bare "NOK" / "NOK <n>" string
+            # instead of the usual JSON object.
+            if not isinstance(data, dict):
+                return Result.error(RATE_LIMITED_MSG)
+
+            status = data.get("email")
+            error_msg = data.get("error_message", "")
+
+            if status == "create_account_passed" and error_msg == "":
+                return Result.available(url=show_url)
+
+            if status == "create_account_failed":
+                if "already registered" in error_msg:
+                    return Result.taken(url=show_url)
+                # For a well-formed address, RedTube reports an existing account
+                # by refusing registration rather than saying it's taken.
+                if "does not meet our registration requirements" in error_msg and is_valid_email(email):
+                    return Result.taken(url=show_url)
+                return Result.available(url=show_url, reason=error_msg)
+
+            return Result.error(f"Unexpected API response: {status}: {error_msg}")
+
+        except Exception as e:
+            return Result.error(e)
+
+
+async def validate_redtube(email: str) -> Result:
+    return await _check(email)


### PR DESCRIPTION
## What

Adds an email-based **RedTube** account check to `email_scan/adult/`, filling one of the missing adult modules.

## How it works

Mirrors the existing `pornhub.py` pattern (RedTube is the same MindGeek/Aylo network):

1. `GET /register` to scrape the per-session `page_params.token` (note: the token ends in a literal `.` that must be preserved, or it's rejected).
2. `POST /user/create_account_check` with `check_what=email` — RedTube returns the same structured JSON as Pornhub.

Response mapping:

| Response | Result |
|----------|--------|
| `create_account_passed` | Not Registered |
| `create_account_failed` + `already registered` | Registered |
| `create_account_failed` + "does not meet our registration requirements" (valid email) | Registered |
| bare `"NOK"` string / HTTP 429 | Rate limited (error) |

## Shared email validation

Extracted a reusable `is_valid_email` helper into `core/helpers.py` (previously an inline regex duplicated twice in `__main__.py`). The new regex is stricter and more reliable, inspired by the `email-validator` package:

- proper dot-atom local part (rejects leading/trailing/double dots)
- valid domain labels (rejects hyphen-edge and empty labels)
- alphabetic TLD (≥2 chars; rejects 1-char and numeric TLDs)
- RFC 5321 length limits and `fullmatch` (rejects trailing-newline edge case)

The two existing CLI call sites now reuse the helper.

## Testing

- Verified live against the RedTube endpoint (passed / registered / rate-limited paths).
- Validator checked against the top 10 mainstream email providers and a range of valid/invalid edge cases.
- `pytest tests/test_helpers.py`: all email-format tests pass (the 2 `*_unreadable` failures are pre-existing Windows `chmod(0)` no-ops, unrelated to this change).