### PR TITLE
Add CodePen username availability module (dev category)

### DIFF
--- a/user_scanner/user_scan/dev/codepen.py
+++ b/user_scanner/user_scan/dev/codepen.py
@@ -1,0 +1,21 @@
+from user_scanner.core.orchestrator import generic_validate, Result
+
+def validate_codepen(user):
+    url = f"https://codepen.io/{user}"
+    show_url = url
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available()
+
+        if response.status_code == 200:
+            marker_og = f'og:url" content="https://codepen.io/{user}'
+            marker_title = f'(@{user})'
+            if marker_og in response.text or marker_title in response.text:
+                return Result.taken(extra={"profile": url})
+            return Result.error("Ambiguous response body, report it via GitHub issues.")
+
+        return Result.error(f"Unexpected status code {response.status_code}")
+
+    headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+    return generic_validate(url, process, show_url=show_url, headers=headers)


### PR DESCRIPTION
Adds a new username availability check for CodePen (codepen.io), following the existing dev/ module pattern.

- File: user_scanner/user_scan/dev/codepen.py
- Exposes validate_codepen(user) using generic_validate
- Available: HTTP 404 on profile URL
- Taken: HTTP 200 + explicit match on og:url meta tag or "(@username)" in page title (avoids false positives from bare 200 status)
- Error: any other unexpected status code

Tested locally with a known existing username and a random non-existent username to confirm both Available/Taken paths resolve correctly.

No changes needed elsewhere — module is picked up automatically by the existing discovery mechanism.