### PR TITLE
fix: motherless.xxx dns resolution hanging

### DIFF
--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -7,9 +7,10 @@ from user_scanner.core.result import Result, Status
 class FakeSession:
     instances = []
 
-    def __init__(self, impersonate=None, proxies=None):
+    def __init__(self, impersonate=None, proxies=None, curl_options=None):
         self.impersonate = impersonate
         self.proxies = proxies
+        self.curl_options = curl_options
         self.calls = []
         FakeSession.instances.append(self)
 

--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,7 +1,8 @@
 import threading
-from typing import Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 from curl_cffi import requests as cffi
+from curl_cffi.const import CurlOpt
 
 from user_scanner.core.helpers import get_global_timeout, get_proxy
 from user_scanner.core.result import Result
@@ -58,18 +59,22 @@ def impersonate_request(
 
 
 def _get_warm_session(
-    impersonate: str, proxy: Optional[str], warmup_url: Optional[str]
+    impersonate: str,
+    proxy: Optional[str],
+    warmup_url: Optional[str],
 ) -> cffi.Session:
     key = (impersonate, proxy)
     with _lock:
         session = _sessions.get(key)
         if session is None:
-            session = cffi.Session(
+            session_kwargs: dict[str, Any] = {
                 # curl_cffi types this as a browser-name Literal; the value is a
                 # validated runtime string, so widen it here only.
-                impersonate=impersonate,  # type: ignore[arg-type]
-                proxies={"http": proxy, "https": proxy} if proxy else None,
-            )
+                "impersonate": impersonate,
+                "proxies": {"http": proxy, "https": proxy} if proxy else None,
+                "curl_options": {CurlOpt.QUICK_EXIT: 1},
+            }
+            session = cffi.Session(**session_kwargs)
             _sessions[key] = session
 
         if warmup_url and key not in _warmed:

--- a/user_scanner/user_scan/adult/motherless.py
+++ b/user_scanner/user_scan/adult/motherless.py
@@ -1,5 +1,8 @@
 import re
-from user_scanner.core.orchestrator import generic_validate, make_request, Result
+
+from user_scanner.core.helpers import get_global_timeout
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.result import Result
 
 CHECK_URL = "https://motherless.xxx/register/checkusername"
 HEADERS = {
@@ -12,6 +15,8 @@ HEADERS = {
 
 def validate_motherless(user):
     show_url = f"https://motherless.xxx/m/{user}"
+    global_timeout = get_global_timeout()
+    timeout = global_timeout if global_timeout is not None else 5.0
 
     def process(response):
         if response.status_code != 200:
@@ -24,23 +29,29 @@ def validate_motherless(user):
         if 'class="not-available"' in body:
             if "invalid" in body.lower():
                 return Result.error("Username rejected by Motherless", url=show_url)
-            return Result.taken(extra=_fetch_profile(show_url), url=show_url)
+            return Result.taken(extra=_fetch_profile(show_url, timeout), url=show_url)
 
         if 'class="available"' in body:
             return Result.available(url=show_url)
 
         return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
 
-    return generic_validate(
-        CHECK_URL, process, show_url=show_url, method="POST", data={"username": user}, headers=HEADERS
+    return impersonate_validate(
+        CHECK_URL,
+        process,
+        show_url=show_url,
+        method="POST",
+        data={"username": user},
+        headers=HEADERS,
+        timeout=timeout,
     )
 
 
-def _fetch_profile(profile_url: str) -> dict:
+def _fetch_profile(profile_url: str, timeout: float) -> dict:
     """The checkusername endpoint only reports availability, so pull the public
     member page for metadata. Best-effort: a failed fetch yields no extra."""
     try:
-        response = make_request(profile_url)
+        response = impersonate_request(profile_url, timeout=timeout)
         if response.status_code != 200:
             return {}
         return _extract_profile(response.text)


### PR DESCRIPTION
## Summary

  Fix Motherless scans hanging for roughly two minutes when DNS resolution fails.

  ## Root cause

  The existing 5-second HTTPX timeout did not cover synchronous DNS resolution. Python’s blocking getaddrinfo() could therefore continue retrying long after the configured request timeout before eventually returning a DNS error.

  ## Fix

  - Route Motherless requests through curl_cffi, whose request timeout covers the DNS lookup path.
  - Apply the configured global timeout, falling back to 5 seconds.
  - Enable curl’s QUICK_EXIT option on shared impersonated sessions to avoid waiting on resolver-thread cleanup during shutdown.
  - Update the session test double to accept the new curl option.

  This keeps the existing error handling and profile lookup behavior while ensuring broken DNS cannot stall the scan.