### PR TITLE
fix: correct Fore.reset typo crashing update error handler

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,6 @@
 from user_scanner.core import helpers as hl
-
+from user_scanner.utils import update as upd
+import subprocess
 
 def test_default_config():
     configs = hl.load_config()
@@ -29,3 +30,20 @@ def test_config_set(tmp_path, monkeypatch):
 
     hl.save_config_value("auto_update_status", True)
     assert get_status() is True
+
+def test_update_self_prints_message_on_install_failure(monkeypatch, capsys):
+    calls = []
+
+    def fake_check_call(cmd, *a, **kw):
+        calls.append(cmd)
+        if "uninstall" in cmd:
+            return 0
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "check_call", fake_check_call)
+
+    upd.update_self()
+
+    out = capsys.readouterr().out
+    assert "Failed to update user-scanner" in out
+    assert len(calls) == 2  # uninstall attempted, then install attempted

--- a/user_scanner/utils/update.py
+++ b/user_scanner/utils/update.py
@@ -19,7 +19,7 @@ def update_self():
             sys.executable, "-m", "pip", "install", "user-scanner"
         ])
     except subprocess.CalledProcessError as e:
-        print(f"{Fore.RED}Failed to update user-scanner: {e}{Fore.reset}")
+        print(f"{Fore.RED}Failed to update user-scanner: {e}{Fore.RESET}")
         return
 
 


### PR DESCRIPTION
Fixes #493 

**Problem**

`update_self()`'s error handler uses `Fore.reset` (lowercase), which doesn't exist on colorama's `Fore` class (only `Fore.RESET` does). When `pip install` fails after `pip uninstall` has already succeeded, the warning meant to tell the user the tool is now uninstalled crashes instead with `AttributeError: 'AnsiFore' object has no attribute 'reset'`, leaving them with a raw traceback and no indication of what happened.

**Fix**

Changed `Fore.reset` to `Fore.RESET` on the affected line.

**Changes**

- `user_scanner/utils/update.py` — one-character fix
- `tests/test_update.py` — added a regression test that mocks uninstall succeeding and install failing with a real `subprocess.CalledProcessError`, and asserts the error message prints without raising

**Testing**

Confirmed the new test fails on unmodified code with the exact real `AttributeError`, and passes with the fix. Full suite: 173 passed, 3 skipped (pre-existing, unrelated) against current `main`. `ruff check .` and `mypy user_scanner` both clean.