### PR TITLE
feat: add Tumblr email scan module

### DIFF
--- a/user_scanner/email_scan/social/tumblr.py
+++ b/user_scanner/email_scan/social/tumblr.py
@@ -1,0 +1,64 @@
+import re
+import httpx
+from user_scanner.core.result import Result
+
+# The public web app's bearer token, embedded in the homepage HTML.
+API_TOKEN_RE = re.compile(r'"API_TOKEN":"([^"]+)"')
+VALIDATE_URL = "https://www.tumblr.com/api/v2/register/account/validate"
+
+# response codes returned by the account-validate endpoint. A deliberately
+# short password means a free email always trips PASSWORD_TOO_SHORT (so no
+# account is created), while a taken email trips USER_EXISTS first regardless.
+USER_EXISTS = 2
+PASSWORD_TOO_SHORT = 1030
+
+
+async def _check(email: str) -> Result:
+    show_url = "https://tumblr.com"
+    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=True) as client:
+        try:
+            headers = {
+                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+                'Accept-Language': "en-US,en;q=0.9",
+            }
+
+            home = await client.get("https://www.tumblr.com/", headers=headers)
+            token_match = API_TOKEN_RE.search(home.text)
+            if not token_match:
+                return Result.error("Token extraction failed, report it via GitHub issues")
+            token = token_match.group(1)
+
+            auth_headers = {**headers, 'Authorization': f"Bearer {token}"}
+            radar = await client.get("https://www.tumblr.com/api/v2/radar", headers=auth_headers)
+            csrf = radar.headers.get("X-Csrf")
+            if not csrf:
+                return Result.error("CSRF extraction failed, report it via GitHub issues")
+
+            response = await client.post(
+                VALIDATE_URL,
+                json={'email': email, 'password': "x", 'tumblelog': "osintuserprobe"},
+                headers={
+                    **auth_headers,
+                    'X-CSRF': csrf,
+                    'Accept': "application/json",
+                    'content-type': "application/json",
+                    'origin': "https://www.tumblr.com",
+                    'referer': "https://www.tumblr.com/register",
+                },
+            )
+
+            data = response.json().get("response")
+            code = data.get("code") if isinstance(data, dict) else None
+            if code == USER_EXISTS:
+                return Result.taken(url=show_url)
+            elif code == PASSWORD_TOO_SHORT:
+                return Result.available(url=show_url)
+            else:
+                return Result.error("Unexpected response, report it via GitHub issues")
+
+        except Exception as e:
+            return Result.error(f"unexpected exception: {e}")
+
+
+async def validate_tumblr(email: str) -> Result:
+    return await _check(email)

--- a/user_scanner/email_scan/social/tumblr.py
+++ b/user_scanner/email_scan/social/tumblr.py
@@ -1,5 +1,8 @@
 import re
-import httpx
+import urllib.request
+import urllib.error
+import json
+import asyncio
 from user_scanner.core.result import Result
 
 # The public web app's bearer token, embedded in the homepage HTML.
@@ -13,52 +16,80 @@ USER_EXISTS = 2
 PASSWORD_TOO_SHORT = 1030
 
 
-async def _check(email: str) -> Result:
+def _check_sync(email: str) -> Result:
     show_url = "https://tumblr.com"
-    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=True) as client:
+    headers = {
+        'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        'Accept-Language': "en-US,en;q=0.9",
+    }
+    try:
+        # 1. Get Home Page
+        req = urllib.request.Request("https://www.tumblr.com/", headers=headers)
+        with urllib.request.urlopen(req, timeout=15.0) as response:
+            html = response.read().decode("utf-8")
+        
+        token_match = API_TOKEN_RE.search(html)
+        if not token_match:
+            return Result.error("Token extraction failed, report it via GitHub issues")
+        token = token_match.group(1)
+
+        # 2. Get Radar to extract CSRF
+        req2 = urllib.request.Request("https://www.tumblr.com/api/v2/radar", headers={
+            **headers,
+            'Authorization': f"Bearer {token}"
+        })
+        with urllib.request.urlopen(req2, timeout=15.0) as response2:
+            csrf = response2.headers.get("X-Csrf")
+        if not csrf:
+            return Result.error("CSRF extraction failed, report it via GitHub issues")
+
+        # 3. Post Account Validate
+        req3 = urllib.request.Request(
+            VALIDATE_URL,
+            headers={
+                **headers,
+                'Authorization': f"Bearer {token}",
+                'X-CSRF': csrf,
+                'Content-Type': "application/json",
+                'Accept': "application/json",
+                'Origin': "https://www.tumblr.com",
+                'Referer': "https://www.tumblr.com/register",
+            },
+            data=json.dumps({'email': email, 'password': "x", 'tumblelog': "osintuserprobe"}).encode("utf-8"),
+            method="POST"
+        )
+        
         try:
