### PR TITLE
fix: reject usernames causing false positives in academia.edu module

### DIFF
--- a/user_scanner/user_scan/community/academia.py
+++ b/user_scanner/user_scan/community/academia.py
@@ -2,6 +2,9 @@ from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_academia(user: str) -> Result:
+    if "." in user:
+        return Result.available("Username cannot contain periods")
+
     url = f"https://independent.academia.edu/{user}"
     
     headers = {


### PR DESCRIPTION
Similar to #437, rejecting usernames with periods in the academia.edu module. The site does not allow usernames with periods, and ignores everything after the first period in profile URLs, causing false positives in the module.

Test case: https://independent.academia.edu/asdfg.fghfghhfhgfhgfghfghghfgh