### PR TITLE
fix: xnxx and xvideos email module false positives

### DIFF
--- a/user_scanner/email_scan/adult/xnxx.py
+++ b/user_scanner/email_scan/adult/xnxx.py
@@ -33,11 +33,14 @@ async def _check(email: str) -> Result:
 
             data = response.json()
             exists_bool = data.get("result")
+            message = data.get("message", "")
 
             if exists_bool is True:
                 return Result.available(url=show_url)
             elif exists_bool is False:
-                return Result.taken(url=show_url)
+                if message == "This email is already in use or its owner has excluded it from our website.":
+                    return Result.taken(url=show_url)
+                return Result.available(url=show_url, reason=message)
             else:
                 return Result.error("Unexpected error, report it via GitHub issues")
 

--- a/user_scanner/email_scan/adult/xvideos.py
+++ b/user_scanner/email_scan/adult/xvideos.py
@@ -35,11 +35,14 @@ async def _check(email: str) -> Result:
             data = response.json()
 
             exists_bool = data.get("result")
+            message = data.get("message", "")
 
             if exists_bool is True:
                 return Result.available(url=show_url)
             elif exists_bool is False:
-                return Result.taken(url=show_url)
+                if message == "This email is already in use or its owner has excluded it from our website.":
+                    return Result.taken(url=show_url)
+                return Result.available(url=show_url, reason=message)
             else:
                 return Result.error("Unexpected error, report it via GitHub issues")
 


### PR DESCRIPTION
The XNXX and XVideos email modules currently report all error messages as taken emails, which causes false positives with email domains, which have been blacklisted. This PR tightens the checks to only report a taken email address when  error messages specifically mention in-use emails.

Previously false positive email to test with: asdgtgffgffhg@bk.ru