### PR TITLE
fix: RedTube, Tube8, YouPorn email module false positives

### DIFF
--- a/user_scanner/email_scan/adult/redtube.py
+++ b/user_scanner/email_scan/adult/redtube.py
@@ -1,6 +1,6 @@
 import httpx
 import re
-from user_scanner.core.helpers import is_valid_email
+import secrets
 from user_scanner.core.result import Result
 
 RATE_LIMITED_MSG = "Rate limited, wait for a few minutes"
@@ -35,32 +35,32 @@ async def _check(email: str) -> Result:
 
             token = token_match.group(1)
 
-            params = {"token": token}
-            payload = {
-                "token": token,
-                "check_what": "email",
-                "email": email,
-            }
+            async def check(address: str) -> dict | Result:
+                response = await client.post(
+                    check_api,
+                    params={"token": token},
+                    headers=headers,
+                    data={"token": token, "check_what": "email", "email": address},
+                )
 
-            response = await client.post(
-                check_api,
-                params=params,
-                headers=headers,
-                data=payload,
-            )
+                if response.status_code == 429:
+                    return Result.error(RATE_LIMITED_MSG)
 
-            if response.status_code == 429:
-                return Result.error(RATE_LIMITED_MSG)
+                if response.status_code != 200:
+                    return Result.error(f"HTTP Error: {response.status_code}")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+                data = response.json()
 
-            data = response.json()
+                # An anti-abuse throttle answers with a bare "NOK" / "NOK <n>" string
+                # instead of the usual JSON object.
+                if not isinstance(data, dict):
+                    return Result.error(RATE_LIMITED_MSG)
 
-            # An anti-abuse throttle answers with a bare "NOK" / "NOK <n>" string
-            # instead of the usual JSON object.
-            if not isinstance(data, dict):
-                return Result.error(RATE_LIMITED_MSG)
+                return data
+
+            data = await check(email)
+            if isinstance(data, Result):
+                return data
 
             status = data.get("email")
             error_msg = data.get("error_message", "")
@@ -71,9 +71,14 @@ async def _check(email: str) -> Result:
             if status == "create_account_failed":
                 if "already registered" in error_msg:
                     return Result.taken(url=show_url)
-                # For a well-formed address, RedTube reports an existing account
-                # by refusing registration rather than saying it's taken.
-                if "does not meet our registration requirements" in error_msg and is_valid_email(email):
+                if "does not meet our registration requirements" in error_msg:
+                    domain = email.rsplit("@", 1)[-1]
+                    probe = await check(f"{secrets.token_hex(16)}@{domain}")
+                    if isinstance(probe, Result):
+                        return probe
+                    probe_error = probe.get("error_message", "")
+                    if "does not meet our registration requirements" in probe_error:
+                        return Result.available(url=show_url, reason=error_msg)
                     return Result.taken(url=show_url)
                 return Result.available(url=show_url, reason=error_msg)
 

--- a/user_scanner/email_scan/adult/tube8.py
+++ b/user_scanner/email_scan/adult/tube8.py
@@ -1,6 +1,6 @@
 import httpx
 import re
-from user_scanner.core.helpers import is_valid_email
+import secrets
 from user_scanner.core.result import Result
 
 RATE_LIMITED_MSG = "Rate limited, wait for a few minutes"
@@ -32,23 +32,25 @@ async def _check(email: str) -> Result:
 
             token = token_match.group(1)
 
-            params = {"token": token}
-            payload = {"token": token, "email": email}
+            async def check(address: str) -> dict | Result:
+                response = await client.post(
+                    check_api,
+                    params={"token": token},
+                    headers=headers,
+                    data={"token": token, "email": address},
+                )
 
-            response = await client.post(
-                check_api,
-                params=params,
-                headers=headers,
-                data=payload,
-            )
+                if response.status_code == 429:
+                    return Result.error(RATE_LIMITED_MSG)
 
-            if response.status_code == 429:
-                return Result.error(RATE_LIMITED_MSG)
+                if response.status_code != 200:
+                    return Result.error(f"HTTP Error: {response.status_code}")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+                return response.json()
 
-            data = response.json()
+            data = await check(email)
+            if isinstance(data, Result):
+                return data
 
             if data.get("success") is True:
                 return Result.available(url=show_url)
@@ -56,12 +58,22 @@ async def _check(email: str) -> Result:
             messages = data.get("messages", [])
             message = " ".join(messages) if isinstance(messages, list) else str(messages)
 
