### PR TITLE
Fix: replace silent Result.taken() fallthrough with explicit Result.error()

### DIFF
--- a/user_scanner/user_scan/dev/codecademy.py
+++ b/user_scanner/user_scan/dev/codecademy.py
@@ -37,7 +37,7 @@ def validate_codecademy(user):
                     return Result.taken(extra={"is_private": False})
                 return Result.available()
             except Exception:
-                return Result.taken()
+                return Result.error("200 response status with no recognizable data, report it via GitHub issues")
 
         return Result.error("Unexpected response body, report it via GitHub issues.")
 

--- a/user_scanner/user_scan/dev/githubgist.py
+++ b/user_scanner/user_scan/dev/githubgist.py
@@ -25,7 +25,7 @@ def validate_githubgist(user):
                 
                 return Result.taken(extra=extra)
             except Exception:
-                return Result.taken()
+                return Result.error("200 response status with no recognizable data, report it via GitHub issues")
                 
         elif response.status_code == 403:
             return Result.error("Rate limited by GitHub API")

--- a/user_scanner/user_scan/finance/destream.py
+++ b/user_scanner/user_scan/finance/destream.py
@@ -26,7 +26,7 @@ def validate_destream(user):
                 return Result.taken(extra=extra)
             except Exception:
                 pass
-            return Result.taken()
+            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
 
         if response.status_code == 404:
             return Result.available()

--- a/user_scanner/user_scan/gaming/apexlegends.py
+++ b/user_scanner/user_scan/gaming/apexlegends.py
@@ -39,7 +39,7 @@ def validate_apexlegends(user):
                 return Result.taken(extra=extra)
             except Exception:
                 pass
-            return Result.taken()
+            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
 
         if response.status_code == 404:
             return Result.available()

--- a/user_scanner/user_scan/gaming/chess_com.py
+++ b/user_scanner/user_scan/gaming/chess_com.py
@@ -42,7 +42,7 @@ def validate_chess_com(user: str) -> Result:
                 return Result.taken(extra=extra)
             except Exception:
                 pass
-            return Result.taken()
+            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
         elif response.status_code == 404:
             return Result.available()
         

--- a/user_scanner/user_scan/gaming/lichess.py
+++ b/user_scanner/user_scan/gaming/lichess.py
@@ -54,7 +54,7 @@ def validate_lichess(user: str) -> Result:
                 return Result.taken(extra=extra)
             except Exception:
                 pass
-            return Result.taken()
+            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
         elif response.status_code == 404:
             return Result.available()
         return Result.error(f"Unexpected status code: {response.status_code}")

--- a/user_scanner/user_scan/gaming/minecraft.py
+++ b/user_scanner/user_scan/gaming/minecraft.py
@@ -20,7 +20,7 @@ def validate_minecraft(user):
                 return Result.taken(extra=extra)
             except Exception:
                 pass
-            return Result.taken()
+            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
         elif response.status_code == 204 or response.status_code == 404:
             return Result.available()
 


### PR DESCRIPTION
Closes #449

## Summary

Several `user_scan` validators silently swallowed parse failures or unrecognized `200` response shapes and fell through to an unconditional `Result.taken()`, instead of returning `Result.error(...)` as required by the module guidelines (Strict Error Handling section of CONTRIBUTING.md).

This replaces that fallback with an explicit error across all 7 affected files:

```python
return Result.error("200 response status with no recognizable data, report it via GitHub issues")
```

## Files changed

- `user_scanner/user_scan/finance/destream.py`
- `user_scanner/user_scan/gaming/apexlegends.py`
- `user_scanner/user_scan/gaming/minecraft.py`
- `user_scanner/user_scan/gaming/lichess.py`
- `user_scanner/user_scan/gaming/chess_com.py`
- `user_scanner/user_scan/dev/codecademy.py`
- `user_scanner/user_scan/dev/githubgist.py`

## Testing

- `ruff check .` — passed
- `mypy user_scanner` — passed
- `pytest` — no test regressions (no per-module tests exist for these validators; existing suite unaffected)