### PR TITLE
fix: reject usernames causing false positives in Calendly, IFTTT, OpenStreetMap modules

### DIFF
--- a/user_scanner/user_scan/other/calendly.py
+++ b/user_scanner/user_scan/other/calendly.py
@@ -3,7 +3,7 @@ from user_scanner.core.orchestrator import Result, make_request
 
 def validate_calendly(user):
     if "." in user:
-        return Result.error("Username cannot contain periods")
+        return Result.available("Username cannot contain periods")
 
     api_url = f"https://calendly.com/api/booking/profiles/{user}"
     show_url = f"https://calendly.com/{user}"

--- a/user_scanner/user_scan/other/calendly.py
+++ b/user_scanner/user_scan/other/calendly.py
@@ -2,6 +2,9 @@ from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_calendly(user):
+    if "." in user:
+        return Result.error("Username cannot contain periods")
+
     api_url = f"https://calendly.com/api/booking/profiles/{user}"
     show_url = f"https://calendly.com/{user}"
 

--- a/user_scanner/user_scan/social/ifttt.py
+++ b/user_scanner/user_scan/social/ifttt.py
@@ -2,7 +2,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_ifttt(user):
     if "." in user:
-        return Result.error("Username cannot contain periods")
+        return Result.available("Username cannot contain periods")
 
     url = f"https://ifttt.com/p/{user}"
 

--- a/user_scanner/user_scan/social/ifttt.py
+++ b/user_scanner/user_scan/social/ifttt.py
@@ -1,6 +1,9 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_ifttt(user):
+    if "." in user:
+        return Result.error("Username cannot contain periods")
+
     url = f"https://ifttt.com/p/{user}"
 
     def process(response):

--- a/user_scanner/user_scan/social/openstreetmap.py
+++ b/user_scanner/user_scan/social/openstreetmap.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 def validate_openstreetmap(user):
     if "." in user:
-        return Result.error("Username cannot contain periods")
+        return Result.available("Username cannot contain periods")
 
     url = f"https://www.openstreetmap.org/user/{user}"
     show_url = f"https://www.openstreetmap.org/user/{user}"

--- a/user_scanner/user_scan/social/openstreetmap.py
+++ b/user_scanner/user_scan/social/openstreetmap.py
@@ -3,6 +3,9 @@ from user_scanner.core.result import Result
 
 
 def validate_openstreetmap(user):
+    if "." in user:
+        return Result.error("Username cannot contain periods")
+
     url = f"https://www.openstreetmap.org/user/{user}"
     show_url = f"https://www.openstreetmap.org/user/{user}"
 


### PR DESCRIPTION
This PR rejects usernames containing periods in Calendly, IFTTT, and OpenStreetMap, which were causing false positives as websites were only checking the part of username before the period. A good test case is the username "test.ddfdddgfdgf".