### PR TITLE
fix(user_scan): restore 11 modules that could never return a verdict

### DIFF
--- a/user_scanner/user_scan/adult/adultism.py
+++ b/user_scanner/user_scan/adult/adultism.py
@@ -1,146 +1,123 @@
+import html
 import re
-from user_scanner.core.orchestrator import generic_validate, Result, make_request
+
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.result import Result
+
+BASE_URL = "https://www.adultism.com"
 
 
-def validate_adultism(user):
-    url = f"https://www.adultism.com/profile/{user}"
-    show_url = f"https://www.adultism.com/profile/{user}"
+def validate_adultism(user: str) -> Result:
+    url = f"{BASE_URL}/profile/{user}"
 
     def process(response):
-        if response.status_code == 200:
-            is_taken = (
-                re.search(r'itemprop="name">\s*' + re.escape(user) + r'\s*</h1>', response.text, re.IGNORECASE) or
-                re.search(r'<title>\s*' + re.escape(user) + r'\s*-\s*Adultism</title>', response.text, re.IGNORECASE) or
-                re.search(r'title="' + re.escape(user) + r'"', response.text, re.IGNORECASE) or
-                re.search(r'alt="' + re.escape(user) + r'"',
-                          response.text, re.IGNORECASE)
-            )
-            if is_taken:
-                extra = {}
-                media = {}
+        if response.status_code == 404:
+            if "No such member" in response.text:
+                return Result.available(url=url)
+            return Result.error("Unexpected 404 (not the not-found page)", url=url)
 
-                # Extract Avatar
-                avatar_match = re.search(r'<img[^>]+src="([^"]+)"[^>]*class="[^"]*profile-image', response.text, re.IGNORECASE) or \
-                    re.search(
-                        r'<img[^>]+class="[^"]*profile-image[^"]*"[^>]*src="([^"]+)"', response.text, re.IGNORECASE)
-                if avatar_match and "defaults/member" not in avatar_match.group(1):
-                    media["image"] = avatar_match.group(1)
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}", url=url)
 
-                # Extract Channel ID
-                channel_match = re.search(
-                    r'data-channel-id="(\d+)"', response.text, re.IGNORECASE)
-                if channel_match:
-                    extra["channel_id"] = channel_match.group(1)
+        profile = _profile_section(response.text)
+        if profile is None:
+            return Result.error("Profile confirmation not found", url=url)
 
-                # Extract Birth date
-                birthdate_match = re.search(
-                    r'<meta[^>]+itemprop="birthDate"[^>]+content="([^"]+)"', response.text, re.IGNORECASE)
-                if birthdate_match:
-                    extra["birthdate"] = birthdate_match.group(1)
+        # Lookups are case-insensitive and the heading carries the canonical
+        # spelling, so it is what ties the page to the requested handle.
+        nick = _nick(profile)
+        if nick.lower() != user.lower():
+            return Result.error("Profile heading does not match the handle", url=url)
 
-                # Extract Gender/Sex
-                sex_match = re.search(
-                    r'Sex:.*?<span[^>]*>\s*(.*?)\s*</span>', response.text, re.DOTALL | re.IGNORECASE)
-                if sex_match:
-                    cleaned_sex = re.sub(
-                        r"\s+", " ", sex_match.group(1)).replace("&nbsp;", " ").strip()
-                    extra["gender"] = cleaned_sex
-                else:
-                    gender_meta = re.search(
-                        r'<meta[^>]+itemprop="gender"[^>]+content="([^"]+)"', response.text, re.IGNORECASE)
-                    if gender_meta and gender_meta.group(1).strip():
-                        extra["gender"] = gender_meta.group(1).strip()
+        extra, media = _extract_profile(profile, nick)
+        extra.update(_fetch_friends_count(user))
+        return Result.taken(extra=extra, media=media, url=url)
 
-                # Extract Age
-                age_match = re.search(
-                    r'Age:.*?<span[^>]*>\s*(.*?)\s*</span>', response.text, re.DOTALL | re.IGNORECASE)
-                if age_match:
-                    extra["age"] = re.sub(
-                        r"\s+", " ", age_match.group(1)).strip()
+    return impersonate_validate(url, process, show_url=url)
 
-                # Extract Location
-                loc_match = re.search(
-                    r'Location:.*?<span[^>]*>\s*(.*?)\s*</span>', response.text, re.DOTALL | re.IGNORECASE)
-                if loc_match:
-                    extra["location"] = re.sub(
-                        r"\s+", " ", loc_match.group(1)).strip()
-                else:
-                    loc_meta = re.search(
-                        r'<meta[^>]+itemprop="homeLocation"[^>]+content="([^"]+)"', response.text, re.IGNORECASE)
-                    if loc_meta:
-                        extra["location"] = loc_meta.group(1).strip()
 
-                # Extract Last login
-                login_match = re.search(
-                    r'Last login:.*?<span[^>]*>(.*?)</span[^>]*>', response.text, re.DOTALL | re.IGNORECASE)
-                if login_match:
-                    val = login_match.group(1)
-                    val = re.sub(r'<[^>]+>', '', val)
-                    extra["last_login"] = re.sub(r"\s+", " ", val).strip()
+def _profile_section(html_text: str) -> str | None:
+    match = re.search(
+        r'(<section id="spr".*?itemtype="http://schema\.org/Person">.*)', html_text, re.DOTALL
+    )
+    return match.group(1) if match else None
 
-                # Extract Registration date
-                joined_match = re.search(
-                    r'Member since:.*?<span[^>]*>\s*(.*?)\s*</span>', response.text, re.DOTALL | re.IGNORECASE)
-                if joined_match:
-                    extra["joined"] = re.sub(
-                        r"\s+", " ", joined_match.group(1)).strip()
 
-                # Extract Subscriber count (checking data-canonical first, then quantity)
-                sub_match = re.search(
-                    r'class="[^"]*subscriber-count[^"]*"[^>]*data-canonical="(\d+)"', response.text, re.IGNORECASE)
-                if sub_match:
-                    extra["subscribers"] = sub_match.group(1)
-                else:
-                    quantity_match = re.search(
-                        r'subscriber-count.*?<span[^>]*class="[^"]*(?:quantity|value)[^"]*"[^>]*>([^<]+)</span>', response.text, re.DOTALL | re.IGNORECASE)
-                    if quantity_match:
-                        extra["subscribers"] = quantity_match.group(1).strip()
-                    else:
-                        sub_span = re.search(
-                            r'subscriber-count.*?<span[^>]*>([^<]+)</span>', response.text, re.DOTALL | re.IGNORECASE)
-                        if sub_span:
-                            extra["subscribers"] = sub_span.group(1).strip()
+def _nick(profile: str) -> str:
+    match = re.search(r'<h1 class="nick" itemprop="name">(.*?)</h1>', profile, re.DOTALL)
+    return _text(match.group(1)) if match else ""
 
-                # Extract Badges (Verified/Premium)
-                if "pc-verified" in response.text:
-                    extra["verified"] = "True"
-                if "pc-premium" in response.text:
-                    extra["premium"] = "True"
 
-                # Extract Description/Interests
-                interests_match = re.search(
-                    r'<div[^>]+itemprop="description"[^>]*>\s*(.*?)\s*</div>', response.text, re.DOTALL | re.IGNORECASE)
-                if interests_match:
-                    cleaned_interests = re.sub(
-                        r"\s+", " ", interests_match.group(1)).strip()
-                    extra["interests"] = cleaned_interests
+def _extract_profile(profile: str, nick: str) -> tuple[dict, dict]:
+    extra: dict = {"name": nick}
+    media: dict = {}
 
-                # Extract Comments
-                comments_match = re.search(
-                    r'<div class="comments">\s*<div[^>]*>Comments:</div>\s*(.*?)\s*</div>', response.text, re.DOTALL | re.IGNORECASE)
-                if comments_match:
-                    cleaned_comments = re.sub(
-                        r"\s+", " ", comments_match.group(1)).strip()
-                    extra["comments"] = cleaned_comments
+    channel_id = re.search(r'<section id="spr" data-channel-id="(\d+)"', profile)
+    if channel_id:
+        extra["channel_id"] = channel_id.group(1)
 
-                # Step 2: Fetch the friends page sequentially to extract exact friends count
-                try:
-                    friends_url = f"https://www.adultism.com/profile/{user}/friends"
-                    friends_resp = make_request(friends_url, timeout=5.0)
-                    if friends_resp.status_code == 200:
-                        friends_count_match = re.search(
-                            r'<li class="page item-count">(\d+)\s+items</li>', friends_resp.text, re.IGNORECASE)
-                        if friends_count_match:
-                            extra["friends_count"] = friends_count_match.group(
-                                1)
-                except Exception:
-                    pass  # Keep going if friends page request fails
+    # The badge row renders the visible count rounded ("5.5k"); data-canonical
+    # holds the exact figure.
+    subscribers = re.search(
+        r'class="cm-value subscriber-count"[^>]*data-canonical="(\d+)"', profile
+    )
+    if subscribers:
+        extra["subscribers"] = subscribers.group(1)
 
-                return Result.taken(extra=extra, media=media, url=show_url)
+    badges = re.findall(r'class="pc-badge pc-[^"]*"\s*title="([^"]+)"', profile)
+    if badges:
+        extra["badges"] = ", ".join(badges)
 
-        if response.status_code == 404 or "Page not found" in response.text:
-            return Result.available(url=show_url)
+    for key, prop in (("birthdate", "birthDate"), ("gender", "gender")):
+        meta = re.search(rf'<meta itemprop="{prop}" content="([^"]*)"', profile)
+        if meta:
+            extra[key] = meta.group(1)
 
-        return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+    for label, value in re.findall(
+        r'<div class="row">\s*<span class="label">(.*?)</span>\s*<span class="value[^"]*">(.*?)</span>',
+        profile,
+        re.DOTALL,
+    ):
+        extra[_text(label)] = _text(value)
 
