### PR TITLE
Handle ModelNotFoundException in Cropty validation

### DIFF
--- a/user_scanner/user_scan/finance/cropty.py
+++ b/user_scanner/user_scan/finance/cropty.py
@@ -31,6 +31,20 @@ def validate_cropty(user):
         if response.status_code == 404:
             return Result.available()
 
+        
+        try:
+            data_json = response.json()
+
+            if (
+                "errors" in data_json
+                and data_json["errors"]
+                and data_json["errors"][0].get("code") == "ModelNotFoundException"
+            ):
+                return Result.available()
+
+        except Exception:
+            pass
+        
         return Result.error(f"Unexpected status: {response.status_code}")
 
     return generic_validate(url, process, headers=headers, show_url=show_url)


### PR DESCRIPTION
## Summary

This PR updates the Cropty validation logic to inspect the response body for `ModelNotFoundException` before returning an unexpected status error.

### What changed

- Preserved the existing behavior for `200` and `404` responses.
- Added a check for `ModelNotFoundException` in the response body for all other HTTP status codes.
- Return `Result.available()` when the API indicates the user does not exist, even if the response status is not explicitly handled.

### Why

Previously, only `200` and `404` responses were handled explicitly. Any other status code (such as `403`, `429`, or `500`) would immediately return:

```python
Result.error(f"Unexpected status: {response.status_code}")
```

without inspecting the response body.

With this change, if the API returns a `ModelNotFoundException` in the response body for an unexpected status code, it is correctly treated as an available username instead of an unexpected error.