### PR TITLE
Add Lobsters (lobste.rs) and Codepen username availability module

### DIFF
--- a/user_scanner/user_scan/community/lobsters.py
+++ b/user_scanner/user_scan/community/lobsters.py
@@ -1,0 +1,29 @@
+from user_scanner.core.orchestrator import generic_validate, Result
+
+def validate_lobsters(user):
+    url = f"https://lobste.rs/u/{user}.json"
+    show_url = f"https://lobste.rs/u/{user}"
+
+    def process(response):
+        if response.status_code == 200:
+            try:
+                data = response.json()
+                extra = {}
+                if data.get("about"):
+                    extra["about"] = data.get("about")
+                if data.get("created_at"):
+                    extra["created_at"] = data.get("created_at")
+                if data.get("karma") is not None:
+                    extra["karma"] = data.get("karma")
+                if data.get("github_username"):
+                    extra["github_username"] = data.get("github_username")
+                return Result.taken(extra=extra)
+            except Exception:
+                return Result.error("Unexpected response body, report it via GitHub issues.")
+        elif response.status_code == 404:
+            return Result.available()
+
+        return Result.error(f"Unexpected status code {response.status_code}")
+
+    headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+    return generic_validate(url, process, show_url=show_url, headers=headers)

--- a/user_scanner/user_scan/dev/codepen.py
+++ b/user_scanner/user_scan/dev/codepen.py
@@ -1,0 +1,21 @@
+from user_scanner.core.orchestrator import generic_validate, Result
+
+def validate_codepen(user):
+    url = f"https://codepen.io/{user}"
+    show_url = url
+
+    def process(response):
+        if response.status_code == 404:
+            return Result.available()
+
+        if response.status_code == 200:
+            marker_og = f'og:url" content="https://codepen.io/{user}'
+            marker_title = f'(@{user})'
+            if marker_og in response.text or marker_title in response.text:
+                return Result.taken(extra={"profile": url})
+            return Result.error("Ambiguous response body, report it via GitHub issues.")
+
+        return Result.error(f"Unexpected status code {response.status_code}")
+
+    headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+    return generic_validate(url, process, show_url=show_url, headers=headers)


### PR DESCRIPTION
Adds a username availability check for Lobsters (lobste.rs), a tech/OSINT community site currently missing from user_scan/community/.

- File: user_scanner/user_scan/community/lobsters.py
- Uses the public, documented JSON endpoint lobste.rs/u/<username>.json
- Available: HTTP 404
- Taken: HTTP 200 + parsed JSON, extracts about/karma/created_at/github_username when present
- Error: any other status code or unparseable body

Tested locally against a known existing username and a random non-existent one; both paths resolve correctly.