-    return generic_validate(url, process, show_url=show_url)
+    interests = re.search(r'<div itemprop="description">(.*?)</div>', profile, re.DOTALL)
+    if interests:
+        extra["interests"] = _text(interests.group(1))
+
+    comments = re.search(
+        r'<div class="section-title">Comments:</div>(.*?)</div>', profile, re.DOTALL
+    )
+    if comments:
+        extra["comments"] = _text(comments.group(1))
+
+    avatar = re.search(
+        r'<a href="([^"]+)">\s*<div class="profile-image-wrapper">\s*'
+        r'<img src="([^"]+)"[^>]*class="profile-image"',
+        profile,
+        re.DOTALL,
+    )
+    if avatar:
+        media["avatar"] = avatar.group(2)
+        media["avatar_full"] = avatar.group(1)
+
+    return extra, media
+
+
+def _fetch_friends_count(user: str) -> dict:
+    """The friends tab is the only page exposing the exact friend total."""
+    try:
+        response = impersonate_request(f"{BASE_URL}/profile/{user}/friends")
+    except Exception:
+        return {}
+
+    if response.status_code != 200:
+        return {}
+
+    count = re.search(r'<li class="page item-count">(\d+)\s+items</li>', response.text)
+    return {"friends": count.group(1)} if count else {}
+
+
+def _text(html_fragment: str) -> str:
+    return re.sub(
+        r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", " ", html_fragment)).replace("\xa0", " ")
+    ).strip()

--- a/user_scanner/user_scan/adult/apclips.py
+++ b/user_scanner/user_scan/adult/apclips.py
@@ -1,84 +1,109 @@
-import re
 import html
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, generic_validate
+import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+BASE_URL = "https://apclips.com"
+
+ABOUT_STAT = re.compile(
+    r'<div class="about-stat">\s*<span class="stat-label">(.*?)</span>\s*'
+    r'<span class="stat-text">(.*?)</span>',
+    re.DOTALL,
+)
+
 
 def validate_apclips(user: str) -> Result:
-    url = f"https://apclips.com/{user}"
-    show_url = url
-
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
+    url = f"{BASE_URL}/{user}"
 
     def process(response):
-        final_url = str(response.url)
-        
-        if final_url.endswith("/models") or "/models" in final_url:
-            return Result.available()
+        if response.status_code in (301, 302):
+            # An unknown handle is bounced to the creator directory; following the
+            # redirect lands on a 200 listing page and destroys the miss signal.
+            location = response.headers.get("location", "")
+            if re.fullmatch(rf"(?:{re.escape(BASE_URL)})?/models/?", location):
+                return Result.available()
+            return Result.error(f"Unexpected redirect: {location}")
 
-        if response.status_code == 200:
-            if "AP Model" in response.text or "profile-fit-text" in response.text:
-                extra = {}
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
 
-                name_match = re.search(
-                    r'<h1 class="page-modelname[^"]*">\s*<span>([^<]+)</span>\s*</h1>',
-                    response.text,
-                    re.IGNORECASE
-                )
-                if name_match:
-                    extra["name"] = html.unescape(name_match.group(1)).strip()
+        page = response.text
+        owner = re.search(r'data-username="([^"]+)"', page)
+        if not owner or owner.group(1).lower() != user.lower():
+            return Result.error("Profile confirmation not found")
 
-                def parse_stat(label):
-                    match = re.search(
-                        rf'<span class="stat-label">[^<]*{label}[^<]*</span>\s*<span class="stat-text">([^<]+)</span>',
-                        response.text,
-                        re.IGNORECASE | re.DOTALL
-                    )
-                    if match:
-                        return match.group(1).strip()
-                    return None
+        return Result.taken(extra=_profile(page, user), media=_media(page, user))
 
-                videos = parse_stat("Videos")
-                if videos:
-                    extra["videos"] = videos
+    return impersonate_validate(url, process, show_url=url)
 
-                views = parse_stat("Views")
-                if views:
-                    extra["views"] = views
 
-                loves = parse_stat("Loves")
-                if loves:
-                    extra["loves"] = loves
+def _profile(page: str, user: str) -> dict:
+    extra: dict[str, str | bool | int] = {}
 
-                faved = parse_stat("Faved")
-                if faved:
-                    extra["faves"] = faved
+    # The masthead label names the account type ("AP Model", "AP Studio").
+    account_type = re.search(r'header-ctlabel"><i[^>]*></i>\s*([^<]+)<', page)
+    if account_type:
+        extra["type"] = _text(account_type.group(1))
 
-                if not extra.get("videos"):
-                    vid_match = re.search(r'<strong>(\d+)</strong>\s*Videos', response.text, re.IGNORECASE)
-                    if vid_match:
-                        extra["videos"] = vid_match.group(1)
+    name = re.search(r'<h1 class="page-modelname[^"]*"><span>([^<]+)</span>', page)
+    if name:
+        extra["name"] = _text(name.group(1))
 
-                photo_match = re.search(r'<strong>(\d+)</strong>\s*Photosets', response.text, re.IGNORECASE)
-                if photo_match:
-                    extra["photosets"] = photo_match.group(1)
+    creator_id = re.search(r'data-creator-id="(\d+)"', page)
+    if creator_id:
+        extra["creator_id"] = creator_id.group(1)
 
-                desc_match = re.search(
-                    r'<div class="text-medium[^"]*">\s*<p>([^<]+)</p>',
-                    response.text,
-                    re.IGNORECASE | re.DOTALL
-                )
-                if desc_match:
-                    extra["bio"] = html.unescape(desc_match.group(1)).strip()
+    bio = re.search(r'<div class="text-medium pb-2">(.*?)</div>', page, re.DOTALL)
+    if bio:
+        extra["bio"] = _text(bio.group(1))
 
-                return Result.taken(extra=extra)
+    for label, value in ABOUT_STAT.findall(page):
+        key = _text(label).lower().replace(" ", "_")
+        if key:
+            extra[key] = _text(value)
 
-        elif response.status_code == 404:
-            return Result.available()
+    # Section counts elsewhere on the page belong to fan-club upsells and other
+    # creators, so each is read from the heading that links to this profile.
+    for section in ("photosets", "bundles"):
+        count = re.search(
+            rf'<strong>([\d,]+)</strong>[^<]*<a href="/{re.escape(user)}/{section}"', page
+        )
+        if count:
+            extra[section] = count.group(1)
 
-        return Result.error(f"Unexpected response status: {response.status_code}")
+    categories = re.findall(r'class="profile-tag-link[^"]*"[^>]*>([^<]+)</a>', page)
+    if categories:
+        extra["categories"] = ", ".join(_text(x) for x in categories)
 
-    return generic_validate(url, process, headers=headers, http2=False, show_url=show_url, follow_redirects=True)
+    links = re.findall(
+        r'<a href="([^"]+)" target="_blank" class="btn btn-outline-dark btn-block"[^>]*>'
+        r'\s*<i[^>]*></i>\s*<span>([^<]*)</span>',
+        page,
+    )
+    if links:
+        extra["links"] = ", ".join(f"{_text(label)}: {href}" for href, label in links)
+
+    return extra
+
+
+def _media(page: str, user: str) -> dict:
+    media = {}
+    handle = re.escape(user)
+
+    avatar = re.search(rf'src="(/ui/img/model/{handle}/avatar/[^"]+)"', page)
+    if avatar:
+        media["avatar"] = BASE_URL + avatar.group(1)
+
+    banner = re.search(
+        rf'id="page-mast" style="background-image: url\(/?(ui/img/model/{handle}/header/[^)]+)\)',
+        page,
+    )
+    if banner:
+        media["banner"] = f"{BASE_URL}/{banner.group(1)}"
+
+    return media
+
+
+def _text(markup: str) -> str:
+    return re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", " ", markup))).strip()

--- a/user_scanner/user_scan/community/academia.py
+++ b/user_scanner/user_scan/community/academia.py
@@ -1,27 +1,159 @@
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+import html
+import json
+import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+# Academia.edu scopes handles per subdomain: the same slug can belong to a
+# different person on an institution host (e.g. ucp.academia.edu). Only the
+# independent-researcher namespace is checkable without enumerating every
+# institution subdomain, so a verdict here covers that namespace alone.
+BASE_URL = "https://independent.academia.edu"
+
 
 def validate_academia(user: str) -> Result:
-    if "." in user:
-        return Result.available("Username cannot contain periods")
+    url = f"{BASE_URL}/{user}"
 
