### PR TITLE
feat: add XVideos username scan module

### DIFF
--- a/user_scanner/user_scan/adult/xvideos.py
+++ b/user_scanner/user_scan/adult/xvideos.py
@@ -10,14 +10,18 @@ def validate_xvideos(user):
     show_url = url
 
     def process(response):
+        # A genuinely missing handle 404s with an "Unknown profile" page (that
+        # phrase is its <title>); require the marker so a transient or blocked
+        # 404 isn't misread as "available".
         if response.status_code == 404:
-            return Result.available(url=show_url)
+            if "unknown profile" in response.text.lower():
+                return Result.available(url=show_url)
+            return Result.error("Unexpected 404 (not the profile-not-found page)", url=show_url)
 
         if response.status_code != 200:
             return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
 
-        # A real profile is titled "<name> - Profile page - XVIDEOS.COM"; a
-        # missing handle 404s with an "Unknown profile" page.
+        # A real profile is titled "<name> - Profile page - XVIDEOS.COM".
         if "profile page" in _title(response.text).lower():
             return Result.taken(extra=_extract_profile(response.text), url=show_url)
 

--- a/user_scanner/user_scan/adult/xvideos.py
+++ b/user_scanner/user_scan/adult/xvideos.py
@@ -1,0 +1,72 @@
+import re
+import json
+import html
+
+from user_scanner.core.orchestrator import generic_validate, Result
+
+
+def validate_xvideos(user):
+    url = f"https://www.xvideos.com/profiles/{user}"
+    show_url = url
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available(url=show_url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+
+        # A real profile is titled "<name> - Profile page - XVIDEOS.COM"; a
+        # missing handle 404s with an "Unknown profile" page.
+        if "profile page" in _title(response.text).lower():
+            return Result.taken(extra=_extract_profile(response.text), url=show_url)
+
+        return Result.error("Profile confirmation not found", url=show_url)
+
+    return generic_validate(url, process, show_url=show_url)
+
+
+def _extract_profile(html_text: str) -> dict:
+    extra = {}
+
+    # Structured identity from the embedded JSON `user` object.
+    user = _user_object(html_text)
+    if user.get("display"):
+        extra["name"] = user["display"]
+    if user.get("id_user"):
+        extra["user_id"] = str(user["id_user"])
+    avatar = user.get("profile_picture") or user.get("profile_picture_small")
+    if avatar:
+        extra["avatar"] = avatar
+
+    # The visible "profile info" panel carries gender, age, country, hits,
+    # languages, signup, last activity, plus any personal/physical details the
+    # user filled in. Each row is:
+    #   <p id="pinfo-<field>"><strong>Label:</strong><span>Value</span></p>
+    for row in re.finditer(
+        r'<p id="pinfo-[a-z-]+"[^>]*>\s*<strong>\s*(.*?):?\s*</strong>\s*<span>(.*?)</span>',
+        html_text, re.DOTALL):
+        label = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", row.group(1))).strip()
+        value = html.unescape(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", row.group(2))).strip())
+        # "Display" is the toggle link on the collapsible personal/physical rows.
+        if label and value and value.lower() != "display":
+            extra[label] = value
+
+    return extra
+
+
+def _user_object(html_text: str) -> dict:
+    # The page embeds the profile as a JSON `user` object whose `url` field comes
+    # last, so match up to it and parse the whole object.
+    match = re.search(r'"user":(\{.*?"url":"[^"]*"\})', html_text, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _title(html_text: str) -> str:
+    match = re.search(r"<title[^>]*>(.*?)</title>", html_text, re.IGNORECASE | re.DOTALL)
+    return html.unescape(match.group(1)).strip() if match else ""


### PR DESCRIPTION
## What

Adds a username-based **XVideos** profile scan to `user_scan/adult/`.

## How it works

Requests `https://www.xvideos.com/profiles/{user}`:

| Response | Result |
| --- | --- |
| 200 + `"<name> - Profile page - XVIDEOS.COM"` title | Found |
| 404 ("Unknown profile") | Not Found |
| other status | Error |

Unlike the recent adult modules, **no `curl_cffi` is needed** — XVideos serves `/profiles/` over plain nginx with no TLS-fingerprint bot wall, so this uses the standard httpx `generic_validate` path. `/profiles/` is also the canonical namespace: models/channels **redirect into** it (`/models/mia → /profiles/mia`), so a single lookup covers regular users and creators alike.

## Metadata

Identity comes from the page's embedded JSON `user` object (`name`, `user_id`, `avatar`), parsed with `json.loads` so escapes resolve cleanly. Everything else is scraped from the visible profile-info panel with a generic row extractor:

```
<p id="pinfo-<field>"><strong>Label:</strong><span>Value</span></p>
```

This captures whatever a profile fills in — no per-field regex to maintain — so it scales with the account: gender, age, country, languages, signup date, last activity, plus optional personal/physical details (relationship, education, religion, ethnicity, height, weight, …). Verified live: a rich viewer profile yielded 20+ fields, a model profile ~22 (with `profile_hits`, `subscribers`), and a nonexistent handle → Not Found.

## Notes

- No account-`type` field: unlike Pornhub (where the redirect namespace reveals viewer/model/pornstar), XVideos serves everything under `/profiles/` with no reliable in-page classifier, so I left `type` out rather than guess.

## Testing

- Verified live: existing handles → Found with metadata; random/non-existent → Not Found.
- ruff + mypy clean; `pytest` passes except the 2 pre-existing Windows `chmod(0)` no-op tests, unrelated to this change.
