### PR TITLE
fix(nix): add missing curl-cffi and rich python dependencies to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
             socksio
             colorama
             h2
+            curl-cffi
+            rich
           ];
 
           pythonImportsCheck = ["user_scanner"];


### PR DESCRIPTION
- Add curl-cffi and rich to dependencies list in flake.nix
- Fix nix build pythonRuntimeDepsCheckHook failures when packaging user-scanner
- Verify nix build and nix run execution