-    url = f"https://independent.academia.edu/{user}"
-    
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9",
-        "Accept-Language": "en-US,en;q=0.9",
+    # Rails reads the segment after a dot as a format extension, so
+    # "/John.Smith" serves the unrelated profile "/john". Such a handle is not
+    # addressable and must not be turned into a verdict.
+    if "." in user:
+        return Result.error("Handles containing a period are not addressable", url=url)
+
+    def process(response):
+        if response.status_code == 404:
+            if "wrong aisle" in response.text:
+                return Result.available(url=url)
+            return Result.error("Unexpected 404 (not the not-found page)", url=url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}", url=url)
+
+        profile = _profile_json(response.text)
+        if profile is None:
+            return Result.error("Profile confirmation not found", url=url)
+
+        # A miss redirects rather than 404s in some casings, and the dot route
+        # above lands on a foreign profile, so the embedded canonical handle is
+        # what confirms the page belongs to the requested user.
+        handle = str(profile.get("mainEntity", {}).get("url", "")).rstrip("/").rsplit("/", 1)[-1]
+        if handle.lower() != user.lower():
+            return Result.error(f"Profile resolved to a different handle: {handle}", url=url)
+
+        extra, media = _extract_profile(response.text, profile)
+        return Result.taken(extra=extra, media=media, url=url)
+
+    return impersonate_validate(url, process, show_url=url, allow_redirects=True)
+
+
+def _profile_json(html_text: str) -> dict | None:
+    for block in re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', html_text, re.DOTALL
+    ):
+        try:
+            data = json.loads(block)
+        except ValueError:
+            continue
+        if isinstance(data, dict) and data.get("@type") == "ProfilePage":
+            return data
+    return None
+
+
+def _extract_profile(html_text: str, profile: dict) -> tuple[dict, dict]:
+    person = profile.get("mainEntity", {})
+    extra: dict = {"name": person.get("name")}
+    media: dict = {}
+
+    avatar = person.get("image")
+    if avatar and "no_pic" not in avatar:
+        media["avatar"] = avatar
+
+    for key, field in (("joined", "dateCreated"), ("updated", "dateModified")):
+        value = profile.get(field)
+        if value:
+            extra[key] = value[:10]
+
+    extra["bio"] = profile.get("description")
+
+    links = person.get("sameAs") or profile.get("sameAs")
+    if links:
+        extra["links"] = ", ".join(links)
+
+    affiliation = re.search(
+        r'class="affiliations-container[^"]*"[^>]*>(.*?)</div>', html_text, re.DOTALL
+    )
+    if affiliation:
+        extra["affiliation"] = _text(affiliation.group(1))
+
+    # Every follow control on the page belongs to the profile owner; the
+    # related-author cards carry no user id of their own.
+    user_id = re.search(r'data-follow-user-id="(\d+)"', html_text)
+    if user_id:
+        extra["user_id"] = user_id.group(1)
+        extra.update(_extract_interests(html_text, user_id.group(1)))
+
+    extra.update(_extract_stats(html_text))
+    extra.update(_extract_bio_details(html_text))
+
+    return extra, media
+
+
+def _extract_interests(html_text: str, user_id: str) -> dict:
+    interests = {}
+
+    total = re.search(
+        rf'data-has-card-for-ri-list="{user_id}"[^>]*>View All \((\d+)\)', html_text
+    )
+    if total:
+        interests["interests_count"] = total.group(1)
+
+    # The interest pills render as sibling React payloads; keying the enclosing
+    # anchor on the owner's id keeps a recommendation carousel out of the list.
+    labels: list[str] = []
+    for anchor in re.findall(
+        rf'data-has-card-for-ri-list="{user_id}"(.*?)</a>', html_text, re.DOTALL
+    ):
+        pill = re.search(r'data-component-name="Pill"[^>]*>(\{.*?\})</script>', anchor, re.DOTALL)
+        if not pill:
+            continue
+        try:
+            children = json.loads(pill.group(1)).get("children") or []
+        except ValueError:
+            continue
+        labels.extend(str(child) for child in children)
+
+    if labels:
+        interests["interests"] = ", ".join(labels)
+
+    return interests
+
+
+def _extract_stats(html_text: str) -> dict:
+    region = re.search(r'class="user-stats-container"(.*?)<aside', html_text, re.DOTALL)
+    if not region:
+        return {}
+
+    stats = {}
+    for label, value in re.findall(
+        r'<p class="label">(.*?)</p>\s*<p class="data">(.*?)</p>', region.group(1), re.DOTALL
+    ):
+        stats[_text(label)] = _text(value)
+    return stats
+
+
+def _extract_bio_details(html_text: str) -> dict:
+    bio = re.search(r'class="profile-bio[^"]*"[^>]*>(.*?)</div>', html_text, re.DOTALL)
+    if not bio:
+        return {}
+
+    return {
+        _text(label): _text(value)
+        for label, value in re.findall(
+            r'<span class="u-fw700">(.*?):.*?</span>(.*?)<br\s*/?>', bio.group(1), re.DOTALL
+        )
     }
-    
-    try:
-        response = make_request(url, headers=headers, follow_redirects=True)
-        
-        if response.status_code == 200:
-            return Result.taken(url=url)
-        elif response.status_code == 404:
-            return Result.available(url=url)
-            
-        return Result.error(f"Unexpected response status: {response.status_code}", url=url)
-        
-    except Exception as e:
-        return Result.error(e, url=url)
+
+
+def _text(html_fragment: str) -> str:
+    return re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", "", html_fragment))).strip()

--- a/user_scanner/user_scan/creator/unsplash.py
+++ b/user_scanner/user_scan/creator/unsplash.py
@@ -1,39 +1,99 @@
-import re
-import html
-import httpx
-from user_scanner.core.result import Result
-from user_scanner.core.orchestrator import make_request
+import json
 
-def validate_unsplash(username: str) -> Result:
-    """Validate a username on Unsplash."""
-    url = f"https://unsplash.com/@{username}"
-    show_url = f"https://unsplash.com/@{username}"
-    
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.result import Result
+
+BASE_URL = "https://unsplash.com"
+# The site's own profile API. It answers with the full user object for a real
+# handle and a distinct not-found payload otherwise, unlike the profile page,
+# which is client-rendered and identical either way.
+API_URL = f"{BASE_URL}/napi/users"
+NOT_FOUND_MARKER = "Couldn't find User"
+
+FIELDS = {
+    "name": "name",
+    "id": "id",
+    "numeric_id": "numeric_id",
+    "bio": "bio",
+    "location": "location",
+    "portfolio_url": "portfolio",
+    "instagram_username": "instagram",
+    "twitter_username": "twitter",
+}
+COUNTS = {
+    "total_photos": "photos",
+    "total_illustrations": "illustrations",
+    "total_collections": "collections",
+    "total_likes": "likes",
+}
+
+
+def validate_unsplash(user: str) -> Result:
+    show_url = f"{BASE_URL}/@{user}"
+
+    def process(response) -> Result:
+        if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
+            return Result.available()
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
+
+        try:
+            profile = json.loads(response.text)
+        except json.JSONDecodeError:
+            return Result.error("Malformed JSON response, report it on Github")
+
+        if str(profile.get("username", "")).lower() != user.lower():
+            return Result.error("Profile payload does not match the requested handle")
+
+        return Result.taken(extra=_extract_profile(profile), media=_extract_media(profile))
+
+    return impersonate_validate(
+        f"{API_URL}/{user}", process, show_url=show_url, allow_redirects=True)
+
+
+def _extract_profile(profile: dict) -> dict:
+    extra: dict[str, str | bool | int] = {}
+
+    for field, label in FIELDS.items():
+        value = profile.get(field)
+        if value in (None, ""):
+            continue
+        extra[label] = value if isinstance(value, (bool, int)) else str(value).strip()
+
+    for field, label in COUNTS.items():
+        value = profile.get(field)
+        if isinstance(value, int):
+            extra[label] = value
+
+    badge = profile.get("badge") or {}
+    if badge.get("title"):
+        extra["badge"] = badge["title"]
+
+    if profile.get("for_hire"):
+        extra["for_hire"] = True
+
+    downloads = _total_downloads(profile["username"])
+    if downloads is not None:
+        extra["downloads"] = downloads
+
+    return extra
+
+
+def _total_downloads(user: str) -> int | None:
+    """The user object carries a `downloads` key that is 0 for every account;
+    the real lifetime figure only comes from the statistics endpoint."""
     try:
-        # We pass headers={} to use httpx's default user-agent, 
-        # as Unsplash blocks/redirects the default browser user-agent.
-        response = make_request(url, headers={}, follow_redirects=True)
-        response_text = response.text
-        
-        # Verify status code 200 AND check unique Unsplash strings in the response body to prevent false positives
-        if response.status_code == 200 and "unsplash" in response_text.lower() and "page not found" not in response_text.lower():
-            extra = {}
-            title_match = re.search(r"<title>(.*?)</title>", response_text, re.IGNORECASE)
-            if title_match:
-                title = html.unescape(title_match.group(1).strip())
-                title_clean = title.split(" | ")[0]
-                match = re.search(r"^(.*?)\s*\((?:@" + re.escape(username) + r")\)", title_clean, re.IGNORECASE)
-                if match:
-                    name = match.group(1).strip()
-                    name = re.sub(r"'\s*s (?:Collections|Photos|Likes|Stats)$", "", name, flags=re.IGNORECASE)
-                    name = re.sub(r"'\''s (?:Collections|Photos|Likes|Stats)$", "", name, flags=re.IGNORECASE)
-                    extra["name"] = name
-            return Result.taken(extra=extra, url=show_url)
-        elif response.status_code == 404 or "page not found" in response_text.lower():
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except httpx.TimeoutException:
-        return Result.skipped("Connection timed out")
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        response = impersonate_request(
+            f"{API_URL}/{user}/statistics", allow_redirects=True)
+        if response.status_code != 200:
+            return None
+        total = json.loads(response.text).get("downloads", {}).get("total")
+    except Exception:
+        return None
+    return total if isinstance(total, int) else None
+
+
+def _extract_media(profile: dict) -> dict:
+    images = profile.get("profile_image") or {}
+    avatar = images.get("large") or images.get("medium") or images.get("small")
+    return {"avatar": avatar} if avatar else {}

--- a/user_scanner/user_scan/dev/npmjs.py
+++ b/user_scanner/user_scan/dev/npmjs.py
@@ -1,18 +1,86 @@
+import base64
+import json
 import re
 
-from user_scanner.core.orchestrator import Result, status_validate
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+BASE_URL = "https://www.npmjs.com"
+NOT_FOUND_MESSAGE = "Scope not found"
 
 
-def validate_npmjs(user):
-    if re.match(r"^[^a-zA-Z0-9_-]", user):
-        return Result.error("Username cannot start with a period")
-
+def validate_npmjs(user: str) -> Result:
+    """npm serves the scope page as JSON when asked with ``x-spiferack``, the
+    header its own front end uses; ``/~<name>`` resolves both user and org
+    scopes, so the account type comes from ``scope.type``.
+    """
     if re.search(r"[A-Z]", user):
         return Result.error("Username cannot contain uppercase letters.")
 
