### PR TITLE
feat: display skipped modules under category headers by default

### DIFF
--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -293,6 +293,9 @@ def test_show_default_filters_non_taken(capsys):
     Result.available(site_name="HiddenSite").show(conf)
     assert capsys.readouterr().out == ""
 
+    Result.skipped(site_name="SkippedSite").show(conf)
+    assert "SkippedSite" in capsys.readouterr().out
+
     Result.taken(site_name="VisibleSite").show(conf)
     assert "VisibleSite" in capsys.readouterr().out
 

--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -521,7 +521,7 @@ def main():
     total_found = len([r for r in results if r.is_found()])
     total_skipped = len([r for r in results if r.status == Status.SKIPPED])
 
-    if not config.show_all and total_found == 0:
+    if not config.show_all and total_found == 0 and total_skipped == 0:
         print(f"\n{R}[✘] No results found for the given target(s).{X}")
     else:
         print(f"\n{C}[i] Scan complete.\n  Total hits:{X} {total_found}")

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -17,7 +17,7 @@ from user_scanner.core.helpers import (
     load_modules,
     get_global_timeout,
 )
-from user_scanner.core.result import Result, Status
+from user_scanner.core.result import Result
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, MofNCompleteColumn
 
 # Monkey-patch httpx clients to automatically use proxies for email scans
@@ -81,10 +81,10 @@ async def _async_worker(
         if not func:
             return Result.error(
                 f"{site_name} has no validate_ function", **params
-            ).show(configs)
+            )
 
         if not configs.allow_loud and is_loud(site_name, is_email=True):
-            return Result.skipped().update(**params).show(configs)
+            return Result.skipped().update(**params)
 
         try:
             import inspect
@@ -95,17 +95,7 @@ async def _async_worker(
         except Exception as e:
             result = Result.error(e)
 
-        result.update(**params)
-
-        # Logic to print header dynamically for --show-all streaming
-        if not configs.show_all and result.status == Status.TAKEN:
-            if printed_cats is not None and actual_cat not in printed_cats:
-                print(
-                    f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}"
-                )
-                printed_cats.add(actual_cat)
-
-        return result.show(configs)
+        return result.update(**params)
 
 
 async def _run_batch(
@@ -144,6 +134,15 @@ async def _run_batch(
 
         for coro in asyncio.as_completed(tasks):
             result = await coro
+            actual_cat = result.category or "Unknown"
+            if not configs.show_all and result.is_visible(configs):
+                if printed_cats is not None and actual_cat not in printed_cats:
+                    print(
+                        f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}"
+                    )
+                    printed_cats.add(actual_cat)
+
+            result.show(configs)
             results.append(result)
             progress.advance(task_id)
 
@@ -233,6 +232,15 @@ async def _run_email_full_batch_async(email: str, configs: ScanConfig) -> List[R
                 
             for coro in asyncio.as_completed(tasks):
                 result = await coro
+                if not configs.show_all and result.is_visible(configs):
+                    display_name = result.category or "Unknown"
+                    if display_name not in printed_cats:
+                        print(
+                            f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}"
+                        )
+                        printed_cats.add(display_name)
+
+                result.show(configs)
                 all_results.append(result)
                 progress.advance(task_id)
 

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -52,10 +52,10 @@ async def _async_worker(
         }
 
         if not func:
-            return Result.error(f"{site_name} has no validate_ function", **params).show(configs)
+            return Result.error(f"{site_name} has no validate_ function", **params)
 
         if not configs.allow_loud and is_loud(site_name):
-            return Result.skipped().update(**params).show(configs)
+            return Result.skipped().update(**params)
 
         try:
             if inspect.iscoroutinefunction(func):
@@ -105,7 +105,7 @@ async def _run_batch(
             
             actual_cat = result.category or "Unknown"
             # Handle specific logic where skipping needs to happen early
-            if not configs.show_all and result.is_found():
+            if not configs.show_all and result.is_visible(configs):
                 if printed_cats is not None and actual_cat not in printed_cats:
                     print(f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}")
                     printed_cats.add(actual_cat)
@@ -189,7 +189,7 @@ async def _run_user_full_async(username: str, configs: ScanConfig) -> List[Resul
             for coro in asyncio.as_completed(tasks):
                 result = await coro
                 
-                if not configs.show_all and result.is_found():
+                if not configs.show_all and result.is_visible(configs):
                     display_name = result.category or "Unknown"
                     if display_name not in printed_cats:
                         print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")

--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -280,11 +280,17 @@ class Result:
         """Returns True if the target was found or registered (Status.TAKEN)"""
         return self.status == Status.TAKEN
 
+    def is_visible(self, configs: ScanConfig | None = None) -> bool:
+        """Returns True if the result should be printed under the current configuration.
+        By default (show_all=False), TAKEN and SKIPPED results are visible."""
+        if configs and configs.show_all:
+            return True
+        return self.status in (Status.TAKEN, Status.SKIPPED)
+
     def show(self, configs: ScanConfig):
         """Prints the console output and returns itself for chaining.
-        If show_all is False, only results with Status.TAKEN are printed."""
-        # Updated show() to accept and pass the show_url flag
-        if not configs.show_all and self.status != Status.TAKEN:
+        If show_all is False, TAKEN and SKIPPED results are printed."""
+        if not self.is_visible(configs):
             return self
         print(self.get_console_output(configs))
         return self


### PR DESCRIPTION
- Display skipped modules under their respective category headers on the terminal by default
- Ensure category headers are dynamically printed when skipped modules complete
- Update Result.show and scanner summary logic to account for skipped module visibility