### PR TITLE
fix(tiktok): detect accounts via the embed page instead of a dead marker

### DIFF
--- a/user_scanner/user_scan/social/tiktok.py
+++ b/user_scanner/user_scan/social/tiktok.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 from user_scanner.core.helpers import get_random_user_agent
@@ -23,23 +24,82 @@ def validate_tiktok(user: str) -> Result:
     headers = {
         "User-Agent": get_random_user_agent(),
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding": "identity",
         "Accept-Language": "en-US,en;q=0.9",
-        "sec-fetch-dest": "document",
-        "Connection": "keep-alive",
     }
 
-    url = f"https://www.tiktok.com/@{user}"
     show_url = f"https://www.tiktok.com/@{user}"
+    # The profile page is a client-rendered shell that is byte-identical for
+    # real and missing handles. The embed page server-renders a userInfo blob
+    # for public accounts and answers 400 for everything else.
+    url = f"https://www.tiktok.com/embed/@{user}"
 
     def process(response) -> Result:
-        if response.status_code == 200:
-            if 'statuscode":10221' in response.text.lower():
-                return Result.available()
-            else:
-                return Result.taken()
-        return Result.error("Unable to load tiktok")
+        # A private account answers 400 exactly like an unregistered handle,
+        # and no public endpoint separates the two, so 400 cannot support a
+        # verdict either way.
+        if response.status_code == 400:
+            return Result.error("No public account (a private one looks the same)")
 