-    url = f"https://www.npmjs.com/~{user}"
-    show_url = f"https://www.npmjs.com/~{user}"
+    url = f"{BASE_URL}/~{user}"
 
-    return status_validate(
-        url, 404, 200, show_url=show_url, timeout=3.0, follow_redirects=True
+    def process(response) -> Result:
+        try:
+            data = response.json()
+        except Exception:
+            return Result.error(f"Unexpected response status: {response.status_code}")
+
+        if response.status_code == 404:
+            if NOT_FOUND_MESSAGE in (data.get("message") or ""):
+                return Result.available()
+            return Result.error(f"Unexpected response body: {data.get('message')}")
+
+        scope = data.get("scope") or {}
+        parent = scope.get("parent") or {}
+        if response.status_code == 200 and parent.get("name") == user:
+            extra = _profile(data, scope, parent)
+            media = {}
+            if avatar := _avatar(parent):
+                media["avatar"] = avatar
+            return Result.taken(extra=extra, media=media)
+
+        return Result.error(f"Unexpected response status: {response.status_code}")
+
+    return impersonate_validate(
+        url, process, headers={"x-spiferack": "1"}, show_url=url
     )
+
+
+def _profile(data: dict, scope: dict, parent: dict) -> dict:
+    resource = parent.get("resource") or {}
+    extra: dict[str, str | int] = {}
+
+    for value, key in (
+        (scope.get("type"), "type"),
+        (resource.get("fullname"), "fullname"),
+        (parent.get("description"), "description"),
+        (scope.get("id"), "id"),
+        (scope.get("created"), "created"),
+    ):
+        if value:
+            extra[key] = value
+
+    if github := resource.get("github"):
+        extra["github"] = f"https://github.com/{github}"
+
+    packages = (data.get("packages") or {}).get("total")
+    if packages is not None:
+        extra["packages"] = packages
+
+    return extra
+
+
+def _avatar(parent: dict) -> str | None:
+    """Avatars are served as ``/npm-avatar/<jwt>``; the unsigned payload holds
+    the upstream image URL, which outlives the token wrapper.
+    """
+    path = (parent.get("avatars") or {}).get("large")
+    if not path:
+        return None
+
+    try:
+        payload = path.rsplit("/", 1)[-1].split(".")[1]
+        decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+        return json.loads(decoded)["avatarURL"]
+    except Exception:
+        return f"{BASE_URL}{path}"

--- a/user_scanner/user_scan/dev/sourceforge.py
+++ b/user_scanner/user_scan/dev/sourceforge.py
@@ -1,6 +1,19 @@
+import html
 import re
 
-from user_scanner.core.orchestrator import Result, status_validate
+from user_scanner.core.impersonate import impersonate_request
+from user_scanner.core.result import Result
+
+BASE_URL = "https://sourceforge.net"
+
+# Cloudflare answers every other curl_cffi fingerprint (including the default
+# "chrome") with a "Just a moment..." interstitial on this host; "safari184" is
+# the only profile that reaches the origin. The same page comes back with 429
+# once the host starts rate limiting, so it is matched on its title, not status.
+IMPERSONATE = "safari184"
+
+NOT_FOUND_TITLE = "Page not found - SourceForge.net"
+MAX_LISTED_PROJECTS = 20
 
 
 def validate_sourceforge(user: str) -> Result:
@@ -13,7 +26,156 @@ def validate_sourceforge(user: str) -> Result:
 
         return Result.error("Only use lowercase letters, numbers, and dashes.")
 
-    url = f"https://sourceforge.net/u/{user}/"
-    show_url = f"https://sourceforge.net/u/{user}/"
+    show_url = f"{BASE_URL}/u/{user}/profile/"
 
-    return status_validate(url, 404, 200, show_url=show_url, follow_redirects=True)
+    try:
+        response = impersonate_request(
+            f"{BASE_URL}/rest/u/{user}/profile", impersonate=IMPERSONATE, allow_redirects=True
+        )
+    except Exception as e:
+        return Result.error(e, url=show_url)
+
+    if _is_challenge(response.text):
+        return Result.error("Blocked by a Cloudflare challenge", url=show_url)
+
+    if response.status_code == 404:
+        if _title(response.text) == NOT_FOUND_TITLE:
+            return Result.available(url=show_url)
+        return Result.error("Unexpected 404 (not the not-found page)", url=show_url)
+
+    if response.status_code != 200:
+        return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+
+    try:
+        profile = response.json()
+    except Exception:
+        return Result.error("Profile endpoint did not return JSON", url=show_url)
+
+    if str(profile.get("username", "")).lower() != user.lower():
+        return Result.error("Profile confirmation not found", url=show_url)
+
+    extra, media = _extract_page(user)
+    extra.update(_extract_profile(profile))
+
+    return Result.taken(extra=extra, media=media, url=show_url)
+
+
+def _extract_page(user: str) -> tuple[dict, dict]:
+    """Read the headline, latest activity and avatar, which the REST profile
+    does not expose. Best effort: a failure here must not affect the verdict."""
+    try:
+        response = impersonate_request(
+            f"{BASE_URL}/u/{user}/profile/", impersonate=IMPERSONATE, allow_redirects=True
+        )
+    except Exception:
+        return {}, {}
+
+    if response.status_code != 200 or _is_challenge(response.text):
+        return {}, {}
+
+    page = response.text
+    extra: dict = {}
+    media: dict = {}
+
+    # The activity feed below repeats both the avatar and h2 markup for other
+    # users, so the header block is the only safe place to read them from.
+    header = _slice(page, '<div class="overview">', "</section>")
+
+    headline = re.search(r'<h2 class="as-h3 summary">(.*?)</h2>', header, re.DOTALL)
+    if headline:
+        extra["headline"] = _text(headline.group(1))
+
+    # The activity feed is ordered newest first.
+    activity = re.search(r'<time datetime="([^"]+)"', page)
+    if activity:
+        extra["last_activity"] = activity.group(1)
+
+    avatar = re.search(r'<img[^>]+src="([^"]*user_icon[^"]*)"', header)
+    if avatar:
+        media["avatar"] = html.unescape(avatar.group(1))
+
+    return extra, media
+
+
+def _extract_profile(profile: dict) -> dict:
+    extra: dict = {}
+
+    if profile.get("name"):
+        extra["name"] = profile["name"]
+
+    if profile.get("joined"):
+        extra["joined"] = profile["joined"]
+
+    localization = profile.get("localization") or {}
+    location = ", ".join(
+        part for part in (localization.get("city"), localization.get("country")) if part
+    )
+    if location:
+        extra["location"] = location
+
+    # The field defaults to "Unknown" for everyone who never set it.
+    if profile.get("sex") and profile["sex"] != "Unknown":
+        extra["sex"] = profile["sex"]
+
+    if profile.get("webpages"):
+        extra["webpages"] = ", ".join(profile["webpages"])
+
+    if profile.get("telnumbers"):
+        extra["phone_numbers"] = ", ".join(profile["telnumbers"])
+
+    socials = "; ".join(
+        f"{entry.get('socialnetwork')}: {entry.get('accounturl')}"
+        for entry in profile.get("socialnetworks") or []
+        if entry.get("accounturl")
+    )
+    if socials:
+        extra["social_networks"] = socials
+
+    skills = "; ".join(_format_skill(entry) for entry in profile.get("skills") or [])
+    if skills:
+        extra["skills"] = skills
+
+    availability = "; ".join(
+        f"{slot.get('week_day')} {slot.get('start_time')}-{slot.get('end_time')}"
+        for slot in profile.get("availability") or []
+    )
+    if availability:
+        extra["availability"] = availability
+
+    projects = profile.get("projects") or []
+    if projects:
+        extra["projects"] = len(projects)
+        names = [project.get("name", "") for project in projects[:MAX_LISTED_PROJECTS]]
+        if len(projects) > MAX_LISTED_PROJECTS:
+            names.append(f"(+{len(projects) - MAX_LISTED_PROJECTS} more)")
+        extra["project_names"] = ", ".join(name for name in names if name)
+
+    return extra
+
+
+def _format_skill(entry: dict) -> str:
+    skill = entry.get("skill") or {}
+    name = skill.get("fullname") or skill.get("fullpath") or skill.get("shortname") or ""
+    level = entry.get("level")
+    return f"{name} ({level})" if name and level else name
+
+
+def _is_challenge(page: str) -> bool:
+    return _title(page) == "Just a moment..."
+
+
+def _title(page: str) -> str:
+    match = re.search(r"<title[^>]*>(.*?)</title>", page, re.IGNORECASE | re.DOTALL)
+    return _text(match.group(1)) if match else ""
+
+
+def _slice(page: str, start_marker: str, end_marker: str) -> str:
+    start = page.find(start_marker)
+    if start < 0:
+        return ""
+    end = page.find(end_marker, start + len(start_marker))
+    return page[start:end] if end > 0 else page[start:]
+
+
+def _text(markup: str) -> str:
+    return html.unescape(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", markup))).strip()

--- a/user_scanner/user_scan/gaming/kick.py
+++ b/user_scanner/user_scan/gaming/kick.py
@@ -1,34 +1,105 @@
-from user_scanner.core.orchestrator import Result, make_request
+import json
+import re
 
-def validate_kick(user):
-    api_url = f"https://kick.com/api/v2/channels/{user}"
-    show_url = f"https://kick.com/{user}"
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
-    # Kick often uses aggressive Cloudflare blocking, so we'll use a more standard browser User-Agent
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
-        "Accept": "application/json",
+BASE_URL = "https://kick.com"
+
+SOCIALS = ("twitter", "instagram", "youtube", "tiktok", "facebook", "discord")
+
+
+def validate_kick(user: str) -> Result:
+    show_url = f"{BASE_URL}/{user}"
+
+    def process(response):
+        if response.status_code == 404:
+            if '"message":"Channel not found."' in response.text:
+                return Result.available()
+            return Result.error("Unexpected 404 (not the not-found payload)")
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
+
+        try:
+            channel = json.loads(response.text)
+        except json.JSONDecodeError:
+            return Result.error("Channel API returned a non-JSON body")
+
+        slug = channel.get("slug")
+        if not isinstance(slug, str) or slug.lower() != user.lower():
+            return Result.error("Channel payload did not match the requested handle")
+
+        return Result.taken(extra=_profile(channel), media=_media(channel))
+
+    # kick.com/<user> is a client-rendered shell that answers 200 for any handle,
+    # so the channel API is the only source of a verdict.
+    return impersonate_validate(
+        f"{BASE_URL}/api/v2/channels/{user}", process, show_url=show_url
+    )
+
+
+def _profile(channel: dict) -> dict:
+    account = channel.get("user") or {}
+    livestream = channel.get("livestream") or {}
+
+    extra = {
+        "display_name": account.get("username"),
+        "user_id": account.get("id"),
+        "channel_id": channel.get("id"),
+        "bio": _clean(account.get("bio")),
+        "verified": channel.get("verified"),
+        "followers": _as_int(channel.get("followers_count")),
+        "is_banned": channel.get("is_banned"),
+        "is_affiliate": channel.get("is_affiliate"),
+        "subscriptions_enabled": channel.get("subscription_enabled"),
+        "vod_enabled": channel.get("vod_enabled"),
+        "is_live": bool(livestream.get("is_live")),
     }
 
+    extra.update({name: account.get(name) for name in SOCIALS})
+
+    recent = [c.get("name") for c in channel.get("recent_categories") or []]
+    extra["recent_categories"] = ", ".join(x for x in recent if x)
+
+    if livestream:
+        categories = [c.get("name") for c in livestream.get("categories") or []]
+        extra.update(
+            {
+                "stream_title": _clean(livestream.get("session_title")),
+                "stream_category": ", ".join(x for x in categories if x),
+                "stream_viewers": livestream.get("viewer_count"),
+                "stream_started_at": livestream.get("start_time"),
+                "stream_language": livestream.get("language"),
+                "stream_is_mature": livestream.get("is_mature"),
+            }
+        )
+
+    return {key: value for key, value in extra.items() if value not in (None, "")}
+
+
+def _media(channel: dict) -> dict:
+    account = channel.get("user") or {}
+    livestream = channel.get("livestream") or {}
+
+    media = {
+        "avatar": account.get("profile_pic"),
+        "banner": (channel.get("banner_image") or {}).get("url"),
+        "offline_banner": (channel.get("offline_banner_image") or {}).get("src"),
+        "stream_thumbnail": (livestream.get("thumbnail") or {}).get("url"),
+    }
+    return {key: value for key, value in media.items() if value}
+
+
+def _as_int(value) -> int | None:
+    # followers_count arrives as an int on some channels and a numeric string on others.
     try:
-        response = make_request(api_url, headers=headers, follow_redirects=True)
-        if response.status_code == 200:
-            data = response.json()
-            
-            extra = {}
-            if user_id := data.get("id"):
-                extra["id"] = str(user_id)
-            if slug := data.get("slug"):
-                extra["slug"] = slug
-            if "is_banned" in data:
-                extra["is_banned"] = str(data["is_banned"])
-                
-            return Result.taken(extra=extra, url=show_url)
-            
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-            
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clean(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return re.sub(r"\s+", " ", value).strip()

--- a/user_scanner/user_scan/shopping/osta.py
+++ b/user_scanner/user_scan/shopping/osta.py
@@ -1,46 +1,80 @@
 import html
 import re
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
-from user_scanner.core.orchestrator import generic_validate, make_request
+from user_scanner.core.impersonate import impersonate_request
 from user_scanner.core.result import Result
 
 BASE_URL = "https://www.osta.ee"
+DEFAULT_AVATAR_PATH = "/assets/gfx/images/avatar_"
 
 
 def validate_osta(user: str) -> Result:
-    url = (
-        f"{BASE_URL}/en?fuseaction=listing.seller&q%5Bseller%5D="
+    seller = _canonical_name(user) or user
+    url = _seller_url(seller)
+
+    try:
+        response = impersonate_request(url, allow_redirects=True)
+    except Exception as exc:
+        return Result.error(exc, url=url)
+
+    if response.status_code == 404 and 'class="error-image"' in response.text:
+        return Result.available(url=url)
+
+    if response.status_code == 200 and re.search(
+        rf'<strong class="username[^"]*">\s*{re.escape(seller)}\s*</strong>',
+        response.text,
+        re.IGNORECASE,
+    ):
+        extra = _extract_profile(response.text)
+        if seller != user:
+            extra["username"] = seller
+
+        profile_url = (
+            f"{BASE_URL}/en/user/{user_id}"
+            if (user_id := _user_id(response.text))
+            else ""
+        )
+        if profile_url:
+            extra.update(_fetch(profile_url, _extract_profile) or {})
+            about_url = f"{BASE_URL}/en?fuseaction=listing.aboutseller&user={user_id}"
+            if (about := _fetch(about_url, _extract_about)) is not None:
+                extra.update(about)
+
+        media = {"avatar": extra.pop("avatar")} if "avatar" in extra else {}
+        return Result.taken(extra=extra, media=media, url=profile_url or url)
+
+    return Result.error(f"Unexpected response status: {response.status_code}", url=url)
+
+
+def _canonical_name(user: str) -> str | None:
+    """The seller listing is case-sensitive, so ``kristjan123`` misses the real
+    ``Kristjan123``. The search route resolves a name case-insensitively and
+    redirects to the canonical spelling; a name that resolves to nothing gets a
+    plain 200 search page instead, which carries no verdict of its own.
+    """
+    search_url = (
+        f"{BASE_URL}/en?fuseaction=search.search&q%5Bseller%5D="
         f"{quote(user, safe='')}"
     )
+    try:
+        response = impersonate_request(search_url, allow_redirects=False)
+    except Exception:
+        return None
 
-    def process(response):
-        if response.status_code == 404:
-            return Result.available()
+    location = response.headers.get("location") or ""
+    if response.status_code not in (301, 302) or "listing.seller" not in location:
+        return None
 
-        if response.status_code == 200 and re.search(
-            rf'<strong class="username[^"]*">\s*{re.escape(user)}\s*</strong>',
-            response.text,
-            re.IGNORECASE,
-        ):
-            extra = _extract_profile(response.text)
-            profile_url = (
-                f"{BASE_URL}/en/user/{user_id}"
-                if (user_id := _user_id(response.text))
-                else ""
-            )
-            if profile_url:
-                extra.update(_fetch(profile_url, _extract_profile) or {})
-                about_url = f"{BASE_URL}/en?fuseaction=listing.aboutseller&user={user_id}"
-                if (about := _fetch(about_url, _extract_about)) is not None:
-                    extra.update(about)
+    names = re.findall(r"[?&]q\[seller\]=([^&]*)", location)
+    return unquote(names[-1]) if names else None
 
-            media = {"avatar": extra.pop("avatar")} if "avatar" in extra else {}
-            return Result.taken(extra=extra, media=media, url=profile_url)
 
-        return Result.error(f"Unexpected response status: {response.status_code}")
-
-    return generic_validate(url, process, follow_redirects=True)
+def _seller_url(seller: str) -> str:
+    return (
+        f"{BASE_URL}/en?fuseaction=listing.seller&q%5Bseller%5D="
+        f"{quote(seller, safe='')}"
+    )
 
 
 def _user_id(html_text: str) -> str | None:
@@ -50,7 +84,7 @@ def _user_id(html_text: str) -> str | None:
 
 def _fetch(url: str, extract):
     try:
-        response = make_request(url, follow_redirects=True)
+        response = impersonate_request(url, allow_redirects=True)
         return extract(response.text) if response.status_code == 200 else None
     except Exception:
         return None
@@ -80,7 +114,7 @@ def _extract_profile(html_text: str) -> dict:
     fields = (
         (r"([\d,.]+)\s+Successful sales per year\b", "successful_sales_per_year"),
         (r"([\d,.]+)\s+Followers\b", "followers"),
-        (r"([\d,.]+)\s+Active sales\b", "active_sales"),
+        (r"\bActive sales\s+([\d,.]+)", "active_sales"),
         (r"\bFeedback\s+([\d,.]+)", "feedback_total"),
     )
     for pattern, key in fields:
@@ -106,8 +140,8 @@ def _extract_profile(html_text: str) -> dict:
         html_text,
         re.IGNORECASE,
     )
-    if avatar:
-        extra["avatar"] = html.unescape(avatar.group(1))
+    if avatar and DEFAULT_AVATAR_PATH not in (url := html.unescape(avatar.group(1))):
+        extra["avatar"] = url
 
     return extra
 

--- a/user_scanner/user_scan/shopping/themeforest.py
+++ b/user_scanner/user_scan/shopping/themeforest.py
@@ -1,24 +1,136 @@
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+import html
+import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+BASE_URL = "https://themeforest.net"
+
+# Cloudflare answers every other curl_cffi fingerprint (including the default
+# "chrome") with a "Just a moment..." interstitial on this host; "safari184" is
+# the only profile that reaches the origin.
+IMPERSONATE = "safari184"
+
+BIO_MAX_LENGTH = 500
+
 
 def validate_themeforest(user: str) -> Result:
-    url = f"https://themeforest.net/user/{user}"
-    
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    
-    try:
-        response = make_request(url, headers=headers, follow_redirects=True)
-        
-        if response.status_code == 200:
-            return Result.taken(url=url)
-        elif response.status_code == 404:
-            return Result.available(url=url)
-            
-        return Result.error(f"Unexpected response status: {response.status_code}", url=url)
-        
-    except Exception as e:
-        return Result.error(e, url=url)
+    url = f"{BASE_URL}/user/{user}"
+
+    def process(response):
+        page = response.text
+
+        if _is_challenge(page):
+            return Result.error("Blocked by a Cloudflare challenge")
+
+        if response.status_code == 404:
+            if _title(page) == "Page Not Found | ThemeForest":
+                return Result.available()
+            return Result.error("Unexpected 404 (not the not-found page)")
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        # A live profile is titled "<handle>'s profile on ThemeForest" and
+        # canonicalises to the handle's own URL; both miss pages fall back to
+        # the generic site chrome.
+        canonical = re.search(r'<link rel="canonical" href="[^"]*/user/([^"/]+)"', page)
+        if not canonical or canonical.group(1).lower() != user.lower():
+            return Result.error("Profile confirmation not found")
+
+        extra, media = _extract_profile(page)
+        return Result.taken(extra=extra, media=media)
+
+    return impersonate_validate(
+        url,
+        process,
+        impersonate=IMPERSONATE,
+        show_url=url,
+        allow_redirects=True,
+    )
+
+
+def _extract_profile(page: str) -> tuple[dict, dict]:
+    extra: dict = {}
+    media: dict = {}
+
+    header = _slice(page, '<div class="user-info-header', "user-info-header__tabs")
+
+    name = re.search(r"<h1[^>]*>(.*?)</h1>", header, re.DOTALL)
+    if name:
+        extra["display_name"] = _text(name.group(1))
+
+    level = re.search(
+        r'user-info-header__author-level"[^>]*>\s*<strong>(.*?)</strong>', header, re.DOTALL
+    )
+    if level:
+        extra["author_level"] = _text(level.group(1))
+
+    # The subtitle line reads "<Country>, Member since <Month Year>", and drops
+    # the country for accounts that expose no location.
+    subtitle = re.search(r'<p class="t-body -size-m h-p0 h-mb0">(.*?)</p>', header, re.DOTALL)
+    if subtitle:
+        parts = re.match(r"(?:(.*?),\s*)?Member since (.+)$", _text(subtitle.group(1)))
+        if parts:
+            extra["location"] = parts.group(1)
+            extra["member_since"] = parts.group(2)
+
+    rating = re.search(r'<span class="is-visually-hidden">([\d.]+) stars</span>', header)
+    if rating:
+        extra["author_rating"] = rating.group(1)
+
+    ratings = re.search(r"\(([\d,]+) ratings\)", header)
+    if ratings:
+        extra["ratings"] = ratings.group(1)
+
+    # Only authors carry a sales figure, so its presence is what separates a
+    # selling account from a plain marketplace member.
+    sales = re.search(r'itemprop="interactionCount" content="AuthorSales:([\d,]+)"', header)
+    if sales:
+        extra["sales"] = sales.group(1)
+    extra["account_type"] = "author" if sales else "member"
+
+    for tab in ("followers", "following"):
+        count = re.search(
+            rf'href="/user/[^"]+/{tab}">[^<]*<span[^>]*>([\d,]+)</span>', page, re.IGNORECASE
+        )
+        if count:
+            extra[tab] = count.group(1)
+
+    bio = _text(_slice(page, '<div class="user-html"', "</div>"))
+    if bio:
+        extra["bio"] = bio if len(bio) <= BIO_MAX_LENGTH else f"{bio[:BIO_MAX_LENGTH]}..."
+
+    badges = re.findall(r'data-title="([^"]+)"', _slice(page, "user-info__badges", "</ul>"))
+    if badges:
+        extra["badges"] = "; ".join(html.unescape(badge) for badge in badges)
+
+    avatar = re.search(
+        r'data-src="([^"]+)"[^>]*user-info-header__user-profile-image-placeholder', header
+    ) or re.search(r'<img[^>]+src="([^"]+)"', header)
+    # Accounts without an uploaded avatar are served a shared placeholder image.
+    if avatar and "default-user" not in avatar.group(1):
+        media["avatar"] = avatar.group(1)
+
+    return extra, media
+
+
+def _is_challenge(page: str) -> bool:
+    return _title(page) == "Just a moment..."
+
+
+def _title(page: str) -> str:
+    match = re.search(r"<title[^>]*>(.*?)</title>", page, re.IGNORECASE | re.DOTALL)
+    return _text(match.group(1)) if match else ""
+
+
+def _slice(page: str, start_marker: str, end_marker: str) -> str:
+    start = page.find(start_marker)
+    if start < 0:
+        return ""
+    end = page.find(end_marker, start + len(start_marker))
+    return page[start:end] if end > 0 else page[start:]
+
+
+def _text(markup: str) -> str:
+    return html.unescape(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", markup))).strip()

--- a/user_scanner/user_scan/social/reddit.py
+++ b/user_scanner/user_scan/social/reddit.py
@@ -1,31 +1,177 @@
+import html
 import json
-from user_scanner.core.orchestrator import generic_validate
+import re
+from datetime import datetime, timezone
+
+from user_scanner.core.impersonate import impersonate_request
 from user_scanner.core.result import Result
 
-def validate_reddit(user):
-    url = f"https://www.reddit.com/user/{user}/about.json"
-    show_url = f"https://www.reddit.com/user/{user}/"
+BASE_URL = "https://www.reddit.com"
+# The signup form's live availability check. It is the only surface that answers
+# for suspended and deleted accounts, which the public profile page renders with
+# the same "Sorry, nobody on Reddit goes by that name" page as a free handle.
+AVAILABLE_URL = f"{BASE_URL}/api/username_available.json"
 
-    def process(response):
-        if response.status_code == 404:
-            return Result.available()
+# Reddit answers an uncleared session with a bot wall and every JSON endpoint
+# with a hard 403; clearance is only offered on an HTML page. The first hit
+# returns a reCAPTCHA interstitial that sets the cookie, the second a
+# proof-of-work whose solution is its seed repeated twice.
+CHALLENGE_TITLE = "Prove your humanity"
+CHALLENGE_SEED_RE = re.compile(r'\(async e=>e\+e\)\("([0-9a-f]+)"\)')
+CHALLENGE_TOKEN_RE = re.compile(r'name="token" value="([0-9a-f]+)"')
+CHALLENGE_ATTEMPTS = 3
 
-        if response.status_code == 429:
-            return Result.error("Rate limit exceeded")
+BOOLEAN_FLAGS = {
+    "is_employee": "employee",
+    "is_mod": "moderator",
+    "is_gold": "premium",
+    "has_verified_email": "verified_email",
+}
+KARMA_FIELDS = {
+    "total_karma": "karma_total",
+    "link_karma": "karma_post",
+    "comment_karma": "karma_comment",
+    "awardee_karma": "karma_awardee",
+    "awarder_karma": "karma_awarder",
+}
 
-        if response.status_code == 200:
-            try:
-                data = response.json()
 
-                if data.get("error") == 404 or data.get("message") == "Not Found":
-                    return Result.available()
+def validate_reddit(user: str) -> Result:
+    show_url = f"{BASE_URL}/user/{user}/"
 
-                if data.get("kind") == "t2" or "data" in data:
-                    return Result.taken()
+    try:
+        _clear_bot_wall()
+        available = _name_available(user)
+    except Exception as e:
+        return Result.error(e, url=show_url)
 
-            except (json.JSONDecodeError, KeyError):
-                return Result.error("Malformed JSON response, report it on Github")
+    if available is None:
+        return Result.error(
+            "Availability check gave no verdict (invalid name or blocked)", url=show_url)
+    if available:
+        return Result.available(url=show_url)
 
-        return Result.error(f"HTTP {response.status_code}")
+    extra, media = _profile(user)
+    return Result.taken(extra=extra, media=media, url=show_url)
 
-    return generic_validate(url, process, show_url=show_url)
+
+def _clear_bot_wall() -> None:
+    """Walk the interstitial chain until the shared session holds a clearance
+    cookie. A session that is already cleared answers with the real homepage on
+    the first hit, so this costs one request per scan after the first module."""
+    for _ in range(CHALLENGE_ATTEMPTS):
+        response = impersonate_request(f"{BASE_URL}/", allow_redirects=True)
+        params = _challenge_params(response.text)
+        if params:
+            impersonate_request(f"{BASE_URL}/", params=params, allow_redirects=True)
+            return
+        if CHALLENGE_TITLE not in response.text:
+            return
+
+
+def _challenge_params(page: str) -> dict[str, str] | None:
+    seed = CHALLENGE_SEED_RE.search(page)
+    token = CHALLENGE_TOKEN_RE.search(page)
+    if not seed or not token:
+        return None
+    return {
+        "solution": seed.group(1) * 2,
+        "js_challenge": "1",
+        "token": token.group(1),
+        "jsc_orig_r": "",
+    }
+
+
+def _name_available(user: str) -> bool | None:
+    """Ask the signup check whether the handle is free. Returns None when the
+    endpoint rejects the name as malformed (`BAD_USERNAME`) or answers
+    unreadably — neither is a verdict about an account existing."""
+    response = impersonate_request(
+        AVAILABLE_URL, params={"user": user}, allow_redirects=True)
+    if response.status_code != 200:
+        return None
+    try:
+        verdict = json.loads(response.text)
+    except json.JSONDecodeError:
+        return None
+    return verdict if isinstance(verdict, bool) else None
+
+
+def _profile(user: str) -> tuple[dict, dict]:
+    """Best-effort enrichment. Deleted accounts keep their handle reserved but
+    404 here, and suspended ones expose only their name, so a thin answer is
+    reported as the account status rather than as missing data."""
+    try:
+        response = impersonate_request(
+            f"{BASE_URL}/user/{user}/about.json", allow_redirects=True)
+    except Exception:
+        return {}, {}
+
+    if response.status_code == 404:
+        return {"status": "deleted"}, {}
+    if response.status_code != 200:
+        return {}, {}
+
+    try:
+        data = json.loads(response.text).get("data") or {}
+    except json.JSONDecodeError:
+        return {}, {}
+    if not data.get("name"):
+        return {}, {}
+    if data.get("is_suspended"):
+        # A suspended account reports every karma figure as 0; only its name is real.
+        return {"name": data["name"], "status": "suspended"}, {}
+
+    return _extract_profile(data), _extract_media(data)
+
+
+def _extract_profile(data: dict) -> dict:
+    profile = data.get("subreddit") or {}
+    extra: dict[str, str | bool | int] = {"name": data["name"], "status": "active"}
+
+    if data.get("id"):
+        extra["id"] = f"t2_{data['id']}"
+
+    title = profile.get("title")
+    if title and title != data["name"]:
+        extra["display_name"] = title
+
+    description = profile.get("public_description")
+    if description:
+        extra["bio"] = re.sub(r"\s+", " ", description).strip()
+
+    created = _created_at(data.get("created_utc"))
+    if created:
+        extra["created"] = created
+
+    for field, label in KARMA_FIELDS.items():
+        value = data.get(field)
+        if isinstance(value, int):
+            extra[label] = value
+
+    for field, label in BOOLEAN_FLAGS.items():
+        if data.get(field):
+            extra[label] = True
+
+    if profile.get("over_18"):
+        extra["nsfw"] = True
+
+    return extra
+
+
+def _created_at(created_utc: object) -> str | None:
+    if not isinstance(created_utc, (int, float)):
+        return None
+    return datetime.fromtimestamp(created_utc, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def _extract_media(data: dict) -> dict:
+    profile = data.get("subreddit") or {}
+    media = {
+        "avatar": data.get("icon_img") or profile.get("icon_img"),
+        "snoovatar": data.get("snoovatar_img"),
+        "banner": profile.get("banner_img"),
+    }
+    # about.json serves these URLs HTML-escaped, so their query strings arrive
+    # with `&amp;` separators and 404 unless unescaped.
+    return {key: html.unescape(value) for key, value in media.items() if value}

--- a/user_scanner/user_scan/social/reddit.py
+++ b/user_scanner/user_scan/social/reddit.py
@@ -1,6 +1,8 @@
 import html
 import json
 import re
+import threading
+import time
 from datetime import datetime, timezone
 
 from user_scanner.core.impersonate import impersonate_request
@@ -20,6 +22,14 @@ CHALLENGE_TITLE = "Prove your humanity"
 CHALLENGE_SEED_RE = re.compile(r'\(async e=>e\+e\)\("([0-9a-f]+)"\)')
 CHALLENGE_TOKEN_RE = re.compile(r'name="token" value="([0-9a-f]+)"')
 CHALLENGE_ATTEMPTS = 3
+VERDICT_ATTEMPTS = 3
+RETRY_BACKOFF = 0.5
+
+# Clearance lives on the shared curl_cffi session, which outlives a single
+# lookup, so re-probing the homepage per handle downloads ~530KB to learn
+# nothing. The lock keeps concurrent lookups (-C) from each paying that cost.
+_cleared = False
+_clear_lock = threading.Lock()
 
 BOOLEAN_FLAGS = {
     "is_employee": "employee",
@@ -57,16 +67,24 @@ def validate_reddit(user: str) -> Result:
 
 def _clear_bot_wall() -> None:
     """Walk the interstitial chain until the shared session holds a clearance
-    cookie. A session that is already cleared answers with the real homepage on
-    the first hit, so this costs one request per scan after the first module."""
-    for _ in range(CHALLENGE_ATTEMPTS):
-        response = impersonate_request(f"{BASE_URL}/", allow_redirects=True)
-        params = _challenge_params(response.text)
-        if params:
-            impersonate_request(f"{BASE_URL}/", params=params, allow_redirects=True)
+    cookie, once per process. Later lookups reuse that session, so they skip
+    this entirely."""
+    global _cleared
+
+    with _clear_lock:
+        if _cleared:
             return
-        if CHALLENGE_TITLE not in response.text:
-            return
+
+        for _ in range(CHALLENGE_ATTEMPTS):
+            response = impersonate_request(f"{BASE_URL}/", allow_redirects=True)
+            params = _challenge_params(response.text)
+            if params:
+                impersonate_request(f"{BASE_URL}/", params=params, allow_redirects=True)
+                _cleared = True
+                return
+            if CHALLENGE_TITLE not in response.text:
+                _cleared = True
+                return
 
 
 def _challenge_params(page: str) -> dict[str, str] | None:
@@ -85,16 +103,31 @@ def _challenge_params(page: str) -> dict[str, str] | None:
 def _name_available(user: str) -> bool | None:
     """Ask the signup check whether the handle is free. Returns None when the
     endpoint rejects the name as malformed (`BAD_USERNAME`) or answers
-    unreadably — neither is a verdict about an account existing."""
-    response = impersonate_request(
-        AVAILABLE_URL, params={"user": user}, allow_redirects=True)
-    if response.status_code != 200:
-        return None
-    try:
-        verdict = json.loads(response.text)
-    except json.JSONDecodeError:
-        return None
-    return verdict if isinstance(verdict, bool) else None
+    unreadably — neither is a verdict about an account existing.
+
+    Under burst load Reddit sheds requests with an empty 404 rather than a 429,
+    which is indistinguishable from a real answer only by its empty body, so a
+    non-verdict is retried before it is believed.
+    """
+    for attempt in range(VERDICT_ATTEMPTS):
+        if attempt:
+            time.sleep(RETRY_BACKOFF * attempt)
+
+        response = impersonate_request(
+            AVAILABLE_URL, params={"user": user}, allow_redirects=True)
+        if response.status_code == 200:
+            try:
+                verdict = json.loads(response.text)
+            except json.JSONDecodeError:
+                return None
+            return verdict if isinstance(verdict, bool) else None
+
+        # A populated body is Reddit answering (e.g. BAD_USERNAME); only an
+        # empty one means the request was dropped and is worth repeating.
+        if response.text.strip():
+            return None
+
+    return None
 
 
 def _profile(user: str) -> tuple[dict, dict]:

--- a/user_scanner/user_scan/social/tumblr.py
+++ b/user_scanner/user_scan/social/tumblr.py
@@ -1,35 +1,109 @@
+import json
 import re
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
 
-def validate_tumblr(user):
-    url = f"https://{user}.tumblr.com/"
-    show_url = url
-    headers = {"User-Agent": get_random_user_agent()}
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
-    try:
-        response = make_request(url, headers=headers)
-        if response.status_code == 200:
-            extra = {}
-            media = {}
-            title = re.search(r'<title[^>]*>(.*?)</title>', response.text, re.IGNORECASE)
-            if title:
-                extra["title"] = title.group(1).strip()
+BLOG_MARKER = '"blog":'
+NOT_FOUND_TITLE_RE = re.compile(r"<title[^>]*>\s*Not found\.", re.IGNORECASE)
 
-            desc = re.search(r'<meta[^>]*name="description"[^>]*content="([^"]+)"', response.text, re.IGNORECASE)
-            if not desc:
-                desc = re.search(r'<meta[^>]*property="og:description"[^>]*content="([^"]+)"', response.text, re.IGNORECASE)
-            if desc:
-                extra["description"] = desc.group(1).strip()
 
-            img = re.search(r'<meta[^>]*property="og:image"[^>]*content="([^"]+)"', response.text, re.IGNORECASE)
-            if img:
-                media["avatar"] = img.group(1).strip()
+def validate_tumblr(user: str) -> Result:
+    if not re.fullmatch(r"[A-Za-z0-9-]{1,32}", user):
+        return Result.error("Only letters, numbers and hyphens allowed (max 32)")
 
-            return Result.taken(extra=extra, media=media, url=show_url)
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+    # Blog names are always lowercase and the www route is case-sensitive, so an
+    # unnormalised handle 404s on a name that is in fact taken.
+    user = user.lower()
+    show_url = f"https://www.tumblr.com/{user}"
+
+    def process(response) -> Result:
+        if response.status_code == 404 and NOT_FOUND_TITLE_RE.search(response.text):
+            return Result.available()
+
+        location = response.headers.get("location", "")
+        if response.status_code == 302 and f"/login_required/{user}" in location:
+            return Result.taken(extra={"username": user, "visibility": "login required"})
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        blog = _find_blog(response.text, user)
+        if not blog:
+            return Result.error("Unrecognised profile payload")
+
+        extra = {"username": blog["name"]}
+        if title := blog.get("title"):
+            extra["title"] = title
+        if description := _npf_text(blog.get("descriptionNpf")):
+            extra["description"] = description
+        if uuid := blog.get("uuid"):
+            extra["uuid"] = uuid
+        if (url := blog.get("url")) and url != show_url:
+            extra["blog_url"] = url
+        if tags := _top_tags(blog.get("topTags")):
+            extra["top_tags"] = tags
+        if blog.get("isAdult"):
+            extra["adult"] = "true"
+        if blog.get("isPasswordProtected"):
+            extra["password_protected"] = "true"
+        if blog.get("ask"):
+            extra["asks_enabled"] = "true"
+
+        media = {}
+        if avatar := _largest_avatar(blog.get("avatar")):
+            media["avatar"] = avatar
+        if header := (blog.get("theme") or {}).get("headerImage"):
+            media["header"] = header
+
+        return Result.taken(extra=extra, media=media)
+
+    # The <user>.tumblr.com host answers every request with Tumblr's own
+    # "Checking your browser..." interstitial, which no HTTP client clears;
+    # the www route serves the blog payload directly.
+    return impersonate_validate(show_url, process, show_url=show_url)
+
+
+def _find_blog(html: str, user: str) -> dict | None:
+    """Return the embedded blog object whose name matches ``user``.
+
+    The page carries sibling blog objects for recommendation rails, so the
+    first match is not necessarily the requested one.
+    """
+    decoder = json.JSONDecoder()
+    index = html.find(BLOG_MARKER)
+    while index != -1:
+        try:
+            blog, _ = decoder.raw_decode(html, index + len(BLOG_MARKER))
+        except ValueError:
+            blog = None
+        if isinstance(blog, dict) and blog.get("name", "").lower() == user.lower():
+            return blog
+        index = html.find(BLOG_MARKER, index + len(BLOG_MARKER))
+    return None
+
+
+def _npf_text(blocks) -> str:
+    if not isinstance(blocks, list):
+        return ""
+    texts = [
+        block["text"]
+        for block in blocks
+        if isinstance(block, dict) and block.get("type") == "text" and block.get("text")
+    ]
+    return "\n".join(texts).strip()
+
+
+def _top_tags(tags) -> str:
+    if not isinstance(tags, list):
+        return ""
+    return ", ".join(tag["tag"] for tag in tags if isinstance(tag, dict) and tag.get("tag"))
+
+
+def _largest_avatar(avatars) -> str:
+    if not isinstance(avatars, list):
+        return ""
+    sized = [a for a in avatars if isinstance(a, dict) and a.get("url")]
+    if not sized:
+        return ""
+    return max(sized, key=lambda a: a.get("width") or 0)["url"]

--- a/user_scanner/user_scan/social/tumblr.py
+++ b/user_scanner/user_scan/social/tumblr.py
@@ -60,8 +60,12 @@ def validate_tumblr(user: str) -> Result:
 
     # The <user>.tumblr.com host answers every request with Tumblr's own
     # "Checking your browser..." interstitial, which no HTTP client clears;
-    # the www route serves the blog payload directly.
-    return impersonate_validate(show_url, process, show_url=show_url)
+    # the www route serves the blog payload directly. Redirects must stay
+    # unfollowed: the hop to /login_required/<user> is the only signal that
+    # separates a login-walled blog from a free name.
+    return impersonate_validate(
+        show_url, process, show_url=show_url, allow_redirects=False
+    )
 
 
 def _find_blog(html: str, user: str) -> dict | None:


### PR DESCRIPTION
## tl;dr

- **Three modules returned a *wrong* verdict, not an error.** `academia` said `taken` on a bare 200, `osta` called real accounts free because its lookup is case-sensitive, and any HTML-based `reddit` check reports suspended accounts as free.
- **11 of 228 username modules could never return a verdict at all.** A fingerprint bot wall 403'd every request, so every handle came back `Error`. All 11 now work.
- **`reddit` now depends on solving an undocumented proof-of-work challenge.** Every JSON endpoint hard-403s until the session is cleared.
- **`sourceforge` and `themeforest` are pinned to `impersonate="safari184"`.** Every other fingerprint, including the default, gets a Cloudflare interstitial.
- **`producthunt.py` carries the same latent false positive as `academia`, left unfixed.** The site is unreachable from here, so a replacement marker cannot be verified.
- **4 other 403'd modules are deliberately untouched** — they are IP/geo blocked, not bot-walled.
- **Zero false positives across 33 invented-handle checks**; 32 real accounts resolve with metadata.

## Three modules returned a wrong verdict, not an error

| Module | Fault | Effect |
| --- | --- | --- |
| academia | Existence read off a bare HTTP 200 | Every handle Found once unblocked |
| osta | Seller lookup is case-sensitive | Real accounts reported free |
| reddit | Suspended accounts render the free-handle page | Suspended handles reported free |

```python
if response.status_code == 200:
    return Result.taken(url=url)          # academia.py, before
```

```
kristjan123 -> Not Found                       # osta, before
kristjan123 -> Found (username: Kristjan123)   # osta, after
```

Reddit renders *suspended* accounts with the same "nobody on Reddit goes by that name" page as a free handle, so `awkwardtheturtle` is indistinguishable from an invented handle on HTML alone. The availability endpoint does not have that flaw, which is why it drives the verdict. Suspended and deleted accounts report `Found` with a `status` field, because Reddit never releases the name.

## 11 of 228 username modules could never return a verdict at all

Routing through the existing `impersonate_*` helpers clears most of them. Tumblr needed a different host: `<user>.tumblr.com` serves its own "Checking your browser..." interstitial that no HTTP client clears, while the `www` route serves the blog payload directly.

| Module | Verdict source |
| --- | --- |
| academia | embedded `ld+json` ProfilePage, canonical handle matched |
| adultism | `schema.org/Person` profile container |
| apclips | 200 + `data-username`, or redirect to `/models` as the miss |
| kick | `api/v2/channels/<user>` |
| npmjs | `/~<user>` with `x-spiferack: 1` |
| osta | `listing.seller`, with a case-resolving search pre-step |
| reddit | `/api/username_available.json` |
| sourceforge | `/rest/u/<user>/profile` (Allura REST) |
| themeforest | canonical link on the profile page |
| tumblr | `www.tumblr.com/<user>` embedded blog object |
| unsplash | `/napi/users/<user>` |

Each confirms *found* with a body marker tied to the requested handle and *not found* with an explicit marker, never a bare status code. Anything else returns `Result.error`.

## `reddit` now depends on solving an undocumented proof-of-work challenge

Reddit hard-403s every JSON endpoint from an uncleared session regardless of fingerprint or headers. Clearance is only offered through an HTML interstitial carrying a proof-of-work whose solution is its seed repeated twice, and `reddit.py` solves it to get the cookie.

- **Fails safe** — an unrecognised challenge shape returns `Result.error`, never a verdict.
- **Cached per process behind a lock**, so a multi-handle scan pays once: over 6 handles that is 3 homepage fetches (~700KB) instead of 6 (~2.3MB).
- **Empty-body 404s are retried, populated ones are not.** Reddit sheds requests under burst with an empty 404 rather than a 429, which the old code read as "no verdict". `_name_available` retries only on an empty body (3 attempts, 0.5s incremental backoff); a populated body is Reddit genuinely answering (e.g. `BAD_USERNAME`) and returns immediately, so invalid handles still yield `Error` instead of being retried into a verdict.

## `sourceforge` and `themeforest` are pinned to `impersonate="safari184"`

Both are 403'd under chrome, chrome131, chrome136, firefox133, firefox135, edge101 and safari180. Forcing them back to `chrome` confirms a challenge never becomes a verdict:

```
SF brondsem             -> Error | Blocked by a Cloudflare challenge
TF zzqnotarealuser8813x -> Error | Blocked by a Cloudflare challenge
```

SourceForge's `/u/` path also rate limits with that same challenge body under a 429, so the check keys on the title, not the status. The verdict lives on `/rest/u/`; the `/u/` fetch only enriches and can never change it.

## `producthunt.py` carries the same latent false positive, left unfixed

It has the pattern `academia` had — `taken` on a bare 200 — so it will report every handle as Found if it ever clears Cloudflare. I cannot reach the site to verify a replacement marker, and guessing one is how a false positive gets written. Flagged here so it is known rather than a surprise.

## 4 modules are IP/geo blocked, not bot-walled

`annaabi`, `donatello`, `producthunt` and `yaga_co_za` are untouched on purpose. Yaga's CloudFront response says it outright:

```
The Amazon CloudFront distribution is configured to block access from your country.
```

The other three answer *every* path, including `robots.txt`, with a challenge or firewall block, and a real stealth browser does not clear them either. I could not exercise a single code path on any of them, and an unverifiable transport swap could silently break them for contributors whose network is not blocked.

## Testing

32 real accounts and 33 invented-handle checks (3 controls × 11 modules), run against the live sites.

| Module | Real accounts | Invented handles | Metadata fields |
| --- | --- | --- | --- |
| academia | 3/3 Found | Not Found | 6-8 |
| adultism | 3/3 Found | Not Found | 13-15 |
| apclips | 3/3 Found | Not Found | 15-20 |
| kick | 2/2 Found | Not Found | 18 |
| npmjs | 3/3 Found | Not Found | 5-7 |
| osta | 3/3 Found | Not Found | 9-13 |
| reddit | 3/3 Found | Not Found | 14-16 |
| sourceforge | 3/3 Found | Not Found | 5-11 |
| themeforest | 3/3 Found | Not Found | 7-12 |
| tumblr | 3/3 Found | Not Found | 7-8 |
| unsplash | 3/3 Found | Not Found | 12-15 |

Edge cases:

```
reddit   awkwardtheturtle  Found     suspended, handle still owned
reddit   Deleted           Found     deleted, handle still owned
reddit   ab                Error     BAD_USERNAME, not retried into a verdict
tumblr   cyle              Found     login-walled blog
tumblr   PhotoMatt         Found     case normalised
osta     kristjan123       Found     case-resolved to Kristjan123
npmjs    babel             Found     org rather than user
npmjs    Isaacs            Error     uppercase rejected before the network
kick     XQC               Found     case-insensitive slug match
academia John.Smith        Error     period route is not addressable
```

Metadata was cross-checked against the live sources rather than trusted: Unsplash `nasa` 118 photos / 2 collections and Kick `xqc` 1,098,790 followers both match the APIs exactly.

A full 228-module scan shows no regression elsewhere — an invented handle went from 186 Not Found / 41 Error / **1 Found** to 195 / 33 / **0 Found**.

Concurrency: all 11 modules at `-C 20`, real and invented handle, no throttling errors. Reddit specifically was run 5 consecutive times at `-C 20` over 8 handles for **40/40 correct**, against roughly one failure per run before the retry.

**Not verified:**

- APClips fan-only accounts have no public page and no read-only check endpoint, so that type reports Not Found.
- Academia handles existing only on an institution subdomain (e.g. `unizg.academia.edu`) are out of scope, since those subdomains are unenumerable.
- Unsplash follower counts need an authenticated client_id and are omitted rather than substituted.
- Reddit accounts under a *temporary* suspension were not found to test.
- SourceForge's `availability` and `phone_numbers` formatters are coded to the Allura schema but no live profile populated them.
- Proxy mode and a non-default `-t` were not exercised.
- The Reddit retry will not rescue a sustained heavy scan — if most requests are shed, it returns `Error`, never a wrong verdict.
