### PR TITLE
docs: fix incorrect example output for {n;m} pattern syntax

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -56,7 +56,7 @@ Specify the length of expansions from a character set.
 ```
 john[a-z]{0-2}    → "john", "johna", "johnb", ..., "johnz", "johnaa", ..., "johnzz"
 code[0-9]{2}      → "code00", "code01", ..., "code99"
-user[a-c]{1;3}    → "usera", "userb", "userc", "useraa", ..., "userccc"
+user[a-c]{1;3}    → "usera", "userb", "userc", "useraaa", ..., "userccc"
 text[0-1]{1-3}    → "text0", "text1", "text00", "text01", "text10", "text11", ..., "text111"
 ```
 


### PR DESCRIPTION
The {1;3} example in the Length Control section showed "useraa" (a
2-character expansion) in its output list. But {n;m} is documented (and
implemented in patterns.py's _parse_lenset) as "exactly n or m characters"
— not a range — so length-2 results are never produced for {1;3}.

Verified directly:
>>> list(expand_patterns("user[a-c]{1;3}"))
# 30 results total: 3 of length 1, 27 of length 3, no length-2 entries

Fixed the example to show a length-3 result ("useraaa") instead of the
impossible length-2 one. Docs only, no code changes.