### PR TITLE
feat: add SpankBang username scan module

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install httpx colorama types-colorama
+          pip install httpx curl_cffi colorama types-colorama
           pip install ruff mypy
 
       - name: Run ruff

--- a/.github/workflows/lint-push.yml
+++ b/.github/workflows/lint-push.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install httpx colorama types-colorama
+          pip install httpx curl_cffi colorama types-colorama
           pip install ruff mypy
 
       - name: Run ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ authors = [
 dependencies = [
   "httpx[http2]>=0.27,<0.29",
   "socksio>=1.0,<2",
-  "colorama>=0.4,<1"
+  "colorama>=0.4,<1",
+  "curl_cffi>=0.7,<1"
 ]
 
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx[http2]>=0.27,<0.29
 socksio>=1.0,<2
 colorama>=0.4,<1
+curl_cffi>=0.7,<1

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+from user_scanner.core import impersonate
+from user_scanner.core.result import Result, Status
+
+
+class FakeSession:
+    instances = []
+
+    def __init__(self, impersonate=None, proxies=None):
+        self.impersonate = impersonate
+        self.proxies = proxies
+        self.calls = []
+        FakeSession.instances.append(self)
+
+    def get(self, url, **kwargs):
+        return self.request("GET", url, **kwargs)
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return SimpleNamespace(status_code=200, headers={}, text="ok")
+
+
+def _reset(monkeypatch):
+    impersonate._sessions.clear()
+    impersonate._warmed.clear()
+    FakeSession.instances.clear()
+    monkeypatch.setattr(impersonate.cffi, "Session", FakeSession)
+    monkeypatch.setattr(impersonate, "get_proxy", lambda: None)
+
+
+def _process(response):
+    return Result.taken() if response.status_code == 200 else Result.error("bad")
+
+
+def test_warmup_runs_once_and_session_is_reused(monkeypatch):
+    _reset(monkeypatch)
+
+    r1 = impersonate.impersonate_validate(
+        "https://site/a", _process, warmup_url="https://site/", show_url="SHOWN"
+    )
+    r2 = impersonate.impersonate_validate(
+        "https://site/b", _process, warmup_url="https://site/"
+    )
+
+    assert r1.status == Status.TAKEN
+    assert r1.url == "SHOWN"
+    assert r2.status == Status.TAKEN
+
+    assert len(FakeSession.instances) == 1
+    session = FakeSession.instances[0]
+    urls = [call[0] for call in session.calls]
+    assert urls == ["https://site/", "https://site/a", "https://site/b"]
+
+    profile_kwargs = session.calls[1][1]
+    assert profile_kwargs.get("allow_redirects") is False
+    assert profile_kwargs.get("timeout") == impersonate.DEFAULT_TIMEOUT
+
+
+def test_request_reuses_warm_session(monkeypatch):
+    _reset(monkeypatch)
+
+    impersonate.impersonate_validate(
+        "https://site/a", _process, warmup_url="https://site/"
+    )
+    resp = impersonate.impersonate_request(
+        "https://site/graphql", method="POST", warmup_url="https://site/", json=[{"q": 1}]
+    )
+
+    assert resp.status_code == 200
+    assert len(FakeSession.instances) == 1
+    session = FakeSession.instances[0]
+    urls = [call[0] for call in session.calls]
+    # warm-up happens once, then the GET and the follow-up POST reuse it
+    assert urls == ["https://site/", "https://site/a", "https://site/graphql"]
+
+
+def test_exception_becomes_error_result(monkeypatch):
+    _reset(monkeypatch)
+
+    def boom(response):
+        raise RuntimeError("kaboom")
+
+    res = impersonate.impersonate_validate(
+        "https://site/a", boom, warmup_url="https://site/", show_url="SHOWN"
+    )
+
+    assert res.status == Status.ERROR
+    assert res.url == "SHOWN"

--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,0 +1,81 @@
+import threading
+from typing import Callable, Literal, Optional
+
+from curl_cffi import requests as cffi
+
+from user_scanner.core.helpers import get_proxy
+from user_scanner.core.result import Result
+
+DEFAULT_IMPERSONATE = "chrome"
+DEFAULT_TIMEOUT = 15.0
+
+_sessions: dict[tuple, cffi.Session] = {}
+_warmed: set[tuple] = set()
+_lock = threading.Lock()
+
+
+def impersonate_validate(
+    url: str,
+    func: Callable[[cffi.Response], Result],
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    show_url: Optional[str] = None,
+    **kwargs,
+) -> Result:
+    """Like ``generic_validate`` but routes the request through a browser-
+    impersonating curl_cffi session, so it clears TLS-fingerprint bot walls
+    (e.g. DataDome) that reject Python's default TLS stack regardless of headers.
+
+    ``warmup_url`` is fetched once per session to obtain the clearance cookie the
+    protected endpoint requires; a blocked warm-up still sets that cookie.
+    """
+    display_url = show_url or url
+    try:
+        response = impersonate_request(
+            url, warmup_url=warmup_url, impersonate=impersonate, **kwargs
+        )
+        return func(response).update(url=display_url)
+    except Exception as e:
+        return Result.error(e, url=display_url)
+
+
+def impersonate_request(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """Issue a single request through a warmed, cookie-persistent browser-
+    impersonating session and return the raw response. Reuses the same cached
+    session as ``impersonate_validate`` for a given (impersonate, proxy), so a
+    follow-up call (e.g. a profile API request) inherits the clearance cookie.
+    """
+    session = _get_warm_session(impersonate, get_proxy(), warmup_url)
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    kwargs.setdefault("allow_redirects", False)
+    return session.request(method, url, **kwargs)
+
+
+def _get_warm_session(
+    impersonate: str, proxy: Optional[str], warmup_url: Optional[str]
+) -> cffi.Session:
+    key = (impersonate, proxy)
+    with _lock:
+        session = _sessions.get(key)
+        if session is None:
+            session = cffi.Session(
+                # curl_cffi types this as a browser-name Literal; the value is a
+                # validated runtime string, so widen it here only.
+                impersonate=impersonate,  # type: ignore[arg-type]
+                proxies={"http": proxy, "https": proxy} if proxy else None,
+            )
+            _sessions[key] = session
+
+        if warmup_url and key not in _warmed:
+            # A blocked (403) warm-up still returns normally and sets the cookie;
+            # only a network error leaves the session unwarmed for a later retry.
+            session.get(warmup_url, timeout=DEFAULT_TIMEOUT)
+            _warmed.add(key)
+
+    return session

--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -3,7 +3,7 @@ from typing import Callable, Literal, Optional
 
 from curl_cffi import requests as cffi
 
-from user_scanner.core.helpers import get_proxy
+from user_scanner.core.helpers import get_global_timeout, get_proxy
 from user_scanner.core.result import Result
 
 DEFAULT_IMPERSONATE = "chrome"
@@ -52,7 +52,7 @@ def impersonate_request(
     follow-up call (e.g. a profile API request) inherits the clearance cookie.
     """
     session = _get_warm_session(impersonate, get_proxy(), warmup_url)
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
 
@@ -75,7 +75,14 @@ def _get_warm_session(
         if warmup_url and key not in _warmed:
             # A blocked (403) warm-up still returns normally and sets the cookie;
             # only a network error leaves the session unwarmed for a later retry.
-            session.get(warmup_url, timeout=DEFAULT_TIMEOUT)
+            session.get(warmup_url, timeout=_timeout())
             _warmed.add(key)
 
     return session
+
+
+def _timeout() -> float:
+    # Honour the CLI -t flag (get_global_timeout), matching make_request();
+    # fall back to DEFAULT_TIMEOUT when the user has not set one.
+    global_timeout = get_global_timeout()
+    return global_timeout if global_timeout is not None else DEFAULT_TIMEOUT

--- a/user_scanner/user_scan/adult/spankbang.py
+++ b/user_scanner/user_scan/adult/spankbang.py
@@ -1,6 +1,8 @@
 import re
 import html
-from user_scanner.core.orchestrator import generic_validate, Result
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
 
 def validate_spankbang(user):
@@ -21,7 +23,7 @@ def validate_spankbang(user):
 
         return Result.error("Profile confirmation not found", url=show_url)
 
-    return generic_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, show_url=show_url)
 
 
 def _is_profile(html_text: str, user: str) -> bool:
@@ -42,11 +44,31 @@ def _extract_profile(html_text: str) -> dict:
     if name:
         extra["name"] = html.unescape(name.group(1)).strip()
 
+    # Stable numeric account id (the handle can be changed; this cannot).
+    user_id = re.search(r"ana_profile_id\s*=\s*'(\d+)'", html_text)
+    if user_id:
+        extra["user_id"] = user_id.group(1)
+
     # Country comes from the flag image filename (ISO code), which is stable
     # regardless of the page language.
     country = re.search(r'class="flag"[^>]*/Flags/([A-Za-z]{2})\.png', html_text, re.IGNORECASE | re.DOTALL)
     if country:
         extra["country"] = country.group(1).upper()
+
+    # Gender and age render in the details block; age is only present when set.
+    gender = re.search(r'<span class="gender">\s*([^<]+?)\s*</span>', html_text, re.IGNORECASE)
+    if gender:
+        extra["gender"] = gender.group(1).strip()
+
+    age = re.search(r'<span class="age">\s*(\d+)\s*</span>', html_text, re.IGNORECASE)
+    if age:
+        extra["age"] = age.group(1)
+
+    # Avatar is a Gravatar keyed on the MD5 of the account email — useful for
+    # cross-referencing even when it falls back to the robohash default.
+    avatar = re.search(r'class="avatar"[^>]*?src="([^"]+)"', html_text, re.IGNORECASE)
+    if avatar:
+        extra["avatar"] = html.unescape(avatar.group(1).strip())
 
     # Stat tabs render as <a href="/profile/<user>/<slug>">Label <span>N</span></a>.
     # Key off the URL slug rather than the visible label so localisation never

--- a/user_scanner/user_scan/adult/spankbang.py
+++ b/user_scanner/user_scan/adult/spankbang.py
@@ -1,4 +1,5 @@
 import re
+import html
 from user_scanner.core.orchestrator import generic_validate, Result
 
 
@@ -16,17 +17,46 @@ def validate_spankbang(user):
         # A real profile answers 200 with a "<user> Profile ... @ SpankBang"
         # title; the not-found page is a 200-less generic front page.
         if _is_profile(response.text, user):
-            return Result.taken(url=show_url)
+            return Result.taken(extra=_extract_profile(response.text), url=show_url)
 
         return Result.error("Profile confirmation not found", url=show_url)
 
     return generic_validate(url, process, show_url=show_url)
 
 
-def _is_profile(html: str, user: str) -> bool:
-    match = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+def _is_profile(html_text: str, user: str) -> bool:
+    match = re.search(r"<title[^>]*>(.*?)</title>", html_text, re.IGNORECASE | re.DOTALL)
     if not match:
         return False
 
     title = match.group(1).strip().lower()
     return title.startswith(user.lower() + " profile") and "spankbang" in title
+
+
+def _extract_profile(html_text: str) -> dict:
+    extra = {}
+
+    # The OpenGraph tags are templated boilerplate here, so read the real
+    # server-rendered profile markup instead.
+    name = re.search(r'<h1 class="profile_name">\s*([^<]+?)\s*</h1>', html_text, re.IGNORECASE)
+    if name:
+        extra["name"] = html.unescape(name.group(1)).strip()
+
+    # Country comes from the flag image filename (ISO code), which is stable
+    # regardless of the page language.
+    country = re.search(r'class="flag"[^>]*/Flags/([A-Za-z]{2})\.png', html_text, re.IGNORECASE | re.DOTALL)
+    if country:
+        extra["country"] = country.group(1).upper()
+
+    # Stat tabs render as <a href="/profile/<user>/<slug>">Label <span>N</span></a>.
+    # Key off the URL slug rather than the visible label so localisation never
+    # breaks extraction; the visible label between > and <span> is ignored.
+    for match in re.finditer(
+        r'/profile/[^/"]+/([a-z_]+)"[^>]*>[^<]*<span>\s*([\d,.]+[KMk]?)\s*</span>',
+        html_text, re.IGNORECASE):
+        slug = match.group(1).lower()
+        count = match.group(2)
+        if slug not in extra and count not in ("0", ""):
+            extra[slug] = count
+
+    return extra

--- a/user_scanner/user_scan/adult/spankbang.py
+++ b/user_scanner/user_scan/adult/spankbang.py
@@ -1,0 +1,32 @@
+import re
+from user_scanner.core.orchestrator import generic_validate, Result
+
+
+def validate_spankbang(user):
+    url = f"https://spankbang.com/profile/{user}"
+    show_url = url
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available(url=show_url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+
+        # A real profile answers 200 with a "<user> Profile ... @ SpankBang"
+        # title; the not-found page is a 200-less generic front page.
+        if _is_profile(response.text, user):
+            return Result.taken(url=show_url)
+
+        return Result.error("Profile confirmation not found", url=show_url)
+
+    return generic_validate(url, process, show_url=show_url)
+
+
+def _is_profile(html: str, user: str) -> bool:
+    match = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+    if not match:
+        return False
+
+    title = match.group(1).strip().lower()
+    return title.startswith(user.lower() + " profile") and "spankbang" in title


### PR DESCRIPTION
## What

Adds a username-based **SpankBang** profile check to `user_scan/adult/`, routed through a browser-impersonating request so it clears Cloudflare's TLS-fingerprint bot wall.

## How it works

Requests `https://spankbang.com/profile/{user}`:

| Response | Result |
| --- | --- |
| 200 + title `"{user} Profile … @ SpankBang"` | Found |
| 404 | Not Found |
| 200 without the profile title (e.g. an interstitial) | Error: "Profile confirmation not found" |
| other status | Error: "Unexpected status: {code}" |

Existence is confirmed by the `<title>` rather than status alone, so a soft/interstitial 200 isn't misread as a hit. On a hit, the profile is enriched from the server-rendered markup with `name`, `user_id` (stable numeric account id), `country`, `gender`, `age`, `avatar`, and whatever activity stat counts the page renders (`videos`, `playlists`, `subscribers`, `achievements`, `likes`).

## Why the new dependency (`curl_cffi`)

SpankBang sits behind **Cloudflare**, which fingerprints the **TLS handshake (JA3/JA4)** rather than the User-Agent. Python's default TLS stack (used by `httpx`) is now rejected with `403` regardless of the browser-like headers `make_request` sends — so a plain-`httpx` request no longer works.

The fix routes the request through `curl_cffi` with `impersonate="chrome"`, which replicates a real Chrome TLS handshake. Unlike a DataDome cookie wall, **no session warm-up is needed** here — Cloudflare's check on these GETs is passive fingerprinting, so the impersonated handshake alone passes:

| Approach | Result |
| --- | --- |
| `httpx` (default, or real Chrome UA + full headers) | 403 |
| `curl_cffi` `impersonate="chrome"` | **200** ✅ |
| `curl_cffi` `impersonate="safari18_0"` | 200 ✅ |
| `curl_cffi` `impersonate="chrome131"` / `"chrome136"` | 403 "Just a moment…" |

The impersonation target matters — the default `"chrome"` alias passes, while some pinned Chrome versions trip Cloudflare's interstitial — so the module uses the default.

This lives in a reusable core helper, `user_scanner/core/impersonate.py` (`impersonate_validate` / `impersonate_request`), that mirrors `generic_validate` but routes through a warmed, cookie-persistent impersonating session (the warm-up is optional — needed for cookie-gated walls like DataDome, skipped here). `curl_cffi>=0.7,<1` is added to `pyproject.toml`/`requirements.txt`, and to the lint job's install step so mypy type-checks against it.

## Notes

- **Username-only.** Email checking is not viable: registration (`/users/auth?ajax=1&register=1`) is reCAPTCHA-gated and exposes no async email-existence endpoint.
- Cloudflare is more volatile than a static header check and can escalate to active JS/managed challenges. It works cleanly today with the `"chrome"` target; if Cloudflare ever hard-challenges a given IP the module degrades to an error (403) rather than a wrong verdict.
- The `impersonate.py` helper is shared with the TripAdvisor module PR (#428) — the file is identical in both, so whichever merges first, the other's copy can be dropped from its diff.
- Neither holehe nor MailAccess has a SpankBang checker.

## Testing

- Verified live across 30+ existing handles → Found with metadata; random/non-existent → Not Found.
- `impersonate.py` has unit tests (`tests/test_impersonate.py`).
- ruff + mypy clean; `pytest` passes except the 2 pre-existing Windows `chmod(0)` no-op tests, unrelated to this change.
