### PR TITLE
feat: add Tube8 email scan module

### DIFF
--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 import random
+import re
 import threading
 import functools
 import asyncio
@@ -14,6 +15,14 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 import httpx
+
+# Pragmatic RFC 5322 / email-validator-style syntax check: an unquoted
+# dot-atom local part, a dotted host name, and an alphabetic TLD. It does not
+# accept quoted local parts, IP-address literals, or internationalized (IDN)
+# domains — none of which the scanners target.
+_EMAIL_LOCAL = r"[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*"
+_EMAIL_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+EMAIL_RE = re.compile(rf"{_EMAIL_LOCAL}@(?:{_EMAIL_LABEL}\.)+[A-Za-z]{{2,63}}")
 
 LOUD_MODULES: Dict[str, List[str]] = {
     "user": [],
@@ -53,6 +62,15 @@ class ScanConfig:
     no_nsfw: bool = False
     only_found: bool = False
     verbose: bool = False
+
+
+def is_valid_email(email: str) -> bool:
+    if not email or len(email) > 254:
+        return False
+    local, _, domain = email.rpartition("@")
+    if len(local) > 64 or len(domain) > 253:
+        return False
+    return bool(EMAIL_RE.fullmatch(email))
 
 
 def get_site_name(module) -> str:

--- a/user_scanner/email_scan/adult/tube8.py
+++ b/user_scanner/email_scan/adult/tube8.py
@@ -1,0 +1,77 @@
+import httpx
+import re
+from user_scanner.core.helpers import is_valid_email
+from user_scanner.core.result import Result
+
+RATE_LIMITED_MSG = "Rate limited, wait for a few minutes"
+
+
+async def _check(email: str) -> Result:
+    base_url = "https://www.tube8.com"
+    show_url = "https://tube8.com"
+    register_url = f"{base_url}/register"
+    check_api = f"{base_url}/register/verify_email"
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": base_url,
+        "Referer": register_url,
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+    }
+
+    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=15.0) as client:
+        try:
+            landing_resp = await client.get(register_url, headers=headers)
+            token_match = re.search(
+                r'page_params\.token\s*=\s*"([^"]+)"', landing_resp.text
+            )
+
+            if not token_match:
+                return Result.error("Failed to extract dynamic token from HTML")
+
+            token = token_match.group(1)
+
+            params = {"token": token}
+            payload = {"token": token, "email": email}
+
+            response = await client.post(
+                check_api,
+                params=params,
+                headers=headers,
+                data=payload,
+            )
+
+            if response.status_code == 429:
+                return Result.error(RATE_LIMITED_MSG)
+
+            if response.status_code != 200:
+                return Result.error(f"HTTP Error: {response.status_code}")
+
+            data = response.json()
+
+            if data.get("success") is True:
+                return Result.available(url=show_url)
+
+            messages = data.get("messages", [])
+            message = " ".join(messages) if isinstance(messages, list) else str(messages)
+
+            # A well-formed address that fails the requirements check is Tube8's
+            # way of reporting an existing account rather than saying it's taken.
+            if "does not meet our registration requirements" in message:
+                if is_valid_email(email):
+                    return Result.taken(url=show_url)
+                return Result.available(url=show_url, reason=message)
+
+            # A stale or over-used token answers "Not available." instead of a verdict.
+            if "not available" in message.lower():
+                return Result.error(RATE_LIMITED_MSG)
+
+            return Result.error(f"Unexpected API response: {message}")
+
+        except Exception as e:
+            return Result.error(e)
+
+
+async def validate_tube8(email: str) -> Result:
+    return await _check(email)


### PR DESCRIPTION
## What

Adds an email-based **Tube8** account check to `email_scan/adult/`.

## How it works

Tube8 is on the same Aylo/MindGeek backend as Pornhub / RedTube / YouPorn and uses the identical signup validation flow:

1. `GET /register` to scrape the per-session `page_params.token` (ends in a literal `.` that must be preserved).
2. `POST /register/verify_email` with `token` + `email`.

Response mapping:

| Response | Result |
|----------|--------|
| `{"success":true}` | Not Registered |
| `{"success":false, ["...does not meet our registration requirements."]}` (valid email) | Registered |
| `{"success":false, ["Not available."]}` (stale/over-used token throttle) | Error (rate limited) |
| non-200 / 429 | Error |

For a well-formed address, Tube8 reports an existing account by refusing registration ("does not meet our registration requirements") rather than saying it's taken — same behavior as YouPorn/RedTube. The `is_valid_email` guard ensures malformed inputs aren't misreported as hits.

## Shared helper

Reuses the `is_valid_email` helper in `core/helpers.py`. This is the **same helper introduced alongside RedTube** (PR #417) and YouPorn (PR #420) — byte-for-byte identical — so overlapping merges resolve as a no-op on `helpers.py`.

## Notes

- **Email-only:** Tube8 user profiles are addressed by numeric ID (Aylo platform), so username lookups by name aren't viable.
- Neither holehe nor MailAccess has a Tube8 checker.
- The module is a domain-swap of the YouPorn module.

## Testing

- Verified live: `test@gmail.com` → Registered; throwaway addresses → Not Registered.
- `pytest tests/`: all pass except 2 pre-existing Windows `chmod(0)` no-op tests, unrelated to this change.

> Note: like the other Aylo sites, the endpoint's anti-enumeration throttle can intermittently return the "requirements" message for a valid address, so a Registered result on a valid email is high-signal but not a hard guarantee; Not Registered is reliable.