### PR TITLE
fix: respect --allow-loud for -m/--module scans

### DIFF
--- a/tests/test_loud_prompt.py
+++ b/tests/test_loud_prompt.py
@@ -1,0 +1,64 @@
+from user_scanner.core import loud_prompt
+from user_scanner.core.helpers import _get_config_path, load_config, save_config_value
+
+
+def test_loud_module_config_value():
+    actual_path = _get_config_path()
+    data = load_config(path=actual_path)
+    status = data.get("auto_loud_single_module_prompt")
+    assert status is True, f"FAIL: Actual config at {actual_path} has auto_loud_single_module_prompt set to {status} (Expected: True)"
+
+
+def test_check_loud_module_permission_tty_yes(monkeypatch):
+    monkeypatch.setattr(loud_prompt.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    monkeypatch.setattr(loud_prompt, "load_config", lambda: {"auto_loud_single_module_prompt": True})
+    assert loud_prompt.check_loud_module_permission("Netflix", "test@example.com") is True
+
+
+def test_check_loud_module_permission_tty_no(monkeypatch):
+    monkeypatch.setattr(loud_prompt.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    monkeypatch.setattr(loud_prompt, "load_config", lambda: {"auto_loud_single_module_prompt": True})
+    assert loud_prompt.check_loud_module_permission("Netflix", "test@example.com") is False
+
+
+def test_check_loud_module_permission_tty_dont_ask(monkeypatch):
+    saved = {}
+    monkeypatch.setattr(loud_prompt.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "d")
+    monkeypatch.setattr(loud_prompt, "load_config", lambda: {"auto_loud_single_module_prompt": True})
+    monkeypatch.setattr(loud_prompt, "update_loud_module_preference", lambda v: saved.setdefault("value", v))
+    assert loud_prompt.check_loud_module_permission("Netflix", "test@example.com") is True
+    assert saved["value"] is False
+
+
+def test_check_loud_module_permission_no_tty(monkeypatch):
+    monkeypatch.setattr(loud_prompt.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(loud_prompt, "load_config", lambda: {"auto_loud_single_module_prompt": True})
+    called = []
+    monkeypatch.setattr("builtins.input", lambda *_: called.append(True))
+    assert loud_prompt.check_loud_module_permission("Netflix", "test@example.com") is False
+    assert called == []  # input() never invoked
+
+
+def test_check_loud_module_permission_saved_preference(monkeypatch):
+    monkeypatch.setattr(loud_prompt, "load_config", lambda: {"auto_loud_single_module_prompt": False})
+    called = []
+    monkeypatch.setattr("builtins.input", lambda *_: called.append(True))
+    assert loud_prompt.check_loud_module_permission("Netflix", "test@example.com") is True
+    assert called == []
+
+def test_save_config_value_preserves_loud_module_key(tmp_path):
+    config_file = tmp_path / "test_save.json"
+
+    # Updating an unrelated key must not disturb auto_loud_single_module_prompt
+    save_config_value("auto_update_status", False, path=config_file)
+    data = load_config(path=config_file)
+    assert data["auto_loud_single_module_prompt"] is True
+
+    # Explicitly flipping it should persist correctly and not affect others
+    save_config_value("auto_loud_single_module_prompt", False, path=config_file)
+    data = load_config(path=config_file)
+    assert data["auto_loud_single_module_prompt"] is False
+    assert data["auto_update_status"] is False

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -25,13 +25,14 @@ from user_scanner.core.helpers import (
     load_categories,
     load_modules,
     set_proxy_manager,
+    find_category,
 )
 from user_scanner.core.orchestrator import (
     run_user_category,
     run_user_full,
     run_user_module,
 )
-from user_scanner.core.result import Status
+from user_scanner.core.result import Result, Status
 from user_scanner.core.version import load_local_version
 from user_scanner.core.hudson import run_hudson_scan
 from user_scanner.utils.update import update_self
@@ -406,6 +407,14 @@ def main():
                 site_name = get_site_name(module)
                 if not config.allow_loud and is_loud(site_name, is_email):
                     if not check_loud_module_permission(site_name, target):
+                        skipped = Result.skipped().update(
+                            site_name=site_name,
+                            username=target,
+                            category=find_category(module) or "Unknown",
+                            is_email=is_email,
+                        )
+                        skipped.show(config)
+                        results.append(skipped)
                         continue
                     per_module_config = replace(config, allow_loud=True)
                     results.extend(fn(module, target, per_module_config))

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -36,7 +36,7 @@ from user_scanner.core.version import load_local_version
 from user_scanner.core.hudson import run_hudson_scan
 from user_scanner.utils.update import update_self
 from user_scanner.utils.updater_logic import check_for_updates
-
+from user_scanner.core.loud_prompt import check_loud_module_permission
 from user_scanner.core.patterns import expand_patterns_random, count_patterns
 
 # Color configs
@@ -402,9 +402,15 @@ def main():
 
         if args.module:
             fn = run_email_module_batch if is_email else run_user_module
-            module_config = replace(config, allow_loud=True)
             for module in validated_modules:
-                results.extend(fn(module, target, module_config))
+                site_name = get_site_name(module)
+                if not config.allow_loud and is_loud(site_name, is_email):
+                    if not check_loud_module_permission(site_name, target):
+                        continue
+                    per_module_config = replace(config, allow_loud=True)
+                    results.extend(fn(module, target, per_module_config))
+                else:
+                    results.extend(fn(module, target, config))
 
         elif args.category:
             fn = run_email_category_batch if is_email else run_user_category

--- a/user_scanner/config.json
+++ b/user_scanner/config.json
@@ -1,5 +1,5 @@
 {
   "auto_update_status": true,
   "auto_hudson_prompt": true,
-  "auto_loud_single_module_prompt": false
+  "auto_loud_single_module_prompt": true
 }

--- a/user_scanner/config.json
+++ b/user_scanner/config.json
@@ -1,4 +1,5 @@
 {
   "auto_update_status": true,
-  "auto_hudson_prompt": true
+  "auto_hudson_prompt": true,
+  "auto_loud_single_module_prompt": false
 }

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -334,7 +334,8 @@ def load_config(path: str | Path | None = None) -> dict:
 
     default = {
         "auto_update_status": True,
-        "auto_hudson_prompt": True
+        "auto_hudson_prompt": True,
+        "auto_loud_single_module_prompt": True,
     }
     cp.parent.mkdir(parents=True, exist_ok=True)
     cp.write_text(json.dumps(default, indent=2))

--- a/user_scanner/core/loud_prompt.py
+++ b/user_scanner/core/loud_prompt.py
@@ -1,0 +1,54 @@
+import sys
+import json
+from colorama import Fore, Style
+from user_scanner.core.helpers import load_config, _get_config_path
+
+# Color configs
+R = Fore.RED
+G = Fore.GREEN
+C = Fore.CYAN
+Y = Fore.YELLOW
+X = Style.RESET_ALL
+
+
+def update_loud_module_preference(show_prompt: bool):
+    """Updates the config file using the existing helper logic."""
+    cp = _get_config_path()
+    content = load_config()
+    content["auto_loud_single_module_prompt"] = show_prompt
+    cp.write_text(json.dumps(content, indent=2))
+
+
+def check_loud_module_permission(site_name: str, target: str) -> bool:
+    """Disclaimers and prompts based on user config. Returns True if the
+    module should run, False if it should be skipped."""
+    config = load_config()
+
+    # If the user already set this to false, skip the prompt and run
+    if not config.get("auto_loud_single_module_prompt", True):
+        print(f"{Y}[i] '{site_name}' allowed via saved preference.{X}")
+        return True
+
+    # Non-interactive session, nowhere to prompt, don't risk a silent notify
+    if not sys.stdin.isatty():
+        print(f"{Y}[i] '{site_name}' is a loud module and was skipped "
+              f"(non-interactive session, pass --allow-loud to run it).{X}")
+        return False
+
+    print(f"\n{Y}[!] LOUD MODULE WARNING:{X}")
+    print(f"    '{site_name}' is known to notify the target when queried (e.g. password reset email).")
+    print(f"    By proceeding, '{C}{target}{Y}' may be alerted that they were scanned.{X}")
+
+    while True:
+        choice = input(f"\n{C}Run '{site_name}' anyway? (y/n/d for don't ask again): {X}").lower().strip()
+        if choice == 'y':
+            return True
+        elif choice == 'n':
+            print(f"{Y}[i] '{site_name}' skipped.{X}")
+            return False
+        elif choice == 'd':
+            update_loud_module_preference(False)
+            print(f"{G}[+] Preference saved. You won't be prompted again for loud modules.{X}")
+            return True
+        else:
+            print(f"{R}[!] Please enter 'y', 'n', or 'd'.{X}")

--- a/user_scanner/core/loud_prompt.py
+++ b/user_scanner/core/loud_prompt.py
@@ -37,7 +37,7 @@ def check_loud_module_permission(site_name: str, target: str) -> bool:
 
     print(f"\n{Y}[!] LOUD MODULE WARNING:{X}")
     print(f"    '{site_name}' is known to notify the target when queried (e.g. password reset email).")
-    print(f"    By proceeding, '{C}{target}{Y}' may be alerted that they were scanned.{X}")
+    print(f"    By proceeding, '{C}{target}{Y}' may receive a password reset or verification email.{X}")
 
     while True:
         choice = input(f"\n{C}Run '{site_name}' anyway? (y/n/d for don't ask again): {X}").lower().strip()


### PR DESCRIPTION
Fixes #463

## Problem
`-m/--module` unconditionally forced `allow_loud=True`, silently overriding
the user's actual `--allow-loud` setting. Scanning a loud module via `-m`
(e.g. `user-scanner -e target@example.com -m netflix`) could send a real
notification to the target with zero warning, even without `--allow-loud`.
This was inconsistent with the `-c/--category` path, which correctly
respects it.

## Fix
Rather than just dropping the override (which would silently skip loud
modules on `-m` with no explanation), this adds a TTY-aware consent prompt,
following the existing `hudson.py` pattern:

- Loud module + no `--allow-loud` + interactive TTY → warning + `(y/n/d)` prompt
  - `y` → run once
  - `n` → skip
  - `d` → run once, save `auto_loud_single_module_prompt: false` to `config.json`
- Loud module + no `--allow-loud` + non-interactive (CI/piped, no TTY) → skip immediately with a printed warning, no hang
- `--allow-loud` passed, or saved preference set → runs without prompting, with a one-line log noting it was allowed

Skipped modules now also produce a `Result.skipped()` (same shape the
orchestrator already builds for the `-c` path),

Non-loud modules and `-c/--category` scans are unaffected.

## Note for reviewer
Loud-module prompting happens per-target inside the target loop, so a
multi-target `-m` scan (e.g. 5 targets) will prompt once per target rather
than once overall. This felt like the safer default since each target has
independent notify risk, but flagging it in case you'd prefer it prompt
once per module across all targets instead.

## Changes
- `user_scanner/core/loud_prompt.py` (new) — `check_loud_module_permission()`, `update_loud_module_preference()`
- `user_scanner/core/helpers.py` — added `auto_loud_single_module_prompt` to default config
- `user_scanner/config.json` — added the new default key (`true`)
- `user_scanner/__main__.py` — replaced blanket `allow_loud=True` override in `-m` handling with per-module consent check + proper skipped-result reporting

## Testing
Manually verified:
- `-m netflix` interactively → prompt appears, `y`/`n`/`d` behave as expected
- `-m netflix` piped/non-interactive (`< /dev/null`) → skips immediately, no hang
- `-m netflix --allow-loud` → runs directly, no prompt
- After `d`, `config.json` persists the preference and subsequent runs skip the prompt with a one-line log

No existing tests cover `-m` handling in `__main__.py`.