### PR TITLE
fix: flipboard email module false positives

### DIFF
--- a/user_scanner/email_scan/news/flipboard.py
+++ b/user_scanner/email_scan/news/flipboard.py
@@ -32,11 +32,25 @@ async def _check(email: str) -> Result:
                 return Result.error("Rate limited", url=show_url)
 
             data = response.json()
+            success = data.get("success")
+            valid = data.get("valid")
+            errorcode = data.get("errorcode")
+            reason = data.get("reason", "")
+            code = data.get("code")
 
-            if data.get("success") is True:
-                if data.get("errorcode") == 3109:
+            if success is True:
+                # 3109 means another account is already associated with this email.
+                if errorcode == 3109:
                     return Result.taken(url=show_url)
-                return Result.available(url=show_url)
+                # 3108 means Flipboard rejected the address itself, not that it is registered.
+                if errorcode == 3108:
+                    return Result.available(url=show_url, reason=reason)
+                if valid is True and errorcode is None and code == 200:
+                    return Result.available(url=show_url)
+                return Result.error(
+                    f"Unexpected Flipboard email response {errorcode}: {reason}",
+                    url=show_url,
+                )
 
             return Result.error("Unexpected JSON response from Flipboard, report it via GitHub issues", url=show_url)
 

--- a/user_scanner/email_scan/news/flipboard.py
+++ b/user_scanner/email_scan/news/flipboard.py
@@ -34,10 +34,9 @@ async def _check(email: str) -> Result:
             data = response.json()
 
             if data.get("success") is True:
-                if data.get("valid") is False:
+                if data.get("errorcode") == 3109:
                     return Result.taken(url=show_url)
-                elif data.get("valid") is True:
-                    return Result.available(url=show_url)
+                return Result.available(url=show_url)
 
             return Result.error("Unexpected JSON response from Flipboard, report it via GitHub issues", url=show_url)
 


### PR DESCRIPTION
The Flipboard email module currently reports all invalid responses as taken emails, which causes false positives with email domains, which, I assume, have been blacklisted. This PR tightens the check to only report a taken email address when Flipboard responds with error code 3109.

Previously false positive email to test with: asddfgdfdgdg@tutanota.com