-            # A well-formed address that fails the requirements check is Tube8's
-            # way of reporting an existing account rather than saying it's taken.
             if "does not meet our registration requirements" in message:
-                if is_valid_email(email):
-                    return Result.taken(url=show_url)
-                return Result.available(url=show_url, reason=message)
+                domain = email.rsplit("@", 1)[-1]
+                probe = await check(f"{secrets.token_hex(16)}@{domain}")
+                if isinstance(probe, Result):
+                    return probe
+                probe_messages = probe.get("messages", [])
+                probe_message = (
+                    " ".join(probe_messages)
+                    if isinstance(probe_messages, list)
+                    else str(probe_messages)
+                )
+                if "does not meet our registration requirements" in probe_message:
+                    return Result.available(url=show_url, reason=message)
+                if "not available" in probe_message.lower():
+                    return Result.error(RATE_LIMITED_MSG)
+                return Result.taken(url=show_url)
 
             # A stale or over-used token answers "Not available." instead of a verdict.
             if "not available" in message.lower():

--- a/user_scanner/email_scan/adult/youporn.py
+++ b/user_scanner/email_scan/adult/youporn.py
@@ -1,6 +1,6 @@
 import httpx
 import re
-from user_scanner.core.helpers import is_valid_email
+import secrets
 from user_scanner.core.result import Result
 
 RATE_LIMITED_MSG = "Rate limited, wait for a few minutes"
@@ -32,23 +32,25 @@ async def _check(email: str) -> Result:
 
             token = token_match.group(1)
 
-            params = {"token": token}
-            payload = {"token": token, "email": email}
+            async def check(address: str) -> dict | Result:
+                response = await client.post(
+                    check_api,
+                    params={"token": token},
+                    headers=headers,
+                    data={"token": token, "email": address},
+                )
 
-            response = await client.post(
-                check_api,
-                params=params,
-                headers=headers,
-                data=payload,
-            )
+                if response.status_code == 429:
+                    return Result.error(RATE_LIMITED_MSG)
 
-            if response.status_code == 429:
-                return Result.error(RATE_LIMITED_MSG)
+                if response.status_code != 200:
+                    return Result.error(f"HTTP Error: {response.status_code}")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+                return response.json()
 
-            data = response.json()
+            data = await check(email)
+            if isinstance(data, Result):
+                return data
 
             if data.get("success") is True:
                 return Result.available(url=show_url)
@@ -56,12 +58,22 @@ async def _check(email: str) -> Result:
             messages = data.get("messages", [])
             message = " ".join(messages) if isinstance(messages, list) else str(messages)
 
-            # A well-formed address that fails the requirements check is YouPorn's
-            # way of reporting an existing account rather than saying it's taken.
             if "does not meet our registration requirements" in message:
-                if is_valid_email(email):
-                    return Result.taken(url=show_url)
-                return Result.available(url=show_url, reason=message)
+                domain = email.rsplit("@", 1)[-1]
+                probe = await check(f"{secrets.token_hex(16)}@{domain}")
+                if isinstance(probe, Result):
+                    return probe
+                probe_messages = probe.get("messages", [])
+                probe_message = (
+                    " ".join(probe_messages)
+                    if isinstance(probe_messages, list)
+                    else str(probe_messages)
+                )
+                if "does not meet our registration requirements" in probe_message:
+                    return Result.available(url=show_url, reason=message)
+                if "not available" in probe_message.lower():
+                    return Result.error(RATE_LIMITED_MSG)
+                return Result.taken(url=show_url)
 
             # A stale or over-used token answers "Not available." instead of a verdict.
             if "not available" in message.lower():


### PR DESCRIPTION
This PR fixes false positives in the RedTube email module, and possibly in the Tube8 and YouPorn modules as well, since they use the same detection mechanism.

The modules previously always interpreted "The email address provided does not meet our registration requirements." error messages as taken emails for well-formed email addresses, but this produced false positives for email domains, which, I assume, have been blacklisted. 

As there aren't any better indicators to go by, the fix is quite unorthodox: in case of a suspicious error message, we generate a random email address on the same domain. If the random email also receives the same response, the domain is most likely blacklisted; otherwise, the email is actually taken.

Previously false positive test case:
`user-scanner -m redtube -e asdgtgffgffhg@zohomail.com`

Sadly I'm not aware of any true positive emails.