### PR TITLE
feat(gravatar): extract links, interests and profile details

### DIFF
--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -93,18 +93,23 @@ async def _collect_profile(client: httpx.AsyncClient, email_hash: str) -> tuple[
                 _extract_profile_data(entries[0], extra, media)
     except Exception:
         pass
+    page_read = False
     try:
         response = await client.get(f"{PROFILE_HOST}/{email_hash}", headers=HEADERS)
         if response.status_code == 200:
             _extract_page_data(response.text, extra)
+            page_read = True
     except Exception:
         pass
-    try:
-        response = await client.get(f"{PROFILE_HOST}/{email_hash}.md", headers=HEADERS)
-        if response.status_code == 200:
-            _extract_markdown_data(response.text, extra)
-    except Exception:
-        pass
+    # The export only refines the two fields the page already reports, so it is
+    # worth a request only once one of them is known to be set.
+    if not page_read or any(key in extra for key in MARKDOWN_KEYS.values()):
+        try:
+            response = await client.get(f"{PROFILE_HOST}/{email_hash}.md", headers=HEADERS)
+            if response.status_code == 200:
+                _extract_markdown_data(response.text, extra)
+        except Exception:
+            pass
     return extra, media
 
 

--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -1,6 +1,7 @@
 import hashlib
 import html
 import re
+from collections.abc import Iterator
 
 import httpx
 
@@ -16,26 +17,21 @@ HEADERS = {
 
 # The public JSON APIs omit the profile's "Links" card, its interests and the
 # advanced-details panel; only the rendered profile page carries them.
-LINKS_SECTION_RE = re.compile(
-    r'g-profile__links".*?(?=<div class="g-profile__card|<button class="g-profile__adv-details-btn)',
-    re.S,
-)
-LINK_RE = re.compile(r'<a class="card-item__link"\s+href="([^"]+)"\s+title="([^"]*)"', re.S)
-INTERESTS_RE = re.compile(r'g-profile__interests-list">(.*?)</ul>', re.S)
+INTERESTS_RE = re.compile(r"<h2[^>]*>\s*Interests\s*</h2>.*?<ul[^>]*>(.*?)</ul>", re.S)
 INTEREST_ITEM_RE = re.compile(r"<span>\s*([^<]+?)\s*</span>")
+TITLE_RE = re.compile(r'title="([^"]*)"')
 ADV_DETAIL_RE = re.compile(
     r"<span>\s*(Profile|Updated|Created|Languages|Time):\s*([^<]+?)\s*</span>"
 )
 # Both JSON APIs list only the providers their schema knows about — a YouTube
 # connection is absent from each yet rendered on the page, so the card is the
-# only complete source.
-VERIFIED_SECTION_RE = re.compile(
-    r'g-profile__card is-verified-accounts".*?(?=<div class="g-profile__card|\Z)', re.S
-)
-VERIFIED_ITEM_RE = re.compile(
-    r'card-item__label-text">\s*([^<]+?)\s*</span>.*?class="card-item__link"\s+href="([^"]+)"',
-    re.S,
-)
+# only complete source. Each entry is anchored on its checkmark's help link and
+# the rel="me" of the account anchor rather than on styling hooks.
+VERIFIED_MARKER = "support.gravatar.com/profiles/verified-accounts"
+VERIFIED_LABEL_RE = re.compile(r">\s*([^<>]{1,60}?)\s*</span>\s*<a[^>]*$", re.S)
+ANCHOR_RE = re.compile(r"<a\b[^>]*>", re.S)
+REL_ME_RE = re.compile(r'rel="[^"]*\bme\b[^"]*"')
+HREF_RE = re.compile(r'href="([^"]+)"')
 TIMEZONE_RE = re.compile(r"\(([^)]+)\)")
 
 ADV_DETAIL_KEYS = {
@@ -139,10 +135,16 @@ def _extract_profile_data(entry: dict, extra: dict, media: dict) -> None:
             if not isinstance(acc, dict):
                 continue
             acc_name = str(acc.get("name") or acc.get("shortname") or "Account")
-            acc_url = acc.get("url") or acc.get("display") or acc.get("username")
-            if acc_url is not None and str(acc_url).strip():
-                status = " (verified)" if acc.get("verified") else ""
-                acc_list.append(f"{acc_name}: {str(acc_url).strip()}{status}")
+            acc_url = str(acc.get("url") or acc.get("display") or acc.get("username") or "").strip()
+            status = " (verified)" if acc.get("verified") else ""
+            # Providers that forbid public profile links (Facebook) are stored
+            # pointing at Gravatar's help page, which says nothing about the user.
+            if VERIFIED_MARKER in acc_url:
+                acc_url = ""
+            if acc_url:
+                acc_list.append(f"{acc_name}: {acc_url}{status}")
+            elif acc.get("verified"):
+                acc_list.append(f"{acc_name}{status}")
         if acc_list:
             extra["verified_accounts"] = ", ".join(acc_list)
 
@@ -207,17 +209,13 @@ def _extract_profile_data(entry: dict, extra: dict, media: dict) -> None:
 def _extract_page_data(page: str, extra: dict) -> None:
     _merge_verified_accounts(page, extra)
 
-    section = LINKS_SECTION_RE.search(page)
-    if section:
-        links = []
-        for url, title in LINK_RE.findall(section.group(0)):
-            url = html.unescape(url).strip()
-            title = html.unescape(title).strip()
-            if not url:
-                continue
-            links.append(f"{title}: {url}" if title and title != url else url)
-        if links:
-            extra["links"] = ", ".join(links)
+    links = []
+    for title, url in _iter_links(page):
+        entry = f"{title}: {url}"
+        if entry not in links:
+            links.append(entry)
+    if links:
+        extra["links"] = ", ".join(links)
 
     interests = INTERESTS_RE.search(page)
     if interests:
@@ -241,21 +239,56 @@ def _extract_page_data(page: str, extra: dict) -> None:
 
 
 def _merge_verified_accounts(page: str, extra: dict) -> None:
-    section = VERIFIED_SECTION_RE.search(page)
-    if not section:
-        return
-
     existing = [e for e in str(extra.get("verified_accounts", "")).split(", ") if e]
-    known = {_normalize_url(e.rsplit(": ", 1)[-1]) for e in existing}
-    for label, url in VERIFIED_ITEM_RE.findall(section.group(0)):
-        label = html.unescape(label).strip()
-        url = html.unescape(url).strip()
-        if not url or _normalize_url(url) in known:
+    known_urls = {_normalize_url(e.rsplit(": ", 1)[-1]) for e in existing}
+    # The same account can carry different URLs in each source — the JSON keeps
+    # whatever the owner entered, the page renders a canonical one — so the
+    # service name is what identifies a duplicate.
+    known_services = {e.split(":", 1)[0].removesuffix(" (verified)").strip().lower() for e in existing}
+    for label, url in _iter_verified_accounts(page):
+        if _normalize_url(url) in known_urls or label.lower() in known_services:
             continue
-        known.add(_normalize_url(url))
+        known_urls.add(_normalize_url(url))
+        known_services.add(label.lower())
         existing.append(f"{label or 'Account'}: {url} (verified)")
     if existing:
         extra["verified_accounts"] = ", ".join(existing)
+
+
+def _iter_verified_accounts(page: str) -> Iterator[tuple[str, str]]:
+    markers = [m.start() for m in re.finditer(re.escape(VERIFIED_MARKER), page)]
+    for index, start in enumerate(markers):
+        # The account anchor sits between this checkmark and the next entry's.
+        end = markers[index + 1] if index + 1 < len(markers) else len(page)
+        url = ""
+        for tag in ANCHOR_RE.finditer(page, start, end):
+            href = HREF_RE.search(tag.group(0))
+            if href and REL_ME_RE.search(tag.group(0)):
+                url = html.unescape(href.group(1)).strip()
+                break
+        # A help-page URL is the placeholder for providers that forbid public
+        # links, and it also matches the marker, so it seeds phantom entries.
+        if not url or VERIFIED_MARKER in url:
+            continue
+        label = VERIFIED_LABEL_RE.search(page, max(0, start - 300), start)
+        yield (html.unescape(label.group(1)).strip() if label else ""), url
+
+
+def _iter_links(page: str) -> Iterator[tuple[str, str]]:
+    # A personal link carries the owner's own caption; every other rel="me"
+    # anchor on the page — the icon row and the verified cards — repeats its own
+    # URL as the title.
+    for tag in ANCHOR_RE.finditer(page):
+        if not REL_ME_RE.search(tag.group(0)):
+            continue
+        href = HREF_RE.search(tag.group(0))
+        title = TITLE_RE.search(tag.group(0))
+        if not href or not title:
+            continue
+        url = html.unescape(href.group(1)).strip()
+        caption = html.unescape(title.group(1)).strip()
+        if url and caption and caption != url:
+            yield caption, url
 
 
 def _normalize_url(value: str) -> str:

--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -24,7 +24,17 @@ LINK_RE = re.compile(r'<a class="card-item__link"\s+href="([^"]+)"\s+title="([^"
 INTERESTS_RE = re.compile(r'g-profile__interests-list">(.*?)</ul>', re.S)
 INTEREST_ITEM_RE = re.compile(r"<span>\s*([^<]+?)\s*</span>")
 ADV_DETAIL_RE = re.compile(
-    r"<span>\s*(Profile|Updated|Created|Languages|Verified connections|Time):\s*([^<]+?)\s*</span>"
+    r"<span>\s*(Profile|Updated|Created|Languages|Time):\s*([^<]+?)\s*</span>"
+)
+# Both JSON APIs list only the providers their schema knows about — a YouTube
+# connection is absent from each yet rendered on the page, so the card is the
+# only complete source.
+VERIFIED_SECTION_RE = re.compile(
+    r'g-profile__card is-verified-accounts".*?(?=<div class="g-profile__card|\Z)', re.S
+)
+VERIFIED_ITEM_RE = re.compile(
+    r'card-item__label-text">\s*([^<]+?)\s*</span>.*?class="card-item__link"\s+href="([^"]+)"',
+    re.S,
 )
 TIMEZONE_RE = re.compile(r"\(([^)]+)\)")
 
@@ -41,7 +51,6 @@ ADV_DETAIL_KEYS = {
     "Updated": "last_updated",
     "Created": "created",
     "Languages": "languages",
-    "Verified connections": "verified_connections",
 }
 
 
@@ -210,6 +219,8 @@ def _extract_profile_data(entry: dict, extra: dict, media: dict) -> None:
 
 
 def _extract_page_data(page: str, extra: dict) -> None:
+    _merge_verified_accounts(page, extra)
+
     section = LINKS_SECTION_RE.search(page)
     if section:
         links = []
@@ -243,6 +254,24 @@ def _extract_page_data(page: str, extra: dict) -> None:
         extra[ADV_DETAIL_KEYS[label]] = value
 
 
+def _merge_verified_accounts(page: str, extra: dict) -> None:
+    section = VERIFIED_SECTION_RE.search(page)
+    if not section:
+        return
+
+    existing = [e for e in str(extra.get("verified_accounts", "")).split(", ") if e]
+    known = {_normalize_url(e.rsplit(": ", 1)[-1]) for e in existing}
+    for label, url in VERIFIED_ITEM_RE.findall(section.group(0)):
+        label = html.unescape(label).strip()
+        url = html.unescape(url).strip()
+        if not url or _normalize_url(url) in known:
+            continue
+        known.add(_normalize_url(url))
+        existing.append(f"{label or 'Account'}: {url} (verified)")
+    if existing:
+        extra["verified_accounts"] = ", ".join(existing)
+
+
 def _extract_markdown_data(page: str, extra: dict) -> None:
     for label, key in MARKDOWN_KEYS.items():
         match = re.search(rf"^- {label}: (.+)$", page, re.M)
@@ -252,3 +281,7 @@ def _extract_markdown_data(page: str, extra: dict) -> None:
         value = re.sub(r"\\(.)", r"\1", match.group(1)).strip()
         if value:
             extra[key] = value
+
+
+def _normalize_url(value: str) -> str:
+    return value.removesuffix(" (verified)").strip().rstrip("/").lower()

--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -1,6 +1,100 @@
 import hashlib
+import html
+import re
+
 import httpx
+
+from user_scanner.core.helpers import get_global_timeout
 from user_scanner.core.result import Result
+
+PROFILE_HOST = "https://gravatar.com"
+DEFAULT_TIMEOUT = 15.0
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
+
+# The public JSON APIs omit the profile's "Links" card, its interests and the
+# advanced-details panel; only the rendered profile page carries them.
+LINKS_SECTION_RE = re.compile(
+    r'g-profile__links".*?(?=<div class="g-profile__card|<button class="g-profile__adv-details-btn)',
+    re.S,
+)
+LINK_RE = re.compile(r'<a class="card-item__link"\s+href="([^"]+)"\s+title="([^"]*)"', re.S)
+INTERESTS_RE = re.compile(r'g-profile__interests-list">(.*?)</ul>', re.S)
+INTEREST_ITEM_RE = re.compile(r"<span>\s*([^<]+?)\s*</span>")
+ADV_DETAIL_RE = re.compile(
+    r"<span>\s*(Profile|Updated|Created|Languages|Verified connections|Time):\s*([^<]+?)\s*</span>"
+)
+TIMEZONE_RE = re.compile(r"\(([^)]+)\)")
+
+# The markdown export spells out what the profile page abbreviates: full
+# language names with primary/secondary, and an IANA zone instead of a
+# DST-dependent UTC offset.
+MARKDOWN_KEYS = {
+    "Languages": "languages",
+    "Timezone": "timezone",
+}
+
+ADV_DETAIL_KEYS = {
+    "Profile": "profile_type",
+    "Updated": "last_updated",
+    "Created": "created",
+    "Languages": "languages",
+    "Verified connections": "verified_connections",
+}
+
+
+async def validate_gravatar(email: str) -> Result:
+    email_clean = email.lower().strip()
+    timeout = get_global_timeout() or DEFAULT_TIMEOUT
+    # Older profiles are only addressable by the legacy MD5 hash.
+    hashes = [
+        hashlib.sha256(email_clean.encode("utf-8")).hexdigest(),
+        hashlib.md5(email_clean.encode("utf-8")).hexdigest(),
+    ]
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            for email_hash in hashes:
+                response = await client.get(
+                    f"https://www.gravatar.com/avatar/{email_hash}?d=404", headers=HEADERS
+                )
+                if response.status_code == 200:
+                    extra = await _collect_profile(client, email_hash)
+                    return Result.taken(url=extra.get("profile_url", PROFILE_HOST), extra=extra)
+                if response.status_code != 404:
+                    return Result.error(f"HTTP {response.status_code}", url=PROFILE_HOST)
+            return Result.available(url=PROFILE_HOST)
+    except httpx.TimeoutException:
+        return Result.error("Connection timed out", url=PROFILE_HOST)
+    except Exception as e:
+        return Result.error(e, url=PROFILE_HOST)
+
+
+async def _collect_profile(client: httpx.AsyncClient, email_hash: str) -> dict:
+    extra: dict = {"avatar_url": f"https://www.gravatar.com/avatar/{email_hash}"}
+    try:
+        response = await client.get(f"https://en.gravatar.com/{email_hash}.json", headers=HEADERS)
+        if response.status_code == 200:
+            entries = response.json().get("entry") or []
+            if entries and isinstance(entries[0], dict):
+                _extract_profile_data(entries[0], extra)
+    except Exception:
+        pass
+    try:
+        response = await client.get(f"{PROFILE_HOST}/{email_hash}", headers=HEADERS)
+        if response.status_code == 200:
+            _extract_page_data(response.text, extra)
+    except Exception:
+        pass
+    try:
+        response = await client.get(f"{PROFILE_HOST}/{email_hash}.md", headers=HEADERS)
+        if response.status_code == 200:
+            _extract_markdown_data(response.text, extra)
+    except Exception:
+        pass
+    return extra
+
 
 def _extract_profile_data(entry: dict, extra: dict) -> None:
     if entry.get("preferredUsername"):
@@ -15,10 +109,16 @@ def _extract_profile_data(entry: dict, extra: dict) -> None:
         extra["bio"] = str(entry["aboutMe"]).strip()
     if entry.get("currentLocation"):
         extra["location"] = str(entry["currentLocation"]).strip()
-    if entry.get("jobTitle"):
-        extra["job_title"] = str(entry["jobTitle"]).strip()
+    # The legacy endpoint returns this as job_title; jobTitle is the v3 spelling.
+    job_title = entry.get("jobTitle") or entry.get("job_title")
+    if job_title:
+        extra["job_title"] = str(job_title).strip()
     if entry.get("company"):
         extra["company"] = str(entry["company"]).strip()
+    if entry.get("pronouns"):
+        extra["pronouns"] = str(entry["pronouns"]).strip()
+    if entry.get("pronunciation"):
+        extra["pronunciation"] = str(entry["pronunciation"]).strip()
 
     name_info = entry.get("name")
     if isinstance(name_info, dict) and name_info.get("formatted"):
@@ -58,6 +158,26 @@ def _extract_profile_data(entry: dict, extra: dict) -> None:
         if url_list:
             extra["websites"] = ", ".join(url_list)
 
+    contact_info = entry.get("contactInfo")
+    if isinstance(contact_info, list):
+        contact_list = [
+            f"{str(c.get('type', 'contact'))}: {str(c['value']).strip()}"
+            for c in contact_info
+            if isinstance(c, dict) and c.get("value") is not None and str(c["value"]).strip()
+        ]
+        if contact_list:
+            extra["contact_info"] = ", ".join(contact_list)
+
+    phones = entry.get("phoneNumbers")
+    if isinstance(phones, list):
+        phone_list = [
+            f"{str(p.get('type', 'phone'))}: {str(p['value']).strip()}"
+            for p in phones
+            if isinstance(p, dict) and p.get("value") is not None and str(p["value"]).strip()
+        ]
+        if phone_list:
+            extra["phone_numbers"] = ", ".join(phone_list)
+
     emails = entry.get("emails")
     if isinstance(emails, list):
         email_list = [
@@ -78,60 +198,54 @@ def _extract_profile_data(entry: dict, extra: dict) -> None:
         if crypto_list:
             extra["crypto_addresses"] = ", ".join(crypto_list)
 
-async def _check(email: str) -> Result:
-    show_url = "https://gravatar.com"
-    email_clean = email.lower().strip()
-    email_hash = hashlib.sha256(email_clean.encode("utf-8")).hexdigest()
-    url = f"https://www.gravatar.com/avatar/{email_hash}?d=404"
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.get(url, headers=headers)
-            if response.status_code == 200:
-                extra = {"avatar_url": f"https://www.gravatar.com/avatar/{email_hash}"}
-                profile_url = f"https://en.gravatar.com/{email_hash}.json"
-                try:
-                    profile_resp = await client.get(profile_url, headers=headers, timeout=15.0)
-                    if profile_resp.status_code == 200:
-                        data = profile_resp.json()
-                        entries = data.get("entry", [])
-                        if entries and isinstance(entries, list):
-                            _extract_profile_data(entries[0], extra)
-                except Exception:
-                    pass
-                final_url = extra.get("profile_url", show_url)
-                return Result.taken(url=final_url, extra=extra)
-            elif response.status_code == 404:
-                # Also fall back to check MD5 since some older profiles might only map via MD5
-                email_md5 = hashlib.md5(email_clean.encode("utf-8")).hexdigest()
-                url_md5 = f"https://www.gravatar.com/avatar/{email_md5}?d=404"
-                
-                response_md5 = await client.get(url_md5, headers=headers)
-                if response_md5.status_code == 200:
-                    extra = {"avatar_url": f"https://www.gravatar.com/avatar/{email_md5}"}
-                    profile_url_md5 = f"https://en.gravatar.com/{email_md5}.json"
-                    try:
-                        profile_resp = await client.get(profile_url_md5, headers=headers, timeout=15.0)
-                        if profile_resp.status_code == 200:
-                            data = profile_resp.json()
-                            entries = data.get("entry", [])
-                            if entries and isinstance(entries, list):
-                                _extract_profile_data(entries[0], extra)
-                    except Exception:
-                        pass
-                    final_url = extra.get("profile_url", show_url)
-                    return Result.taken(url=final_url, extra=extra)
-                elif response_md5.status_code == 404:
-                    return Result.available(url=show_url)
-                else:
-                    return Result.error(f"HTTP MD5 {response_md5.status_code}", url=show_url)
-            return Result.error(f"HTTP {response.status_code}", url=show_url)
-    except httpx.TimeoutException:
-        return Result.error("Connection timed out", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+    background = entry.get("profileBackground")
+    if isinstance(background, dict):
+        if background.get("url"):
+            extra["background_image"] = str(background["url"]).strip()
+        if background.get("color"):
+            extra["background_color"] = str(background["color"]).strip()
 
-async def validate_gravatar(email: str) -> Result:
-    return await _check(email)
+
+def _extract_page_data(page: str, extra: dict) -> None:
+    section = LINKS_SECTION_RE.search(page)
+    if section:
+        links = []
+        for url, title in LINK_RE.findall(section.group(0)):
+            url = html.unescape(url).strip()
+            title = html.unescape(title).strip()
+            if not url:
+                continue
+            links.append(f"{title}: {url}" if title and title != url else url)
+        if links:
+            extra["links"] = ", ".join(links)
+
+    interests = INTERESTS_RE.search(page)
+    if interests:
+        items = [html.unescape(i).strip() for i in INTEREST_ITEM_RE.findall(interests.group(1))]
+        items = [i for i in items if i]
+        if items:
+            extra["interests"] = ", ".join(items)
+
+    for label, value in ADV_DETAIL_RE.findall(page):
+        value = html.unescape(value).strip()
+        if not value or value == "-":
+            continue
+        if label == "Time":
+            zone = TIMEZONE_RE.search(value)
+            # Profiles with no timezone set render as UTC, so a bare "UTC" says
+            # nothing about the owner and is dropped.
+            if zone and zone.group(1).strip() != "UTC":
+                extra["timezone"] = zone.group(1).strip()
+            continue
+        extra[ADV_DETAIL_KEYS[label]] = value
+
+
+def _extract_markdown_data(page: str, extra: dict) -> None:
+    for label, key in MARKDOWN_KEYS.items():
+        match = re.search(rf"^- {label}: (.+)$", page, re.M)
+        if not match:
+            continue
+        # Markdown-escapes any punctuation, e.g. America/Sao\_Paulo.
+        value = re.sub(r"\\(.)", r"\1", match.group(1)).strip()
+        if value:
+            extra[key] = value

--- a/user_scanner/email_scan/social/gravatar.py
+++ b/user_scanner/email_scan/social/gravatar.py
@@ -38,14 +38,6 @@ VERIFIED_ITEM_RE = re.compile(
 )
 TIMEZONE_RE = re.compile(r"\(([^)]+)\)")
 
-# The markdown export spells out what the profile page abbreviates: full
-# language names with primary/secondary, and an IANA zone instead of a
-# DST-dependent UTC offset.
-MARKDOWN_KEYS = {
-    "Languages": "languages",
-    "Timezone": "timezone",
-}
-
 ADV_DETAIL_KEYS = {
     "Profile": "profile_type",
     "Updated": "last_updated",
@@ -93,23 +85,12 @@ async def _collect_profile(client: httpx.AsyncClient, email_hash: str) -> tuple[
                 _extract_profile_data(entries[0], extra, media)
     except Exception:
         pass
-    page_read = False
     try:
         response = await client.get(f"{PROFILE_HOST}/{email_hash}", headers=HEADERS)
         if response.status_code == 200:
             _extract_page_data(response.text, extra)
-            page_read = True
     except Exception:
         pass
-    # The export only refines the two fields the page already reports, so it is
-    # worth a request only once one of them is known to be set.
-    if not page_read or any(key in extra for key in MARKDOWN_KEYS.values()):
-        try:
-            response = await client.get(f"{PROFILE_HOST}/{email_hash}.md", headers=HEADERS)
-            if response.status_code == 200:
-                _extract_markdown_data(response.text, extra)
-        except Exception:
-            pass
     return extra, media
 
 
@@ -275,17 +256,6 @@ def _merge_verified_accounts(page: str, extra: dict) -> None:
         existing.append(f"{label or 'Account'}: {url} (verified)")
     if existing:
         extra["verified_accounts"] = ", ".join(existing)
-
-
-def _extract_markdown_data(page: str, extra: dict) -> None:
-    for label, key in MARKDOWN_KEYS.items():
-        match = re.search(rf"^- {label}: (.+)$", page, re.M)
-        if not match:
-            continue
-        # Markdown-escapes any punctuation, e.g. America/Sao\_Paulo.
-        value = re.sub(r"\\(.)", r"\1", match.group(1)).strip()
-        if value:
-            extra[key] = value
 
 
 def _normalize_url(value: str) -> str:


### PR DESCRIPTION
## tl;dr

- **`job_title` was silently dropped for every profile that sets one.** The extractor read `jobTitle`; the legacy endpoint this module calls returns `job_title`.
- **`verified_accounts` was incomplete and nothing revealed it.** Both JSON APIs omit providers their schema predates — a YouTube connection is absent from each yet rendered on the page.
- **Merging the two sources double-listed accounts and reported a help page as an account URL.** Both found by scanning 11 live profiles, both fixed.
- **Page data is selected without CSS classes**, so a restyle does not silently truncate the result.
- **Links, interests and advanced details exist only in the rendered page**, so the module now scrapes it — one extra request per hit.
- **`phoneNumbers`, `contactInfo`, `pronouns`, `pronunciation` and the profile background were already in the payload and simply unread.**
- **Not verified: `crypto_addresses`, `websites`, and the MD5 fallback leg.**

Net effect on a live scan: 8 `extra` fields before, 19 after.

## `job_title` was silently dropped for every profile that sets one

```python
if entry.get("jobTitle"):          # legacy endpoint returns job_title
    extra["job_title"] = ...
```

The v3 API spells it `jobTitle`, the legacy endpoint spells it `job_title`. The key was never present, so the field vanished for every profile. Now reads either spelling.

## `verified_accounts` was incomplete and nothing revealed it

The advanced-details panel reports a count, and on a test profile it disagreed with the list:

```
verified connections (page count):  5
verified_accounts (legacy JSON):    X, LinkedIn, GitHub, Stack Overflow   -> 4
verified_accounts (v3 API):         X, LinkedIn, GitHub, Stack Overflow   -> 4
verified_accounts (page card):      + YouTube                             -> 5
```

Neither JSON source is complete, so the page card is merged onto the JSON list.

The count itself is no longer emitted — it was the length of the list beside it. It was also the only signal that the list was short, so nothing detects a future gap automatically now.

## Merging two sources double-listed accounts and leaked a help URL

Scanning 11 live profiles instead of one turned up two faults the primary test account could not expose:

| Profile | Symptom | Cause |
| --- | --- | --- |
| `ryan@boren.me` | 11 accounts listed, page says 7 | JSON stores vanity URLs (`ryanboren.link/x`), the page stores canonical ones (`x.com/rboren`); URL comparison cannot match them |
| `skeltoac@gmail.com` | `Facebook: https://support.gravatar.com/…#facebook` | Gravatar stores its own help page as the URL for providers that forbid public profile links |

Dedup now compares the service name as well as the URL, and help-page URLs are dropped — such an account is reported as `Facebook (verified)` with no URL, since the fact of the connection is real but the URL says nothing about the owner.

Every scanned profile now agrees with the page's own count:

```
brunolm7 5=5   beau 4=4   matt 0=0   nacin 2=2   skeltoac 4=4   jack 0=0
ian      7=7   jason 4=4  ryan 7=7   conrad 0=0  zach 0=0
```

## Page data is selected without CSS classes

| Region | Anchored on |
| --- | --- |
| verified accounts | the checkmark's link to `support.gravatar.com/profiles/verified-accounts`, then the account anchor's `rel="me"` |
| links | `rel="me"` anchors whose `title` differs from their `href` — a personal link carries the owner's caption, every other `rel="me"` anchor repeats its URL |
| interests | the `<h2>Interests</h2>` heading and the `<ul>` after it |
| advanced details | `<span>Label: value</span>` — no classes to begin with |

`rel="me"` is the microformats identity relation and the help URL is user-facing documentation; neither is a styling hook. Verified by rewriting every `g-profile__`, `card-item__` and `g-profile-card__` class in the live HTML and re-extracting: identical output on all 11 profiles.

Two fragilities remain rather than being removed. A link captioned with its own URL is indistinguishable from a verified account and is dropped, and `interests` now depends on the English heading instead of a class — the same kind of dependency advanced-details already had.

## Where each field comes from

| Source | Fields |
| --- | --- |
| Legacy JSON | username, display_name, profile_url, bio, location, job_title, company, pronouns, pronunciation, contact_info, phone_numbers, public_emails, background_color, `media`: avatar, thumbnail, photos, background |
| Profile page | verified_accounts (merge), links, interests, profile_type, created, last_updated, languages, timezone |

An ablation over three live profiles confirms the split is minimal: legacy JSON alone reaches 14 of 19 fields, the page alone reaches 8, together they reach all of them.

Gravatar also serves a markdown export that respells `En, Pt` as `English (primary), Portuguese (secondary)` and `GMT-03:00` as `America/Sao_Paulo`. It is deliberately not fetched — it contributes no field the page lacks, and a third request per hit is not worth two prettier values. The consequence is that `timezone` is a UTC offset, correct only outside DST.

## The scraping will rot, and it degrades quietly

Enrichment goes from 2 GETs to 3, and both enrichment fetches are wrapped in try/except and can only add to `extra`, so the Registered/Not-Registered verdict — still resting solely on the avatar endpoint's 200/404 — is untouched by this PR.

The failure mode is not symmetric: if the page markup changes in a way the new anchors do not survive, `verified_accounts` falls back to the incomplete JSON list rather than going empty, which looks identical to a profile that genuinely has fewer connections.

## Also in this PR

- **The global `-t` flag is now honoured.** The module hardcoded `timeout=15.0`. With `-t 0.001`: before `Registered`, after `Error: Connection timed out`.
- **Background image moved to `media`** alongside the avatar, following #496; `background_color` stays in `extra`.
- **Omitted deliberately:** `avatar_alt_text`, `hide_default_header_image` and `section_visibility` are rendering hints for Gravatar's own page, not facts about the account. Wallet/payments and profile feeds need an API key.

## Testing

Eleven live profiles plus four misses:

```
brunolm7@gmail.com               Found      3 GETs  extra=19 media=3  verified=5
beau@automattic.com              Found      3 GETs  extra=18 media=4  verified=4
ian@mckellar.org                 Found      3 GETs  extra= 9 media=4  verified=7
ryan@boren.me                    Found      3 GETs  extra=15 media=3  verified=7
skeltoac@gmail.com               Found      3 GETs  extra=11 media=3  verified=4
jasonhoffman@gmail.com           Found      3 GETs  extra=10 media=3  verified=4
nacin@wordpress.org              Found      3 GETs  extra=10 media=3  verified=2
conrad@trueventures.com          Found      3 GETs  extra=10 media=3  verified=0
jack@baty.net                    Found      3 GETs  extra= 9 media=3  verified=0
zach@londonmade.co.uk            Found      3 GETs  extra= 6 media=3  verified=0
matt@mullenweg.com               Found      3 GETs  extra= 5 media=3  verified=0
zzznotarealuser99xzq@gmail.com   Not Found  2 GETs
john@example.com                 Not Found  2 GETs
not-an-email                     Not Found  2 GETs
""                               Not Found  2 GETs
```

The set covers a background image and colour, phone numbers, a profile with no verified accounts and no links, a near-empty profile, and both faults described above. `  BrunoLM7@GMAIL.com ` (case and surrounding whitespace) returns the same 19 fields as the clean spelling.

Not verified: `crypto_addresses` and `websites` (no public profile found that sets them), and the MD5-hash fallback leg, unchanged in behaviour but refactored into a loop alongside the SHA-256 attempt.