-    return generic_validate(
-        url, process, show_url=show_url, headers=headers, timeout=4.0
-    )
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        info = _extract_user_info(response.text)
+        if not info or not info.get("uniqueId"):
+            return Result.error("Unrecognised embed payload")
+
+        extra = {}
+        if handle := info.get("uniqueId"):
+            extra["username"] = handle
+        if nickname := info.get("nickname"):
+            extra["name"] = nickname
+        if user_id := info.get("id"):
+            extra["user_id"] = str(user_id)
+        if bio := info.get("signature"):
+            extra["bio"] = bio.strip()
+        if (followers := info.get("followerCount")) is not None:
+            extra["followers"] = str(_unwrap_int32(followers))
+        if (following := info.get("followingCount")) is not None:
+            extra["following"] = str(_unwrap_int32(following))
+        if (likes := info.get("heartCount")) is not None:
+            extra["likes"] = str(_unwrap_int32(likes))
+        if info.get("verified"):
+            extra["verified"] = "true"
+        if info.get("privateAccount"):
+            extra["private"] = "true"
+
+        media = {}
+        if avatar := info.get("avatarThumbUrl"):
+            media["avatar"] = avatar
+
+        return Result.taken(extra=extra, media=media)
+
+    return generic_validate(url, process, show_url=show_url, headers=headers)
+
+
+def _extract_user_info(html: str) -> dict | None:
+    """Parse the ``userInfo`` object out of the embed page's state blob."""
+    marker = '"userInfo":'
+    start = html.find(marker)
+    if start == -1:
+        return None
+
+    start += len(marker)
+    depth = 0
+    for index in range(start, len(html)):
+        char = html[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(html[start : index + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def _unwrap_int32(value: int) -> int:
+    """Counts above 2^31 arrive from the embed API wrapped into a signed
+    32-bit integer, so a negative total is the real one minus 2^32."""
+    return value + 2**32 if value < 0 else value


### PR DESCRIPTION
### tl;dr

- **The module reported every handle as Found**, including ones I invented — a bare `else` behind a body marker that no longer exists.
- **It was also nondeterministic** — the same nonexistent handle returned `TAKEN` and then `AVAILABLE` from unmodified code.
- **Fixed by switching to `tiktok.com/embed/@<user>`**, which server-renders profile data for public accounts.
- **Adds 7 metadata fields plus an avatar** where the module previously returned nothing.
- **A 400 now returns `error`, not `available`** — a private account is indistinguishable from an unregistered handle, verified on a live account toggled private.
- **`heartCount` overflows int32** and needs unwrapping — the subtlest thing in this diff.
- **`videoList` deliberately excluded** — it's a recent-videos slice, not a total.
- **Gates clean**, tested live across public, private, nonexistent and invalid handles.

---

### The module reported every handle as Found

Existence was decided by scraping the profile page:

```python
if 'statuscode":10221' in response.text.lower():
    return Result.available()
else:
    return Result.taken()
```

That page is now a 1462-byte client-rendered shell, byte-identical for real and missing handles, with no `__UNIVERSAL_DATA_FOR_REHYDRATION__` and no `SIGI_STATE`. The marker never matches, so the `else` always wins:

```
brunolm_7            -> TAKEN
zzznotarealuser99xzq -> TAKEN   # invented
xqzznobodyhere4471   -> TAKEN   # invented
```

This is the bare-`else` pattern `AGENTS.md` rule 3 prohibits. It rotted silently because nothing fails loudly when a body marker disappears.

### It was also nondeterministic

The marker appears intermittently rather than never. Across runs, `zzznotarealuser99xzq` returned `TAKEN` once and `AVAILABLE` later from unmodified code. That is worse than a consistent failure: re-running can appear to corroborate whichever answer you got first.

### Fixed by switching to the embed page

`tiktok.com/embed/@<user>` server-renders a `userInfo` blob for public accounts. A plain httpx request through `generic_validate` is enough — no impersonation needed.

`userInfo` is extracted with a brace-balanced scan rather than a regex terminating at `,"videoList"`, so accounts with no videos still parse.

### Adds 7 metadata fields plus an avatar

`username`, `name`, `user_id`, `bio`, `followers`, `following`, `likes`, plus `verified` / `private` when true, and the avatar in `media`. `extra` was previously empty on every hit.

### A 400 now returns `error`, not `available`

TikTok answers 400 for a private account exactly as it does for an unregistered handle. I confirmed this against a live account toggled private mid-test, and no public endpoint separates the two:

| Endpoint | Private | Nonexistent | Discriminates? |
| --- | --- | --- | --- |
| `/embed/@user` | 400 | 400 | No |
| `/oembed?url=` | 400 | 400 | No |
| `/@user` (curl_cffi) | 200, 1462 B | 200, 1462 B | No — byte-identical |
| `/api/user/detail/` | 200, empty | 200, empty | No |
| `/node/share/user/@` | 403 | 403 | No |
| `/@user` as Googlebot | 403 | 403 | No |
| signup-style check endpoints | `"url doesn't match"` | same | No |

Returning `available` would assert a handle is free when it may belong to a private account — an estimated 20–25% of TikTok accounts. This follows `erome.py`, which refuses a verdict on a 410 for the same reason.

**This trades away availability detection**: the module can no longer return `available` from any network path. That is deliberate, and it is the cost of not asserting something false.

### `heartCount` overflows int32 — review this closely

Large accounts return a **negative** like count:

```
khaby.lame -> heartCount: -1642920348
-1642920348 + 2**32 = 2652046948   # matches his real ~2.65B
```

`_unwrap_int32` corrects it, applied to all three counters since followers can cross the same threshold. Small accounts are unaffected, so this is invisible unless a large account is tested.

### `videoList` deliberately excluded

The page also carries a `videoList`, but it is the embed's recent-videos slice, not a total. Any count derived from it would be a figure whose label I cannot trace.

### Gates clean, tested live

`ruff check .` clean · `mypy user_scanner` clean across 435 files · `pytest` 172 passed (2 failures are pre-existing Windows chmod no-ops, unrelated).

Verified against a public account, the **same account toggled private**, a large verified account (`khaby.lame`), two nonexistent handles, and every invalid-syntax branch. Verdicts were stable across repeated runs.

Behaviour across the privacy toggle, same handle and command:

```
private -> [!] Tiktok (brunolm_7): Error (No public account (a private one looks the same))
public  -> [✔] Tiktok (brunolm_7): Found  (username, name, user_id, bio, followers, following, likes)
```

**Note on visibility:** the default terminal view prints neither errors nor available results, so a private account still shows `No results found` unless `--all` is passed. The corrected status and reason always reach JSON/CSV export. Surfacing errors by default would mean changing the shared formatter, which is out of scope here.