-            headers = {
-                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
-                'Accept-Language': "en-US,en;q=0.9",
-            }
-
-            home = await client.get("https://www.tumblr.com/", headers=headers)
-            token_match = API_TOKEN_RE.search(home.text)
-            if not token_match:
-                return Result.error("Token extraction failed, report it via GitHub issues")
-            token = token_match.group(1)
-
-            auth_headers = {**headers, 'Authorization': f"Bearer {token}"}
-            radar = await client.get("https://www.tumblr.com/api/v2/radar", headers=auth_headers)
-            csrf = radar.headers.get("X-Csrf")
-            if not csrf:
-                return Result.error("CSRF extraction failed, report it via GitHub issues")
-
-            response = await client.post(
-                VALIDATE_URL,
-                json={'email': email, 'password': "x", 'tumblelog': "osintuserprobe"},
-                headers={
-                    **auth_headers,
-                    'X-CSRF': csrf,
-                    'Accept': "application/json",
-                    'content-type': "application/json",
-                    'origin': "https://www.tumblr.com",
-                    'referer': "https://www.tumblr.com/register",
-                },
-            )
-
-            data = response.json().get("response")
-            code = data.get("code") if isinstance(data, dict) else None
-            if code == USER_EXISTS:
-                return Result.taken(url=show_url)
-            elif code == PASSWORD_TOO_SHORT:
-                return Result.available(url=show_url)
+            with urllib.request.urlopen(req3, timeout=15.0) as response3:
+                res_body = response3.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            if e.code == 400:
+                res_body = e.read().decode("utf-8")
             else:
-                return Result.error("Unexpected response, report it via GitHub issues")
+                return Result.error(f"Unexpected HTTP status: {e.code}")
+        
+        data = json.loads(res_body).get("response")
+        if not isinstance(data, dict):
+            return Result.error("Invalid API response format, response is not a dict")
+            
+        code = data.get("code")
+        error_msg = str(data.get("error", "")).lower()
+        
+        # Check both response code and the description message to prevent false positives if the structure changes
+        if code == USER_EXISTS and "user already exists" in error_msg:
+            return Result.taken(url=show_url)
+        elif code == PASSWORD_TOO_SHORT and "password" in error_msg:
+            return Result.available(url=show_url)
+        else:
+            return Result.error(f"Unexpected response (code: {code}, error: {error_msg}), report it via GitHub issues")
 
-        except Exception as e:
-            return Result.error(f"unexpected exception: {e}")
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")
 
 
 async def validate_tumblr(email: str) -> Result:
-    return await _check(email)
+    try:
+        return await asyncio.to_thread(_check_sync, email)
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")


### PR DESCRIPTION
Adds an email-existence scan module for Tumblr.

## How it works
- Scrapes the web app's `API_TOKEN` from the homepage, reads the `X-Csrf` header from `GET /api/v2/radar`, then `POST /api/v2/register/account/validate` with the email and a deliberately short password.
- This is a validation-only endpoint and the short password means **no account is ever created** and no email is sent.

## Signal
- **Registered** → `response.code == 2` ("User already exists") → `Result.taken`
- **Not registered** → `response.code == 1030` (password-too-short — the email cleared the uniqueness check) → `Result.available`
- Neither → `Result.error`

## Testing
- Verified live end-to-end: a registered address returns Registered, a random unregistered address returns Not Registered.
- Auto-discovered (no registry changes). Full test suite passes (only the pre-existing `*_unreadable` tests fail, and only on Windows).