### PR TITLE
feat: auto enable show_all when scanning <= 10 modules with -m flag

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -354,10 +354,16 @@ def main():
                 )
 
     results = []
+    show_all = args.all
+    if args.module and not args.all:
+        raw_module_str = ",".join(args.module) if isinstance(args.module, list) else args.module
+        requested_modules = [m.strip() for m in raw_module_str.split(",") if m.strip()]
+        if len(requested_modules) <= 10:
+            show_all = True
 
     config = ScanConfig(
         allow_loud=args.allow_loud,
-        show_all=args.all,
+        show_all=show_all,
         no_nsfw=args.no_nsfw,
         verbose=args.verbose,
         timeout=args.timeout,


### PR DESCRIPTION
- Automatically enable show_all when 10 or fewer modules are requested via the -m flag
- Ensure results for targeted module scans are displayed on the terminal instead of exiting silently
- Retain default found-only behavior when scanning more than 10 modules unless --all is specified