### PR TITLE
fix: YouTube username module false positives

### DIFF
--- a/user_scanner/user_scan/social/youtube.py
+++ b/user_scanner/user_scan/social/youtube.py
@@ -1,10 +1,13 @@
-from user_scanner.core.orchestrator import Result, make_request
-import re
 import json
+import re
+
+import httpx
+
+from user_scanner.core.orchestrator import Result, make_request
 
 
 def validate_youtube(user) -> Result:
-    url = f"https://www.youtube.com/@{user}"
+    url = f"https://www.youtube.com/@{user}?cbrd=1&ucbcb=1"
     show_url = f"https://youtube.com/@{user}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
@@ -16,31 +19,40 @@ def validate_youtube(user) -> Result:
         if response.status_code == 200:
             if "This channel does not exist" in response.text or "404 Not Found" in response.text:
                 return Result.available(url=show_url)
-            
+
             extra = {}
-            m = re.search(r'var ytInitialData = (\{.*?\});', response.text)
-            if m:
-                try:
-                    data = json.loads(m.group(1))
-                    meta = data.get('metadata', {}).get('channelMetadataRenderer', {})
-                    if title := meta.get('title'): extra['fullname'] = title
-                    if desc := meta.get('description'): extra['bio'] = desc
-                    if cid := meta.get('externalId'): extra['youtube_channel_id'] = cid
-                    if purl := meta.get('vanityChannelUrl'): extra['channel_url'] = purl
-                    if safe := meta.get('isFamilySafe'): extra['is_family_safe'] = str(safe)
-                    if kw := meta.get('keywords'): extra['keywords'] = kw
-                    if thumbs := meta.get('avatar', {}).get('thumbnails'):
-                        if len(thumbs) > 0: extra['image'] = thumbs[0].get('url')
-                except Exception:
-                    pass
-                    
+            marker = "var ytInitialData = "
+            start = response.text.find(marker)
+            if start == -1:
+                return Result.error("Could not confirm YouTube channel", url=show_url)
+
+            try:
+                data = json.JSONDecoder().raw_decode(response.text[start + len(marker) :])[0]
+                meta = data.get("metadata", {}).get("channelMetadataRenderer", {})
+                channel_id = meta.get("externalId")
+                if not re.fullmatch(r"UC[\w-]+", channel_id or ""):
+                    return Result.error("Could not confirm YouTube channel", url=show_url)
+                extra["youtube_channel_id"] = channel_id
+                extra["channel_url"] = f"https://www.youtube.com/channel/{channel_id}"
+                if title := meta.get("title"):
+                    extra["fullname"] = title
+                if desc := meta.get("description"):
+                    extra["bio"] = desc
+                if keywords := meta.get("keywords"):
+                    extra["keywords"] = keywords
+                if thumbs := meta.get("avatar", {}).get("thumbnails"):
+                    extra["image"] = thumbs[0].get("url")
+            except json.JSONDecodeError:
+                return Result.error("Could not confirm YouTube channel", url=show_url)
+
             subs = re.search(r'\"content\":\"([0-9.]+[A-Z]? subscribers)\"', response.text)
-            if subs: extra['subscribers'] = subs.group(1)
-            
+            if subs:
+                extra["subscribers"] = subs.group(1)
+
             return Result.taken(extra=extra, url=show_url)
         elif response.status_code == 404:
             return Result.available(url=show_url)
         else:
             return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
+    except httpx.HTTPError as e:
         return Result.error(e, url=show_url)


### PR DESCRIPTION
This PR fixes the YouTube username module reporting false positives with all usernames. The module currently reports the username as taken whenever the visited page does not explicitly say that the user does not exist. However, at least in my case, the request does not even reach the actual target as it is redirected to a YouTube consent page, and the module considers this valid.

1. adds `?cbrd=1&ucbcb=1` query parameters, which skip the YouTube consent page and go directly to the user profile or 404 page
2. only reports the username as taken if there are clear indications of it; reports an error in case of an ambiguous state

I think I have patched all false positives I've discovered now.