### PR TITLE
fix: follow redirects in Zomato username module

### DIFF
--- a/user_scanner/user_scan/other/zomato.py
+++ b/user_scanner/user_scan/other/zomato.py
@@ -60,5 +60,6 @@ def validate_zomato(user):
 
         return Result.error(f"Unexpected status: {response.status_code}")
 
-    return generic_validate(url, process, headers=headers, show_url=show_url)
-
+    return generic_validate(
+        url, process, headers=headers, show_url=show_url, follow_redirects=True
+    )


### PR DESCRIPTION
This PR enables redirects in the Zomato username module. At least in my case, the site redirects to a localised version (i.e. https://www.zomato.com/pl/.../reviews), causing the module to currently fail due to the 302 response code.