### PR TITLE
fix: handle Freesound rate limited responses as errors instead of positives

### DIFF
--- a/user_scanner/user_scan/music/freesound.py
+++ b/user_scanner/user_scan/music/freesound.py
@@ -12,6 +12,9 @@ def validate_freesound(user):
     }
 
     def process(response):
+        if response.status_code == 403:
+            return Result.error("Freesound rate limit or blocked")
+
         if response.status_code == 404 or "Page not found" in response.text:
             return Result.available()
 

--- a/user_scanner/user_scan/music/freesound.py
+++ b/user_scanner/user_scan/music/freesound.py
@@ -13,7 +13,7 @@ def validate_freesound(user):
 
     def process(response):
         if response.status_code == 403:
-            return Result.error("Freesound rate limit or blocked")
+            return Result.error("Freesound rate limit or blocked with status code 403")
 
         if response.status_code == 404 or "Page not found" in response.text:
             return Result.available()


### PR DESCRIPTION
Freesound responds with 403 when you are rate limited. The module currently handles these responses as positives...