### PR TITLE
feat: add StackB username and email scan modules

### DIFF
--- a/user_scanner/email_scan/gaming/stackb.py
+++ b/user_scanner/email_scan/gaming/stackb.py
@@ -98,5 +98,4 @@ async def _check(email: str) -> Result:
 
 
 async def validate_stackb(email: str) -> Result:
-    """Check StackB's login response without sending email; repeated checks may be rate-limited."""
     return await _check(email)

--- a/user_scanner/email_scan/gaming/stackb.py
+++ b/user_scanner/email_scan/gaming/stackb.py
@@ -1,0 +1,102 @@
+import html
+import re
+
+import httpx
+
+from user_scanner.core.helpers import get_random_user_agent
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    show_url = "https://stackb.net"
+    login_url = f"{show_url}/login"
+    headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "ru,en-US;q=0.9,en;q=0.8",
+    }
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=15.0,
+            headers=headers,
+            follow_redirects=True,
+        ) as client:
+            login_response = await client.get(login_url)
+            if login_response.status_code != 200:
+                return Result.error(
+                    f"Unexpected login status: {login_response.status_code}",
+                    url=show_url,
+                )
+
+            csrf_match = re.search(
+                r'<meta name="csrf-token" content="([^"]+)"',
+                login_response.text,
+            )
+            snapshot_match = re.search(
+                r'<div wire:snapshot="([^"]+)"[^>]*wire:id="[^"]+"'
+                r'[^>]*x-data="loginFormCaptcha',
+                login_response.text,
+            )
+            if not csrf_match or not snapshot_match:
+                return Result.error(
+                    "Could not find login form tokens",
+                    url=show_url,
+                )
+
+            csrf_token = html.unescape(csrf_match.group(1))
+            payload = {
+                "_token": csrf_token,
+                "components": [
+                    {
+                        "snapshot": html.unescape(snapshot_match.group(1)),
+                        "updates": {
+                            "identifier": email,
+                            "password": "StackB-not-the-password-12345",
+                        },
+                        "calls": [
+                            {"path": "", "method": "submitLogin", "params": []}
+                        ],
+                    }
+                ],
+            }
+            login_check = await client.post(
+                f"{show_url}/livewire/update",
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "Origin": show_url,
+                    "Referer": login_url,
+                    "X-CSRF-TOKEN": csrf_token,
+                    "X-Livewire": "true",
+                },
+                json=payload,
+            )
+
+            if login_check.status_code != 200:
+                return Result.error(
+                    f"Unexpected login check status: {login_check.status_code}",
+                    url=show_url,
+                )
+
+            components = login_check.json().get("components", [])
+            login_messages = " ".join(
+                str(dispatch.get("params", {}).get("message", ""))
+                for component in components
+                for dispatch in component.get("effects", {}).get(
+                    "dispatches", []
+                )
+            )
+
+            if "Таких пользователей не нашлось" in login_messages:
+                return Result.available(url=show_url)
+            if "Пароль введен неверно" in login_messages:
+                return Result.taken(url=show_url)
+            return Result.error("Unexpected login check response", url=show_url)
+    except Exception as exc:
+        return Result.error(exc, url=show_url)
+
+
+async def validate_stackb(email: str) -> Result:
+    """Check StackB's login response without sending email; repeated checks may be rate-limited."""
+    return await _check(email)

