### PR TITLE
fix(facebook): update stale unavailable marker string

### DIFF
--- a/user_scanner/user_scan/social/facebook.py
+++ b/user_scanner/user_scan/social/facebook.py
@@ -8,8 +8,7 @@ PROFILE_TITLE_RE = re.compile(r'<meta property="og:title" content="[^"]+"')
 PROFILE_URL_RE = re.compile(
     r'<meta property="og:url" content="https://www\.facebook\.com/[^"]+"'
 )
-UNAVAILABLE_MARKER = "This content isn't available right now"
-
+UNAVAILABLE_MARKER = "This content isn't available at the moment"
 
 def _process_profile_response(status_code: int, html: str) -> Result:
     if status_code == 429:


### PR DESCRIPTION
## Summary

Facebook updated the copy on its profile-not-found interstitial from **"This content isn't available right now"** to **"This content isn't available at the moment"**. The hardcoded `UNAVAILABLE_MARKER` in `facebook.py` no longer matched this string, so `_process_profile_response()` fell through to the generic catch-all and returned `Result.error("Unexpected response body, report it via GitHub issues.")` instead of `Result.available()` for non-existent usernames.

Fixes #484

## Root Cause

Diffed raw HTML (using full browser-style request headers to get past Facebook's bot detection) between a known-existing profile and a non-existent username:

- The `og:title` / `og:url` meta tag based "taken" detection still works correctly — no change needed there.
- Only the "not found" marker string had drifted from Facebook's side.

## Fix

```diff
- UNAVAILABLE_MARKER = "This content isn't available right now"
+ UNAVAILABLE_MARKER = "This content isn't available at the moment"
```

## Testing

Ran locally against a mix of known-taken and known-available usernames: