### PR TITLE
feat: add faproulette.co email and username scan modules

### DIFF
--- a/user_scanner/email_scan/adult/faproulette.py
+++ b/user_scanner/email_scan/adult/faproulette.py
@@ -1,0 +1,43 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    show_url = "https://faproulette.co"
+    url = "https://faproulette.co/api/userCheckEmail"
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": show_url,
+        "Referer": show_url + "/",
+    }
+    payload = {"email": email, "timeoutID": 1}
+
+    try:
+        async with httpx.AsyncClient(http2=True, timeout=15.0) as client:
+            response = await client.post(url, data=payload, headers=headers)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited, wait for a few minutes")
+
+            if response.status_code != 200:
+                return Result.error(f"HTTP Error: {response.status_code}")
+
+            data = response.json()
+
+            if data.get("success") == 1:
+                return Result.available(url=show_url)
+
+            error_msg = data.get("error", "")
+            if "already in use" in error_msg:
+                return Result.taken(url=show_url)
+
+            return Result.error(error_msg or "Unexpected response body, report it via GitHub issues")
+
+    except Exception as e:
+        return Result.error(e)
+
+
+async def validate_faproulette(email: str) -> Result:
+    return await _check(email)

--- a/user_scanner/user_scan/adult/faproulette.py
+++ b/user_scanner/user_scan/adult/faproulette.py
@@ -1,4 +1,5 @@
 import re
+import html
 from user_scanner.core.orchestrator import generic_validate, Result
 
 
@@ -17,15 +18,15 @@ def validate_faproulette(user):
         # 200 without it (age gate, generic landing) is not a hit.
         canonical = _canonical_user(response.text)
         if canonical and canonical.lower() == user.lower():
-            return Result.taken(url=show_url)
+            return Result.taken(extra=_extract_profile(response.text), url=show_url)
 
         return Result.error("Profile confirmation not found", url=show_url)
 
     return generic_validate(url, process, show_url=show_url)
 
 
-def _canonical_user(html: str) -> str | None:
-    link = re.search(r'<link\b[^>]*\brel="canonical"[^>]*>', html, re.IGNORECASE)
+def _canonical_user(html_text: str) -> str | None:
+    link = re.search(r'<link\b[^>]*\brel="canonical"[^>]*>', html_text, re.IGNORECASE)
     if not link:
         return None
 
@@ -35,3 +36,27 @@ def _canonical_user(html: str) -> str | None:
 
     match = re.search(r'/@([^/?#]+)', href.group(1))
     return match.group(1) if match else None
+
+
+def _extract_profile(html_text: str) -> dict:
+    extra = {}
+
+    # og:title is "<DisplayName>'s Profile - Fap Roulette"; the apostrophe may
+    # arrive raw or html-encoded depending on the rendering path.
+    name = re.search(
+        r'og:title"\s+content="(.+?)(?:&#0?39;|&apos;|\')s Profile',
+        html_text, re.IGNORECASE)
+    if name:
+        extra["name"] = html.unescape(name.group(1)).strip()
+
+    joined = re.search(
+        r'<span class="type">Joined</span>.{0,200}?(\d{4}-\d{2}-\d{2})',
+        html_text, re.IGNORECASE | re.DOTALL)
+    if joined:
+        extra["joined"] = joined.group(1)
+
+    roulettes = re.search(r'roulettes_total(?:&quot;|")\s*:\s*(\d+)', html_text, re.IGNORECASE)
+    if roulettes:
+        extra["roulettes"] = roulettes.group(1)
+
+    return extra

--- a/user_scanner/user_scan/adult/faproulette.py
+++ b/user_scanner/user_scan/adult/faproulette.py
@@ -1,0 +1,37 @@
+import re
+from user_scanner.core.orchestrator import generic_validate, Result
+
+
+def validate_faproulette(user):
+    url = f"https://faproulette.co/@{user}"
+    show_url = url
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available(url=show_url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+
+        # A real profile answers 200 with a canonical link echoing /@{user}; a
+        # 200 without it (age gate, generic landing) is not a hit.
+        canonical = _canonical_user(response.text)
+        if canonical and canonical.lower() == user.lower():
+            return Result.taken(url=show_url)
+
+        return Result.error("Profile confirmation not found", url=show_url)
+
+    return generic_validate(url, process, show_url=show_url)
+
+
+def _canonical_user(html: str) -> str | None:
+    link = re.search(r'<link\b[^>]*\brel="canonical"[^>]*>', html, re.IGNORECASE)
+    if not link:
+        return None
+
+    href = re.search(r'href="([^"]+)"', link.group(0), re.IGNORECASE)
+    if not href:
+        return None
+
+    match = re.search(r'/@([^/?#]+)', href.group(1))
+    return match.group(1) if match else None


### PR DESCRIPTION
## What

Adds **faproulette.co** to both scan modes — an email module and a username module.

## Email module (`email_scan/adult/faproulette.py`)

Uses the site's own signup-form endpoint `POST /api/userCheckEmail` (email + timeoutID; no CSRF/Turnstile needed for the check):

| Response | Result |
|----------|--------|
| `{"success":1,...}` | Not Registered |
| `{"success":0,"error":"Email address is already in use."}` | Registered |
| other `success:0` / non-200 / 429 | Error |

## Username module (`user_scan/adult/faproulette.py`)

Checks the public profile page `GET /@{user}` via `generic_validate`:

| Response | Result |
|----------|--------|
| 200 + `<link rel="canonical">` echoing `/@{user}` | Found |
| 404 | Not Found |
| 200 without a matching canonical | Error: "Profile confirmation not found" |
| other status | Error: "Unexpected status: {code}" |

Canonical extraction isolates the `<link rel="canonical">` tag before pulling `href`, so it is independent of HTML attribute order.

## Notes

- faproulette.co supports **both** lookups, so it appears in both scans (like other dual-capable sites). Registration is Turnstile-gated and password reset is non-enumerating, but `userCheckEmail` cleanly reveals email existence.
- Error branches follow each category's majority convention (`email_scan` omits `url=` on errors; `user_scan/adult` includes it).

## Testing

- Verified live: `brunolm7@gmail.com` → Registered and `brunolm` → Found; throwaway email/username → Not Registered / Not Found; case-insensitive username match confirmed.
- `pytest tests/`: all pass except 2 pre-existing Windows `chmod(0)` no-op tests, unrelated to this change.