### PR TITLE
feat(cli): support multiple comma-separated values and edge cases for module and category flags

### DIFF
--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -10,11 +10,11 @@
 | `--allow-loud`              | Enable scanning sites that may send emails/notifications    |
 | `--no-nsfw`                 | Disable NSFW site scanning                                  |
 | `--hudson, --hudson-scan`   | Check for infostealer intelligence using Hudson Rock's API  |
-| `-c, --category CATEGORY`   | Scan all platforms in a specific category                   |
+| `-c, --category CATEGORY`   | Scan all platforms in a specific category (comma-separated for multiple) |
 | `-lu, --list-user`          | List all available modules for username scanning            |
 | `-le, --list-email`         | List all available modules for email scanning               |
 | `-v, --verbose`             | Enable verbose output to show urls of the websites          |
-| `-m, --module MODULE`       | Scan a single specific module                               |
+| `-m, --module MODULE`       | Scan a specific module (comma-separated for multiple)                    |
 | `-p, --permute PERMUTE`     | Generate username permutations using a pattern/suffix       |
 | `-P, --proxy-file FILE`     | Use proxies from file (one per line)                        |
 | `--validate-proxies`        | Validate proxies before scanning (tests against google.com) |

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -67,9 +67,9 @@ def main():
         "-ef", "--email-file", help="File containing emails (one per line)"
     )
 
-    parser.add_argument("-c", "--category", help="Scan all platforms in a category")
+    parser.add_argument("-c", "--category", nargs="+", help="Scan all platforms in a category (comma-separated for multiple)")
 
-    parser.add_argument("-m", "--module", help="Scan a single specific module")
+    parser.add_argument("-m", "--module", nargs="+", help="Scan a specific module (comma-separated for multiple)")
 
     parser.add_argument(
         "-lu",
@@ -338,6 +338,53 @@ def main():
         timeout=args.timeout,
     )
 
+    validated_modules = []
+    validated_categories = []
+
+    if args.hudson_scan:
+        if args.category or args.module:
+            print(f"{R}[✘] Error: --hudson cannot be used with -m or -c {X}")
+            print(f"{Y}[i] Use it independently{X}")
+            sys.exit(1)
+    else:
+        if args.module:
+            raw_module_str = ",".join(args.module) if isinstance(args.module, list) else args.module
+            requested_modules = [m.strip() for m in raw_module_str.split(",") if m.strip()]
+            
+            if not requested_modules:
+                print(R + f"[✘] Error: No valid {'email' if is_email else 'user'} modules specified." + Style.RESET_ALL)
+                sys.exit(1)
+
+            for m in requested_modules:
+                found = find_module(m.replace(".", "_"), is_email, args.no_nsfw)
+                if not found:
+                    print(
+                        R
+                        + f"[✘] Error: {'Email' if is_email else 'User'} module '{m}' not found."
+                        + Style.RESET_ALL
+                    )
+                    sys.exit(1)
+                validated_modules.extend(found)
+        elif args.category:
+            raw_category_str = ",".join(args.category) if isinstance(args.category, list) else args.category
+            requested_categories = [c.strip() for c in raw_category_str.split(",") if c.strip()]
+            
+            if not requested_categories:
+                print(R + f"[✘] Error: No valid {'email' if is_email else 'user'} categories specified." + Style.RESET_ALL)
+                sys.exit(1)
+
+            categories_dict = load_categories(is_email, args.no_nsfw)
+            for c in requested_categories:
+                cat_path = categories_dict.get(c)
+                if not cat_path:
+                    print(
+                        R
+                        + f"[✘] Error: {'Email' if is_email else 'User'} category '{c}' not found."
+                        + Style.RESET_ALL
+                    )
+                    sys.exit(1)
+                validated_categories.append(cat_path)
+
     for i, target in enumerate(targets):
         if i != 0 and args.delay:
             time.sleep(args.delay)
@@ -349,45 +396,25 @@ def main():
 
 
         if args.hudson_scan:
-            if args.category or args.module:
-                print(f"{R}[✘] Error: --hudson cannot be used with -m or -c {X}")
-                print(f"{Y}[i] Use it independently{X}")
-                sys.exit(1)
-
             run_hudson_scan(target, is_email)
             continue
 
 
         if args.module:
-            modules = find_module(args.module.replace(".", "_"), is_email, args.no_nsfw)
             fn = run_email_module_batch if is_email else run_user_module
-            if modules:
-                module_config = replace(config, allow_loud=True)
-                for module in modules:
-                    results.extend(fn(module, target, module_config))
-            else:
-                print(
-                    R
-                    + f"[!] {'Email' if is_email else 'User'} module '{args.module}' not found."
-                    + Style.RESET_ALL
-                )
+            module_config = replace(config, allow_loud=True)
+            for module in validated_modules:
+                results.extend(fn(module, target, module_config))
 
         elif args.category:
-            cat_path = load_categories(is_email, args.no_nsfw).get(args.category)
             fn = run_email_category_batch if is_email else run_user_category
-            if cat_path:
+            for cat_path in validated_categories:
                 results.extend(
                     fn(
                         cat_path,
                         target,
                         config,
                     )
-                )
-            else:
-                print(
-                    R
-                    + f"[!] {'Email' if is_email else 'User'} category '{args.category}' not found."
-                    + Style.RESET_ALL
                 )
         else:
             fn = run_email_full_batch if is_email else run_user_full


### PR DESCRIPTION
### Changes

1. **Multi-Value Support**: Enhanced the `-m, --module` and `-c, --category` flags to accept multiple comma-separated values.
2. **Whitespace Tolerance**: Switched parameters to use `nargs='+'` in `argparse` to cleanly parse unquoted space-separated arguments (e.g., `-m hackerone, github`).
3. **Trailing Commas Handling**: Strips and ignores empty modules/categories resulting from trailing commas (e.g., `-m hackerone,`) without throwing error messages.
4. **Pre-flight Validation (Fail-Fast)**: Performs validation checks on all specified modules or categories before starting the target loop.
5. **Safe Aborts**: Aborts the execution with a clean error message and `sys.exit(1)` immediately if any of the provided modules/categories are invalid.
6. **Documentation**: Updated `docs/FLAGS.md` to reflect the multi-value capabilities for these CLI flags.