### PR TITLE
ci: pin ruff to 0.15.22 in lint workflows

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install httpx curl_cffi colorama types-colorama
-          pip install ruff mypy
+          pip install ruff==0.15.22 mypy
 
       - name: Run ruff
         run: ruff check .

--- a/.github/workflows/lint-push.yml
+++ b/.github/workflows/lint-push.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install httpx curl_cffi colorama types-colorama
-          pip install ruff mypy
+          pip install ruff==0.15.22 mypy
 
       - name: Run ruff
         run: ruff check .


### PR DESCRIPTION
## Problem

The `Lint & Type Checks` job installs ruff **unpinned** (`pip install ruff mypy`). On 2026-07-23, ruff **0.16.0** shipped and massively widened its default rule set. The next unpinned CI run picked it up automatically and flagged **900+ pre-existing lint errors repo-wide** — turning lint red with **no code change**.

### Ruff versions

| Version | Released (UTC) | Default rule set |
| --- | --- | --- |
| `0.15.22` | 2026-07-16 15:13:19 | narrow (`E4` / `E7` / `E9` / `F`) — repo was green |
| `0.16.0` | 2026-07-23 19:10:46 | widened (adds `I`, `BLE`, `S`, `UP`, `SIM`, `FURB`, `RUF`, `DTZ`, `PL`, `TRY`, …) |

### CI timeline — `Lint & Type Checks`

| Time (UTC) | Commit | ruff installed | Result |
| --- | --- | --- | --- |
| 2026-07-23 19:10:46 | — | **ruff 0.16.0 published to PyPI** | — |
| before 0.16.0 shipped | `edc4486` | 0.15.x | ✅ pass |
| 2026-07-23 19:35:27 | `63bba01` | 0.16.0 | ❌ Found 917 errors |

`63bba01` ran **~25 minutes after** 0.16.0 was published — `pip install ruff` grabbed the brand-new release, and the same code that had passed under 0.15.x went red.

### Sample of the new violations

```
345  I001    unsorted-imports
341  BLE001  blind-except
 92  S110    try-except-pass
 43  UP006   non-pep585-annotation
 ...                        → Found 917 errors
```

## Fix

Pin ruff to **0.15.22** (the last pre-0.16 release) in both lint workflows:

```diff
-          pip install ruff mypy
+          pip install ruff==0.15.22 mypy
```

This makes the lint job reproducible and immune to ruff's release cadence. Verified locally: `ruff==0.15.22 check .` → `All checks passed!`.

## Notes

- Intentionally a version pin, not a rule-set change — it keeps the exact behavior the repo has been green on. Adopting 0.16's wider defaults later is a deliberate, separate effort (~900 fixes / `--fix` + review).
- `mypy` is installed unpinned too and carries the same exposure; pinning it is a reasonable follow-up.
