### PR TITLE
fix: batch execution for multi-module scan progress bar

### DIFF
--- a/user_scanner/__main__.py
+++ b/user_scanner/__main__.py
@@ -433,6 +433,7 @@ def main():
 
         if args.module:
             fn = run_email_module_batch if is_email else run_user_module
+            modules_to_run = []
             for module in validated_modules:
                 site_name = get_site_name(module)
                 if not config.allow_loud and is_loud(site_name, is_email):
@@ -449,7 +450,10 @@ def main():
                     per_module_config = replace(config, allow_loud=True)
                     results.extend(fn(module, target, per_module_config))
                 else:
-                    results.extend(fn(module, target, config))
+                    modules_to_run.append(module)
+
+            if modules_to_run:
+                results.extend(fn(modules_to_run, target, config))
 
         elif args.category:
             fn = run_email_category_batch if is_email else run_user_category

--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -2,7 +2,7 @@ import asyncio
 import httpx
 from pathlib import Path
 from types import ModuleType
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Union
 
 from colorama import Fore, Style
 
@@ -150,12 +150,14 @@ async def _run_batch(
 
 
 async def _run_email_module_batch_async(
-    module: ModuleType, email: str, configs: ScanConfig
+    module: Union[ModuleType, List[ModuleType]], email: str, configs: ScanConfig
 ) -> List[Result]:
-    return await _run_batch([module], email, configs)
+    modules = [module] if isinstance(module, ModuleType) else list(module)
+    return await _run_batch(modules, email, configs)
+
 
 def run_email_module_batch(
-    module: ModuleType, email: str, configs: ScanConfig
+    module: Union[ModuleType, List[ModuleType]], email: str, configs: ScanConfig
 ) -> List[Result]:
     return asyncio.run(_run_email_module_batch_async(module, email, configs))
 

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -3,7 +3,7 @@ import inspect
 import concurrent.futures
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, List, Dict, Optional, Set
+from typing import Callable, List, Dict, Optional, Set, Union
 import threading
 
 import httpx
@@ -118,9 +118,10 @@ async def _run_batch(
 
 
 def run_user_module(
-    module: ModuleType, username: str, configs: ScanConfig
+    module: Union[ModuleType, List[ModuleType]], username: str, configs: ScanConfig
 ) -> List[Result]:
-    return asyncio.run(_run_batch([module], username, configs))
+    modules = [module] if isinstance(module, ModuleType) else list(module)
+    return asyncio.run(_run_batch(modules, username, configs))
 
 
 def run_user_category(


### PR DESCRIPTION
- Batch execution of requested modules in __main__.py so progress bar total reflects true module count
- Update run_user_module and run_email_module_batch to accept List[ModuleType]
- Ensure multi-module scans run concurrently with progress advancing from 0/N to N/N