--- a/user_scanner/user_scan/gaming/stackb.py
+++ b/user_scanner/user_scan/gaming/stackb.py
@@ -1,0 +1,131 @@
+import html
+import json
+import re
+from urllib.parse import quote
+
+from user_scanner.core.helpers import get_random_user_agent
+from user_scanner.core.orchestrator import make_request
+from user_scanner.core.result import Result
+
+
+def validate_stackb(user: str) -> Result:
+    profile_url = f"https://stackb.net/@{user}"
+    url = f"https://stackb.net/@{quote(user, safe='')}"
+    login_url = "https://stackb.net/login"
+
+    headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "ru,en-US;q=0.9,en;q=0.8",
+    }
+
+    try:
+        login_response = make_request(login_url, headers=headers, follow_redirects=True)
+        if login_response.status_code != 200:
+            return Result.error(f"Unexpected login status: {login_response.status_code}", url=url)
+
+        login_text = login_response.text
+        csrf_match = re.search(r'<meta name="csrf-token" content="([^"]+)"', login_text)
+        snapshot_match = re.search(
+            r'<div wire:snapshot="([^"]+)"[^>]*wire:id="([^"]+)"[^>]*x-data="loginFormCaptcha',
+            login_text,
+        )
+        if not csrf_match or not snapshot_match:
+            return Result.error("Could not find login form tokens", url=url)
+
+        csrf_token = html.unescape(csrf_match.group(1))
+        snapshot = html.unescape(snapshot_match.group(1))
+        payload = {
+            "_token": csrf_token,
+            "components": [
+                {
+                    "snapshot": snapshot,
+                    "updates": {
+                        "identifier": user,
+                        "password": "StackB-not-the-password-12345",
+                    },
+                    "calls": [{"path": "", "method": "submitLogin", "params": []}],
+                }
+            ],
+        }
+        login_check = make_request(
+            "https://stackb.net/livewire/update",
+            method="POST",
+            headers={
+                **headers,
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Origin": "https://stackb.net",
+                "Referer": login_url,
+                "X-CSRF-TOKEN": csrf_token,
+                "X-Livewire": "true",
+            },
+            json=payload,
+        )
+
+        if login_check.status_code != 200:
+            return Result.error(f"Unexpected login check status: {login_check.status_code}", url=url)
+
+        try:
+            login_data = login_check.json()
+            login_messages = " ".join(
+                str(dispatch.get("params", {}).get("message", ""))
+                for component in login_data.get("components", [])
+                for dispatch in component.get("effects", {}).get("dispatches", [])
+            )
+        except (ValueError, AttributeError):
+            return Result.error("Unexpected login check response", url=url)
+
+        if "Максимальная длина никнейма" in login_messages:
+            return Result.available(
+                "Username format rejected by StackB",
+                url=url,
+            )
+        if "Таких пользователей не нашлось" in login_messages:
+            return Result.available(url=url)
+        if "Пароль введен неверно" not in login_messages:
+            return Result.error("Unexpected login check response", url=url)
+
+        extra = {}
+        try:
+            profile_response = make_request(
+                url,
+                headers=headers,
+                show_url=url,
+                follow_redirects=True,
+            )
+            response_text = profile_response.text
+            profile = {}
+            for json_match in re.finditer(r'<script type="application/ld\+json">(.*?)</script>', response_text, re.DOTALL):
+                try:
+                    data = json.loads(html.unescape(json_match.group(1)))
+                except json.JSONDecodeError:
+                    continue
+
+                if data.get("@type") == "ProfilePage":
+                    entity = data.get("mainEntity")
+                    if isinstance(entity, dict):
+                        profile = entity
+                    break
+
+            if profile:
+                description_match = re.search(r'<meta [^>]*property=["\']og:description["\'][^>]*content=["\']([^"\']*)', response_text, re.IGNORECASE)
+                stats_text = html.unescape(description_match.group(1)).strip() if description_match else None
+
+                if name := profile.get("name"): extra["display_name"] = name
+                if description := profile.get("description"): extra["bio"] = description
+                if image := profile.get("image"): extra["avatar"] = image
+
+                if stats_text:
+                    if rank_match := re.search(r"Ранг:\s*([^\.]+)", stats_text):
+                        extra["rank"] = rank_match.group(1).strip()
+                    if followers_match := re.search(r"Подписчики:\s*(\d+)", stats_text):
+                        extra["followers"] = int(followers_match.group(1))
+
+                extra["profile_url"] = profile_url
+        except Exception:
+            pass
+
+        return Result.taken(extra=extra, url=url)
+    except Exception as exc:
+        return Result.error(exc, url=url)


### PR DESCRIPTION
Attempt number 3... 

Compared to the previous PR, I did some fuzz testing on the StackB module and only received unexpected responses for usernames longer than 16 characters, which is their limit. I added a check to interpret such usernames as available based on the received error message. Not sure about the timeouts though, the site seems to be available from everywhere.

I also added an email module, which works using the same login form as the username module.

I also found an interesting resource that could come handy for testing, containing all registered users: https://stackb.net/sitemap-profiles-1.xml (the numbers go up to 25).