### PR TITLE
fix: Bluesky username module false positives

### DIFF
--- a/user_scanner/user_scan/social/bluesky.py
+++ b/user_scanner/user_scan/social/bluesky.py
@@ -5,75 +5,39 @@ from user_scanner.core.result import Result
 
 def validate_bluesky(user):
     handle = user if user.endswith(".bsky.social") else f"{user}.bsky.social"
-    url = "https://bsky.social/xrpc/com.atproto.temp.checkHandleAvailability"
-    show_url = f"https://bsky.app/profile/{user}.bsky.social"
-
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept-Encoding": "gzip",
-        "atproto-accept-labelers": "did:plc:ar7c4by46qjdydhdevvrndac;redact",
-        "sec-ch-ua-platform": '"Android"',
-        "sec-ch-ua": '"Google Chrome";v="141", "Not?A_Brand";v="8", "Chromium";v="141"',
-        "sec-ch-ua-mobile": "?1",
-        "origin": "https://bsky.app",
-        "sec-fetch-site": "cross-site",
-        "sec-fetch-mode": "cors",
-        "sec-fetch-dest": "empty",
-        "referer": "https://bsky.app/",
-        "accept-language": "en-US,en;q=0.9",
-    }
-
-    params = {
-        "handle": handle,
-    }
+    url = "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile"
 
     def process(response):
         if response.status_code == 200:
             data = response.json()
-            result_type = data.get("result", {}).get("$type")
+            extra = {}
+            if data.get("displayName"):
+                extra["display_name"] = data["displayName"]
+            if data.get("description"):
+                extra["bio"] = data["description"].strip()
+            if data.get("followersCount") is not None:
+                extra["followers"] = data["followersCount"]
+            if data.get("followsCount") is not None:
+                extra["following"] = data["followsCount"]
+            if data.get("postsCount") is not None:
+                extra["posts"] = data["postsCount"]
+            if data.get("avatar"):
+                extra["avatar"] = data["avatar"]
+            return Result.taken(extra=extra)
 
-            if (
-                result_type
-                == "com.atproto.temp.checkHandleAvailability#resultAvailable"
-            ):
+        if response.status_code == 400:
+            message = response.json().get("message")
+            if message == "Profile not found":
                 return Result.available()
-            elif (
-                result_type
-                == "com.atproto.temp.checkHandleAvailability#resultUnavailable"
-            ):
-                extra = {}
-                try:
-                    import httpx
-                    profile_res = httpx.get(
-                        "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile",
-                        params={"actor": handle},
-                        headers={"User-Agent": headers["User-Agent"]},
-                        timeout=5.0
-                    )
-                    if profile_res.status_code == 200:
-                        p_data = profile_res.json()
-                        if p_data.get("displayName"):
-                            extra["display_name"] = p_data.get("displayName")
-                        if p_data.get("description"):
-                            extra["bio"] = p_data.get("description").strip()
-                        if p_data.get("followersCount") is not None:
-                            extra["followers"] = p_data.get("followersCount")
-                        if p_data.get("followsCount") is not None:
-                            extra["following"] = p_data.get("followsCount")
-                        if p_data.get("postsCount") is not None:
-                            extra["posts"] = p_data.get("postsCount")
-                        if p_data.get("avatar"):
-                            extra["avatar"] = p_data.get("avatar")
-                except Exception:
-                    pass
-                return Result.taken(extra=extra)
-        elif response.status_code == 400:
-            return Result.error(
-                "Username can only contain letters, numbers, hyphens (no leading/trailing)"
-            )
+            return Result.error(message or "Invalid Bluesky handle")
 
-        return Result.error("Invalid status code!")
+        return Result.error(f"HTTP {response.status_code}")
 
     return generic_validate(
-        url, process, show_url=show_url, headers=headers, params=params, timeout=15.0
+        url,
+        process,
+        show_url=f"https://bsky.app/profile/{handle}",
+        headers={"User-Agent": get_random_user_agent()},
+        params={"actor": handle},
+        timeout=15.0,
     )

--- a/user_scanner/user_scan/social/bluesky.py
+++ b/user_scanner/user_scan/social/bluesky.py
@@ -31,7 +31,7 @@ def validate_bluesky(user):
                 return Result.available()
             return Result.error(message or "Invalid Bluesky handle")
 
-        return Result.error(f"HTTP {response.status_code}")
+        return Result.error(f"HTTP {response.status_code}, report it via GitHub issues")
 
     return generic_validate(
         url,


### PR DESCRIPTION
This PR fixes false positives in the Bluesky username module. In addition to taken usernames, the currently used "checkHandleAvailability" RPC call also rejects usernames that are invalid for other reasons.

I removed the "checkHandleAvailability" RPC call, instead checking username availability using the "getProfile" RPC, which was already used to fetch enrichments. As a result, the module also became much simpler.

Previously false positive test case:
`user-scanner -u dgfghhfghfgfghijogh --verbose -m bluesky`