### PR TITLE
feat: default to found-only results and introduce --all flag, progress bar with rich

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install httpx curl_cffi colorama types-colorama
+          pip install httpx curl_cffi colorama types-colorama rich
           pip install ruff==0.15.22 mypy
 
       - name: Run ruff

--- a/.github/workflows/lint-push.yml
+++ b/.github/workflows/lint-push.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install httpx curl_cffi colorama types-colorama
+          pip install httpx curl_cffi colorama types-colorama rich
           pip install ruff==0.15.22 mypy
 
       - name: Run ruff

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ user-scanner -u johndoe             # single username scanning
 ```
 ### Verbose mode 
 
-Use `-v` flag to show the url of the sites being checked
+Use `-v` flag to show the url of the sites being checked.
+Use `--all` flag to show all sites (including those where the target was not found, skipped, or errored).
+Note: By default, the scanner only displays sites where the target is found/registered.
 ```bash
 user-scanner -v -e johndoe@gmail.com -c dev
 ```

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -6,7 +6,6 @@
 | `-e, --email EMAIL`         | Scan a single email across platforms                        |
 | `-uf, --username-file FILE` | Scan multiple usernames from file (one per line)            |
 | `-ef, --email-file FILE`    | Scan multiple emails from file (one per line)               |
-| `--only-found`              | Only show sites where the username/email was found          |
 | `--allow-loud`              | Enable scanning sites that may send emails/notifications    |
 | `--no-nsfw`                 | Disable NSFW site scanning                                  |
 | `--hudson, --hudson-scan`   | Check for infostealer intelligence using Hudson Rock's API  |
@@ -14,6 +13,7 @@
 | `-lu, --list-user`          | List all available modules for username scanning            |
 | `-le, --list-email`         | List all available modules for email scanning               |
 | `-v, --verbose`             | Enable verbose output to show urls of the websites          |
+| `--all`                     | Show all results including Not Found/Not Registered/Error/Skipped |
 | `-m, --module MODULE`       | Scan a specific module (comma-separated for multiple)                    |
 | `-p, --permute PERMUTE`     | Generate username permutations using a pattern/suffix       |
 | `-P, --proxy-file FILE`     | Use proxies from file (one per line)                        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "httpx[http2]>=0.27,<0.29",
   "socksio>=1.0,<2",
   "colorama>=0.4,<1",
-  "curl_cffi>=0.7,<1"
+  "curl_cffi>=0.7,<1",
+  "rich>=13.0.0"
 ]
 
 requires-python = ">=3.10"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -26,7 +26,7 @@ def test_run_module_single_prints_json_and_csv(capsys):
 
     setattr(module, "validate_testsite", validate_testsite)
 
-    orchestrator.run_user_module(module, "bob", ScanConfig())
+    orchestrator.run_user_module(module, "bob", ScanConfig(show_all=True))
     out = capsys.readouterr().out
     assert "bob" in out  # Needs to be improved
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -287,13 +287,20 @@ def test_get_output_color_and_icon_per_status():
     assert Result.skipped().get_output_icon() == "[~]"
 
 
-def test_show_only_found_filters_non_taken(capsys):
-    conf = ScanConfig(only_found=True)
+def test_show_default_filters_non_taken(capsys):
+    conf = ScanConfig()
 
     Result.available(site_name="HiddenSite").show(conf)
     assert capsys.readouterr().out == ""
 
     Result.taken(site_name="VisibleSite").show(conf)
+    assert "VisibleSite" in capsys.readouterr().out
+
+
+def test_show_all_displays_non_taken(capsys):
+    conf = ScanConfig(show_all=True)
+
+    Result.available(site_name="VisibleSite").show(conf)
     assert "VisibleSite" in capsys.readouterr().out
 
 

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -51,6 +51,12 @@ MAX_PERMUTATIONS_LIMIT = 100
 
 
 def main():
+    if "--only-found" in sys.argv:
+        print(f"{Fore.YELLOW}[!] The '--only-found' flag is deprecated and has been removed.{Style.RESET_ALL}")
+        print(f"{Fore.YELLOW}[!] Showing only found modules is now the DEFAULT behavior.{Style.RESET_ALL}")
+        print(f"{Fore.YELLOW}[!] To show all results, use the '--all' flag.{Style.RESET_ALL}")
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(
         prog="user-scanner",
         description="Scan usernames or emails across multiple platforms.",
@@ -91,6 +97,12 @@ def main():
         "--verbose",
         action="store_true",
         help="Enable verbose output to show urls of the websites",
+    )
+
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all results including Not Found/Not Registered/Error/Skipped.",
     )
 
     parser.add_argument(
@@ -140,12 +152,6 @@ def main():
         "--validate-proxies",
         action="store_true",
         help="Validate proxies before scanning (tests against gstatic.com/generate_204)",
-    )
-
-    parser.add_argument(
-        "--only-found",
-        action="store_true",
-        help="Only show sites where the username/email was found",
     )
 
     parser.add_argument(
@@ -339,7 +345,7 @@ def main():
 
     config = ScanConfig(
         allow_loud=args.allow_loud,
-        only_found=args.only_found,
+        show_all=args.all,
         no_nsfw=args.no_nsfw,
         verbose=args.verbose,
         timeout=args.timeout,
@@ -515,7 +521,7 @@ def main():
     total_found = len([r for r in results if r.is_found()])
     total_skipped = len([r for r in results if r.status == Status.SKIPPED])
 
-    if args.only_found and total_found == 0:
+    if not config.show_all and total_found == 0:
         print(f"\n{R}[✘] No results found for the given target(s).{X}")
     else:
         print(f"\n{C}[i] Scan complete.\n  Total hits:{X} {total_found}")

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -188,7 +188,7 @@ def run_email_category_batch(
 async def _run_email_full_batch_async(email: str, configs: ScanConfig) -> List[Result]:
     categories = load_categories(True, configs.no_nsfw)
     all_results = []
-    printed_cats = set()
+    printed_cats: Set[str] = set()
 
     # 1. Pre-spawn all tasks for all categories (global concurrency)
     category_tasks = []

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -18,6 +18,7 @@ from user_scanner.core.helpers import (
     get_global_timeout,
 )
 from user_scanner.core.result import Result, Status
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, MofNCompleteColumn
 
 # Monkey-patch httpx clients to automatically use proxies for email scans
 _original_async_client_init = httpx.AsyncClient.__init__
@@ -128,7 +129,25 @@ async def _run_batch(
 
     if not tasks:
         return []
-    return list(await asyncio.gather(*tasks))
+
+    results = []
+    
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(f"[cyan]Scanning {email}...", total=len(tasks))
+
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            results.append(result)
+            progress.advance(task_id)
+
+    return results
 
 
 async def _run_email_module_batch_async(
@@ -171,20 +190,51 @@ async def _run_email_full_batch_async(email: str, configs: ScanConfig) -> List[R
     all_results = []
     printed_cats = set()
 
+    # 1. Pre-spawn all tasks for all categories (global concurrency)
+    category_tasks = []
+    total_tasks = 0
     for cat_name, cat_path in categories.items():
+        display_name = cat_name.capitalize()
         modules = load_modules(cat_path)
+        
+        sem = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+        tasks = []
+        for module in modules:
+            tasks.append(
+                _async_worker(
+                    module,
+                    email,
+                    sem,
+                    configs,
+                    printed_cats=printed_cats,
+                )
+            )
+        category_tasks.append((display_name, tasks))
+        total_tasks += len(tasks)
 
-        if configs.show_all:
-            print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
-            printed_cats.add(cat_name)
-
-        cat_results = await _run_batch(
-            modules,
-            email,
-            configs,
-            printed_cats=printed_cats,
-        )
-        all_results.extend(cat_results)
+    # 2. Await tasks category by category to stream grouped output
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(f"[cyan]Scanning {email}...", total=total_tasks)
+        
+        for display_name, tasks in category_tasks:
+            if not tasks:
+                continue
+                
+            if configs.show_all:
+                print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
+                printed_cats.add(display_name)
+                
+            for coro in asyncio.as_completed(tasks):
+                result = await coro
+                all_results.append(result)
+                progress.advance(task_id)
 
     return all_results
 

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -96,8 +96,8 @@ async def _async_worker(
 
         result.update(**params)
 
-        # Logic to print header dynamically for --only-found streaming
-        if configs.only_found and result.status == Status.TAKEN:
+        # Logic to print header dynamically for --show-all streaming
+        if not configs.show_all and result.status == Status.TAKEN:
             if printed_cats is not None and actual_cat not in printed_cats:
                 print(
                     f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}"
@@ -149,7 +149,7 @@ async def _run_email_category_batch_async(
     modules = load_modules(category_path)
     printed_cats = set()
 
-    if not configs.only_found:
+    if configs.show_all:
         print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
         printed_cats.add(cat_name)
 
@@ -174,7 +174,7 @@ async def _run_email_full_batch_async(email: str, configs: ScanConfig) -> List[R
     for cat_name, cat_path in categories.items():
         modules = load_modules(cat_path)
 
-        if not configs.only_found:
+        if configs.show_all:
             print(f"\n{Fore.MAGENTA}== {cat_name.upper()} SITES =={Style.RESET_ALL}")
             printed_cats.add(cat_name)
 

--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -60,7 +60,7 @@ CONFIG_PATH = Path(__file__).parent.parent / "config.json"
 class ScanConfig:
     allow_loud: bool = False
     no_nsfw: bool = False
-    only_found: bool = False
+    show_all: bool = False
     verbose: bool = False
     timeout: Optional[float] = None
 

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -20,7 +20,7 @@ from user_scanner.core.helpers import (
     load_modules,
     get_global_timeout,
 )
-from user_scanner.core.result import Result, Status
+from user_scanner.core.result import Result
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, MofNCompleteColumn
 
 

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -20,7 +20,8 @@ from user_scanner.core.helpers import (
     load_modules,
     get_global_timeout,
 )
-from user_scanner.core.result import Result
+from user_scanner.core.result import Result, Status
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, MofNCompleteColumn
 
 
 MAX_CONCURRENT_REQUESTS = 60
@@ -88,18 +89,30 @@ async def _run_batch(
         )
 
     results = []
-    for coro in asyncio.as_completed(tasks):
-        result = await coro
-        
-        actual_cat = result.category or "Unknown"
-        # Handle specific logic where skipping needs to happen early
-        if not configs.show_all and result.is_found():
-            if printed_cats is not None and actual_cat not in printed_cats:
-                print(f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}")
-                printed_cats.add(actual_cat)
-                
-        result.show(configs)
-        results.append(result)
+    
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(f"[cyan]Scanning {username}...", total=len(tasks))
+
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            
+            actual_cat = result.category or "Unknown"
+            # Handle specific logic where skipping needs to happen early
+            if not configs.show_all and result.is_found():
+                if printed_cats is not None and actual_cat not in printed_cats:
+                    print(f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}")
+                    printed_cats.add(actual_cat)
+                    
+            result.show(configs)
+            results.append(result)
+            progress.advance(task_id)
         
     return results
 
@@ -140,6 +153,7 @@ async def _run_user_full_async(username: str, configs: ScanConfig) -> List[Resul
     
     # 1. Pre-spawn all tasks for all categories (global concurrency)
     category_tasks = []
+    total_tasks = 0
     for cat_name, cat_path in categories:
         display_name = cat_name.capitalize()
         modules = load_modules(cat_path)
@@ -151,26 +165,39 @@ async def _run_user_full_async(username: str, configs: ScanConfig) -> List[Resul
                 )
             )
         category_tasks.append((display_name, tasks))
+        total_tasks += len(tasks)
 
     # 2. Await tasks category by category to stream grouped output
-    for display_name, tasks in category_tasks:
-        if not tasks:
-            continue
-            
-        if configs.show_all:
-            print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
-            printed_cats.add(display_name)
-            
-        for coro in asyncio.as_completed(tasks):
-            result = await coro
-            
-            if not configs.show_all and result.is_found():
-                if display_name not in printed_cats:
-                    print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
-                    printed_cats.add(display_name)
-                    
-            result.show(configs)
-            all_results.append(result)
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(f"[cyan]Scanning {username}...", total=total_tasks)
+        
+        for display_name, tasks in category_tasks:
+            if not tasks:
+                continue
+                
+            if configs.show_all:
+                print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
+                printed_cats.add(display_name)
+                
+            for coro in asyncio.as_completed(tasks):
+                result = await coro
+                
+                if not configs.show_all and result.is_found():
+                    display_name = result.category or "Unknown"
+                    if display_name not in printed_cats:
+                        print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
+                        printed_cats.add(display_name)
+                        
+                result.show(configs)
+                all_results.append(result)
+                progress.advance(task_id)
 
     return all_results
 

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -92,7 +92,8 @@ async def _run_batch(
         result = await coro
         
         actual_cat = result.category or "Unknown"
-        if configs.only_found and result.is_found():
+        # Handle specific logic where skipping needs to happen early
+        if not configs.show_all and result.is_found():
             if printed_cats is not None and actual_cat not in printed_cats:
                 print(f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}")
                 printed_cats.add(actual_cat)
@@ -116,7 +117,7 @@ def run_user_category(
     modules = load_modules(category_path)
     printed_cats = set()
 
-    if not configs.only_found:
+    if configs.show_all:
         print(f"\n{Fore.MAGENTA}== {category_name.upper()} SITES =={Style.RESET_ALL}")
         printed_cats.add(category_name)
 
@@ -156,14 +157,14 @@ async def _run_user_full_async(username: str, configs: ScanConfig) -> List[Resul
         if not tasks:
             continue
             
-        if not configs.only_found:
+        if configs.show_all:
             print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
             printed_cats.add(display_name)
             
         for coro in asyncio.as_completed(tasks):
             result = await coro
             
-            if configs.only_found and result.is_found():
+            if not configs.show_all and result.is_found():
                 if display_name not in printed_cats:
                     print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")
                     printed_cats.add(display_name)

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -282,9 +282,9 @@ class Result:
 
     def show(self, configs: ScanConfig):
         """Prints the console output and returns itself for chaining.
-        If only_found is True, only results with Status.TAKEN are printed."""
+        If show_all is False, only results with Status.TAKEN are printed."""
         # Updated show() to accept and pass the show_url flag
-        if configs.only_found and self.status != Status.TAKEN:
+        if not configs.show_all and self.status != Status.TAKEN:
             return self
         print(self.get_console_output(configs))
         return self


### PR DESCRIPTION
- Rename only_found configuration parameter to show_all and default to False
- Intercept --only-found flag to warn users of deprecation and exit gracefully
- Add --all flag to allow users to view all results including targets that were not found or errored
- Update docs/FLAGS.md and README.md to reflect new flag behavior
- Update tests in test_orchestrator.py to account for new show_all=False default
---
- Add dynamic terminal progress bar using rich displaying live percentage and processed module counts
- Ensure progress bar cleans up seamlessly upon scan completion without leaving terminal artifacts
- Support progress bar across standard, category-specific, and module-specific username and email scans"