### PR TITLE
fix: unblock apexlegends, buzzfeed, cups7 and flickr

### DIFF
--- a/user_scanner/user_scan/gaming/apexlegends.py
+++ b/user_scanner/user_scan/gaming/apexlegends.py
@@ -1,53 +1,99 @@
-from user_scanner.core.orchestrator import generic_validate, Result
+from user_scanner.core.impersonate import impersonate_request
+from user_scanner.core.result import Result
 
-def validate_apexlegends(user):
-    url = f"https://api.tracker.gg/api/v2/apex/standard/profile/origin/{user}"
-    show_url = f"https://apex.tracker.gg/apex/profile/origin/{user}/overview"
+API_URL = "https://api.tracker.gg/api/v2/apex/standard/profile"
+PROFILE_URL = "https://apex.tracker.gg/apex/profile"
 
-    headers = {
-        "Accept-Language": "en-US,en;q=0.5",
-        "Origin": "https://apex.tracker.gg",
-        "Referer": "https://apex.tracker.gg/",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
-    }
+# Apex accounts are per-platform: a handle can resolve on PSN and miss on the
+# other two, so a single namespace never settles availability.
+PLATFORMS = {"origin": "EA", "psn": "PlayStation", "xbl": "Xbox"}
 
-    def process(response):
-        if response.status_code == 200:
-            try:
-                payload = response.json()
-                data = payload.get("data", {})
-                extra = {}
-                media = {}
+HEADERS = {
+    "Accept-Language": "en-US,en;q=0.5",
+    "Origin": "https://apex.tracker.gg",
+    "Referer": "https://apex.tracker.gg/",
+}
 
-                p_info = data.get("platformInfo", {})
-                if handle := p_info.get("platformUserHandle"): extra["username"] = handle
-                if avatar := p_info.get("avatarUrl"): media["avatar"] = avatar
 
-                u_info = data.get("userInfo", {})
-                if country := u_info.get("countryCode"): extra["country"] = country
-                if u_info.get("isPremium"): extra["premium"] = "Yes"
-                if u_info.get("isInfluencer"): extra["influencer"] = "Yes"
+def validate_apexlegends(user: str) -> Result:
+    show_url = f"{PROFILE_URL}/origin/{user}/overview"
 
-                meta = data.get("metadata", {})
-                if legend := meta.get("activeLegendName"): extra["active_legend"] = legend
+    hits: dict[str, dict] = {}
+    errors: list[str] = []
 
-                segments = data.get("segments", [])
-                if segments:
-                    stats = segments[0].get("stats", {})
-                    if lvl := stats.get("level"): extra["level"] = str(lvl.get("displayValue"))
-                    if kills := stats.get("kills"): extra["kills"] = str(kills.get("displayValue"))
-
-                return Result.taken(extra=extra, media=media)
-            except Exception:
-                pass
-            return Result.error("200 response status with no recognizable data, report it via GitHub issues")
+    for platform in PLATFORMS:
+        try:
+            response = impersonate_request(
+                f"{API_URL}/{platform}/{user}", headers=HEADERS
+            )
+        except Exception as e:
+            errors.append(f"{platform}: {e}")
+            continue
 
         if response.status_code == 404:
-            return Result.available()
+            continue
 
-        if response.status_code in [403, 429]:
-            return Result.error("Request blocked by anti-bot protection.")
+        if response.status_code in (403, 429):
+            errors.append(f"{platform}: blocked by anti-bot protection ({response.status_code})")
+            continue
 
-        return Result.error(f"Unexpected status code: {response.status_code}")
+        if response.status_code != 200:
+            errors.append(f"{platform}: unexpected status {response.status_code}")
+            continue
 
-    return generic_validate(url, process, headers=headers, show_url=show_url)
+        try:
+            data = response.json().get("data") or {}
+        except Exception:
+            errors.append(f"{platform}: 200 response with unparseable body")
+            continue
+
+        if data.get("platformInfo", {}).get("platformSlug") != platform:
+            errors.append(f"{platform}: 200 response with no recognizable profile")
+            continue
+
+        hits[platform] = data
+
+    if hits:
+        extra, media = _extract(hits)
+        first = next(iter(hits))
+        return Result.taken(extra=extra, media=media, url=f"{PROFILE_URL}/{first}/{user}/overview")
+
+    # A blocked leg proves nothing about the handle; only an all-clear miss does.
+    if errors:
+        return Result.error("; ".join(errors), url=show_url)
+
+    return Result.available(url=show_url)
+
+
+def _extract(hits: dict[str, dict]) -> tuple[dict, dict]:
+    extra: dict = {"platforms": ", ".join(PLATFORMS[p] for p in hits)}
+    media: dict = {}
+
+    for platform, data in hits.items():
+        prefix = f"{platform}_" if len(hits) > 1 else ""
+
+        p_info = data.get("platformInfo") or {}
+        if handle := p_info.get("platformUserHandle"):
+            extra[f"{prefix}username"] = handle
+        if avatar := p_info.get("avatarUrl"):
+            media.setdefault(f"{prefix}avatar", avatar)
+
+        u_info = data.get("userInfo") or {}
+        if country := u_info.get("countryCode"):
+            extra[f"{prefix}country"] = country
+        if u_info.get("isPremium"):
+            extra[f"{prefix}premium"] = "Yes"
+        if u_info.get("isInfluencer"):
+            extra[f"{prefix}influencer"] = "Yes"
+
+        if legend := (data.get("metadata") or {}).get("activeLegendName"):
+            extra[f"{prefix}active_legend"] = legend
+
+        segments = data.get("segments") or []
+        stats = segments[0].get("stats", {}) if segments else {}
+        if level := stats.get("level"):
+            extra[f"{prefix}level"] = str(level.get("displayValue"))
+        if kills := stats.get("kills"):
+            extra[f"{prefix}kills"] = str(kills.get("displayValue"))
+
+    return extra, media

--- a/user_scanner/user_scan/social/buzzfeed.py
+++ b/user_scanner/user_scan/social/buzzfeed.py
@@ -1,67 +1,73 @@
 import json
 import re
-from datetime import datetime
-from user_scanner.core.orchestrator import generic_validate
+from datetime import datetime, timezone
+
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
 
 def validate_buzzfeed(user: str) -> Result:
     url = f"https://www.buzzfeed.com/{user}"
-    show_url = f"https://www.buzzfeed.com/{user}"
 
     def process(r):
         if r.status_code == 404:
             return Result.available()
 
-        if r.status_code == 200:
-            extra = {}
-            media = {}
-            match = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', r.text)
-            if match:
-                try:
-                    data = json.loads(match.group(1))
-                    page_props = data.get("props", {}).get("pageProps", {})
-                    user_data = page_props.get("user", {})
+        if r.status_code != 200:
+            return Result.error(f"HTTP {r.status_code}")
 
-                    if user_data.get("displayName"):
-                        extra["display_name"] = user_data.get("displayName")
-                    if user_data.get("bio"):
-                        extra["bio"] = user_data.get("bio")
+        page_props = _page_props(r.text)
+        user_data = page_props.get("user") or {}
 
-                    if user_data.get("image"):
-                        img = user_data.get("image")
-                        if not img.startswith("http"):
-                            img = f"https://img.buzzfeed.com/buzzfeed-static{img}"
-                        media["avatar_url"] = img
+        # Section pages (/quizzes, /tasty, /search) answer 200 with the same
+        # shell and no user node, so a bare 200 is not an account.
+        if not user_data:
+            return Result.error("200 response with no profile data")
 
-                    if user_data.get("memberSince"):
-                        try:
-                            created_ts = int(user_data.get("memberSince"))
-                            extra["joined"] = datetime.utcfromtimestamp(created_ts).strftime("%Y-%m-%d")
-                        except Exception:
-                            pass
+        extra, media = _extract(page_props, user_data)
+        return Result.taken(extra=extra, media=media)
 
-                    if page_props.get("points") is not None:
-                        extra["points"] = int(page_props.get("points"))
-                    if page_props.get("buzz_count") is not None:
-                        extra["posts"] = int(page_props.get("buzz_count"))
+    return impersonate_validate(url, process, allow_redirects=True)
 
-                    # Parse social links
-                    links = []
-                    for s in user_data.get("social", []):
-                        if s.get("url"):
-                            links.append(s.get("url"))
-                    if links:
-                        extra["links"] = links
 
-                    return Result.taken(extra=extra, media=media)
-                except Exception:
-                    pass
+def _page_props(text: str) -> dict:
+    match = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', text, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        return json.loads(match.group(1)).get("props", {}).get("pageProps", {})
+    except json.JSONDecodeError:
+        return {}
 
-            return Result.taken()
 
-        return Result.error(f"HTTP {r.status_code}")
+def _extract(page_props: dict, user_data: dict) -> tuple[dict, dict]:
+    extra: dict = {}
+    media: dict = {}
 
-    return generic_validate(
-        url, process, show_url=show_url, follow_redirects=True
-    )
+    if display_name := user_data.get("displayName"):
+        extra["display_name"] = display_name
+    if bio := user_data.get("bio"):
+        extra["bio"] = bio
+
+    if img := user_data.get("image"):
+        if not img.startswith("http"):
+            img = f"https://img.buzzfeed.com/buzzfeed-static{img}"
+        media["avatar_url"] = img
+
+    if member_since := user_data.get("memberSince"):
+        try:
+            joined = datetime.fromtimestamp(int(member_since), tz=timezone.utc)
+            extra["joined"] = joined.strftime("%Y-%m-%d")
+        except (TypeError, ValueError, OSError):
+            pass
+
+    if page_props.get("points") is not None:
+        extra["points"] = int(page_props["points"])
+    if page_props.get("buzz_count") is not None:
+        extra["posts"] = int(page_props["buzz_count"])
+
+    links = [s["url"] for s in user_data.get("social", []) if s.get("url")]
+    if links:
+        extra["links"] = links
+
+    return extra, media

--- a/user_scanner/user_scan/social/cups7.py
+++ b/user_scanner/user_scan/social/cups7.py
@@ -1,28 +1,105 @@
-from user_scanner.core.orchestrator import generic_validate, Result
+import html
+import re
+from datetime import datetime, timezone
 
-def validate_7cups(user):
-    url = f"https://www.7cups.com/@{user}"
-    show_url = url
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
+BASE_URL = "https://www.7cups.com"
+
+# Public profile pages sit behind an AWS WAF JS challenge no HTTP client can
+# clear; this JSON endpoint backs the same page and is served unchallenged.
+API_URL = f"{BASE_URL}/apiv2/user"
+
+USER_TYPES = {"l": "listener", "m": "member", "t": "therapist"}
+
+
+def validate_7cups(user: str) -> Result:
+    show_url = f"{BASE_URL}/@{user}"
 
     def process(response):
-        if response.status_code == 202 or "x-amzn-waf-action" in response.headers:
-            return Result.error("AWS WAF challenge triggered")
-
         if response.status_code == 404:
             return Result.available()
 
-        if "Profile - 7 Cups" in response.text:
-            return Result.taken()
+        if response.status_code == 202 or "x-amzn-waf-action" in response.headers:
+            return Result.error("AWS WAF challenge triggered")
 
-        if "The content you're attempting to access could not be" in response.text:
-            return Result.available()
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}")
 
-        return Result.error(f"Unexpected response status: {response.status_code}")
+        try:
+            data = response.json()
+        except Exception:
+            return Result.error("Profile response was not JSON")
 
-    return generic_validate(url, process, show_url=show_url, headers=headers, follow_redirects=True)
+        if not isinstance(data, dict) or not data.get("screenName"):
+            return Result.error("200 response with no profile data")
+
+        extra, media = _extract(data)
+        return Result.taken(extra=extra, media=media)
+
+    return impersonate_validate(f"{API_URL}/{user}", process, show_url=show_url)
+
+
+def _extract(data: dict) -> tuple[dict, dict]:
+    extra: dict = {"screen_name": data["screenName"]}
+    media: dict = {}
+
+    # `listType` names the listener sub-role; plain accounts only carry userType.
+    account_type = data.get("listType") or USER_TYPES.get(str(data.get("userType", "")))
+    if account_type:
+        extra["type"] = account_type
+
+    if user_id := (data.get("userID") or data.get("memID") or data.get("listID")):
+        extra["user_id"] = user_id
+    if bio := _plain_text(data.get("bio")):
+        extra["bio"] = bio
+    if quote := _plain_text(data.get("quote")):
+        extra["quote"] = quote
+    if age := data.get("age"):
+        extra["age"] = str(age)
+    if country := data.get("Country"):
+        extra["country"] = country
+    if language := data.get("language"):
+        extra["language"] = language
+    if joined := _date(data.get("signupDateU")):
+        extra["joined"] = joined
+    if approved := _date(data.get("approvalDateU")):
+        extra["listener_since"] = approved
+    if level := (data.get("listenerLevel") or data.get("memberLevel")):
+        extra["level"] = level
+    if points := data.get("points_formatted"):
+        extra["points"] = points
+    if data.get("numConversations"):
+        extra["conversations"] = str(data["numConversations"])
+    if data.get("compassionHearts"):
+        extra["compassion_hearts"] = str(data["compassionHearts"])
+    if data.get("forumUpvotes"):
+        extra["forum_upvotes"] = str(data["forumUpvotes"])
+    if rating := data.get("overallRating"):
+        extra["rating"] = f"{rating} ({data.get('R_numratings', 0)} ratings)"
+    if last_active := data.get("lastActive"):
+        extra["last_active"] = last_active
+    if data.get("onlineNow"):
+        extra["online"] = "Yes"
+    if badges := [b.get("badgeName") for b in data.get("badges", []) if b.get("active")]:
+        extra["badges"] = ", ".join(filter(None, badges))
+
+    avatar = data.get("imgURL") or data.get("image")
+    if avatar:
+        media["avatar"] = avatar if avatar.startswith("http") else f"{BASE_URL}{avatar}"
+
+    return extra, media
+
+
+def _plain_text(value) -> str:
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", " ", value))).strip()
+
+
+def _date(timestamp) -> str:
+    try:
+        return datetime.fromtimestamp(int(timestamp), tz=timezone.utc).strftime("%Y-%m-%d")
+    except (TypeError, ValueError, OSError):
+        return ""

--- a/user_scanner/user_scan/social/flickr.py
+++ b/user_scanner/user_scan/social/flickr.py
@@ -1,61 +1,90 @@
-import re
 import json
+import re
 import urllib.parse
-from user_scanner.core.orchestrator import generic_validate
+
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
+
+BASE_URL = "https://www.flickr.com"
 
 
 def validate_flickr(user: str) -> Result:
-    url = f"https://www.flickr.com/photos/{user}"
-    show_url = f"https://www.flickr.com/photos/{user}"
+    url = f"{BASE_URL}/photos/{user}"
 
     def process(r):
+        owner, profile, contacts = _models(r.text)
+
         if r.status_code == 404:
+            if owner:
+                return Result.error("404 response carrying a photostream owner")
             return Result.available()
 
-        if r.status_code == 200:
-            extra = {}
-            media = {}
-            match = re.search(r"modelExport:\s*(.*?),\s*auth", r.text)
-            if match:
-                try:
-                    raw_encoded = match.group(1)
-                    raw_decoded = urllib.parse.unquote(raw_encoded)
-                    data = json.loads(raw_decoded)
-                    main = data.get("main", {})
+        if r.status_code != 200:
+            return Result.error(f"HTTP {r.status_code}")
 
-                    photostream = main.get("photostream-models", [{}])[0].get("data", {})
-                    owner = photostream.get("owner", {}).get("data", {})
-                    profile = main.get("person-profile-models", [{}])[0].get("data", {})
-                    contacts = main.get("person-contacts-count-models", [{}])[0].get("data", {})
+        # /photos/tags, /photos/search and friends answer 200 with a page that
+        # has no owner, and every real photostream names its own handle.
+        if not _owns(owner, user):
+            return Result.error("200 response with no matching photostream owner")
 
-                    if owner.get("username"):
-                        extra["display_name"] = owner.get("username")
-                    if owner.get("realname"):
-                        extra["fullname"] = owner.get("realname")
-                    if profile.get("location"):
-                        extra["location"] = profile.get("location")
+        extra, media = _extract(owner, profile, contacts)
+        return Result.taken(extra=extra, media=media)
 
-                    avatar_retina = owner.get("buddyicon", {}).get("data", {}).get("retina") or owner.get("buddyicon", {}).get("retina")
-                    if avatar_retina:
-                        if avatar_retina.startswith("//"):
-                            avatar_retina = "https:" + avatar_retina
-                        media["avatar"] = avatar_retina
+    return impersonate_validate(url, process, allow_redirects=True)
 
-                    if profile.get("photoCount") is not None:
-                        extra["photos"] = int(profile.get("photoCount"))
-                    if contacts.get("followerCount") is not None:
-                        extra["followers"] = int(contacts.get("followerCount"))
-                    if contacts.get("followingCount") is not None:
-                        extra["following"] = int(contacts.get("followingCount"))
 
-                except Exception:
-                    pass
+def _models(text: str) -> tuple[dict, dict, dict]:
+    match = re.search(r"modelExport:\s*(.*?),\s*auth", text)
+    if not match:
+        return {}, {}, {}
 
-            return Result.taken(extra=extra, media=media)
+    try:
+        data = json.loads(urllib.parse.unquote(match.group(1)))
+    except (json.JSONDecodeError, ValueError):
+        return {}, {}, {}
 
-        return Result.error(f"HTTP {r.status_code}")
+    main = data.get("main") or {}
 
-    return generic_validate(
-        url, process, show_url=show_url, follow_redirects=True
-    )
+    def first(key: str) -> dict:
+        models = main.get(key) or [{}]
+        return models[0].get("data") or {}
+
+    photostream = first("photostream-models")
+    owner = (photostream.get("owner") or {}).get("data") or photostream.get("owner") or {}
+    return owner, first("person-profile-models"), first("person-contacts-count-models")
+
+
+def _owns(owner: dict, user: str) -> bool:
+    # Handles resolve case-insensitively, and accounts with no custom URL are
+    # addressed by their NSID (`12345678@N00`) instead of a path alias.
+    candidates = {str(owner.get("pathAlias") or ""), str(owner.get("id") or "")}
+    return user.lower() in {c.lower() for c in candidates if c}
+
+
+def _extract(owner: dict, profile: dict, contacts: dict) -> tuple[dict, dict]:
+    extra: dict = {}
+    media: dict = {}
+
+    if username := owner.get("username"):
+        extra["display_name"] = username
+    if realname := owner.get("realname"):
+        extra["fullname"] = realname
+    if nsid := owner.get("id"):
+        extra["user_id"] = nsid
+    if path_alias := owner.get("pathAlias"):
+        extra["path_alias"] = path_alias
+    if location := profile.get("location"):
+        extra["location"] = location
+    if profile.get("photoCount") is not None:
+        extra["photos"] = int(profile["photoCount"])
+    if contacts.get("followerCount") is not None:
+        extra["followers"] = int(contacts["followerCount"])
+    if contacts.get("followingCount") is not None:
+        extra["following"] = int(contacts["followingCount"])
+
+    buddyicon = owner.get("buddyicon") or {}
+    avatar = (buddyicon.get("data") or {}).get("retina") or buddyicon.get("retina")
+    if avatar:
+        media["avatar"] = f"https:{avatar}" if avatar.startswith("//") else avatar
+
+    return extra, media


### PR DESCRIPTION
## tl;dr

- **Buzzfeed and Flickr reported reserved site pages as accounts.** `/quizzes`, `/tasty`, `/photos/search` and `/photos/me` all soft-200; both modules now require the payload to name the requested handle.
- **Apexlegends checked one of three account namespaces.** Apex accounts are per-platform, so a PSN-only account was reported free. Now checks `origin`, `psn` and `xbl`.
- **Apexlegends, Buzzfeed and Flickr were fingerprint-blocking httpx** (403 / 406 / 502), returning errors for every handle. Moved to curl_cffi.
- **7 Cups profile pages are behind an AWS WAF JS challenge** no HTTP client can clear. Replaced with the unchallenged JSON endpoint that backs the same page — which also takes the module from zero `extra` fields to twenty.
- **Apexlegends now costs 3 requests per handle**, so tracker.gg's rate limit arrives 3x sooner. Blocked legs return `error`, never a verdict.

Handles below are written as `<real>` / `<real-listener>` etc. rather than the live accounts they were tested against.

## Buzzfeed and Flickr reported reserved site pages as accounts

Both trusted a bare 200. Buzzfeed fell through to `Result.taken()` whenever `__NEXT_DATA__` had no user node; Flickr returned `taken` for any 200 at all.

```
buzzfeed/quizzes  -> TAKEN      # section page
flickr/search     -> TAKEN      # site page under /photos/
flickr/me         -> TAKEN
```

Buzzfeed now requires `props.pageProps.user`, and Flickr requires the photostream owner's `pathAlias` or NSID to match the requested handle. Both return `error` on a 200 that carries neither — the name is not free, but nothing confirms an account.

Flickr's owner match is case-insensitive and accepts the NSID, since handles resolve at any casing and accounts with no custom URL are addressed as `12345678@N00`:

```
flickr/<Real>            -> FOUND   # canonical path alias is lowercase
flickr/<nsid>@N01        -> FOUND   # same account
```

## Apexlegends checked one of three account namespaces

Only `origin` was queried, so a PSN- or Xbox-only account was reported available.

| Handle | origin | psn | xbl |
| --- | --- | --- | --- |
| `<real-multi-platform>` | 200 | 200 | 200 |
| `<real-psn-only>` | 404 | **200** | 404 |
| `zzznotarealuser99xzq` | 404 | 404 | 404 |

`available` now needs a clean 404 on all three; if any leg was blocked, that error is returned instead. When more than one platform hits, `extra` keys are prefixed (`origin_level`, `psn_kills`) and `platforms` lists them.

### The psn/xbl legs are not stubs or catch-alls

Some psn/xbl hits come back thin (level 2-3, 0 kills), which looks like a placeholder. Three checks say they are real accounts:

| Probe | Result |
| --- | --- |
| 5 invented but plausible gamertags | 404 on psn **and** xbl — no profile is created on lookup |
| 8 confirmed-real PSN IDs sampled from a trophy leaderboard | 7 x 404, 1 x 200 — not a PSN-existence catch-all |
| 3 tracker.gg xbl hits vs. an independent gamertag directory | all 3 exist on Xbox Live; the invented control is absent from both |

The single leaderboard ID that hit came back `pageviews=0` on a first-ever request, so the profile was resolved live from EA rather than left over from earlier traffic. A thin profile is someone who launched Apex on that platform and stopped.

One consequence worth stating: a psn/xbl 404 means no *Apex* account on that platform, not that the gamertag is unclaimed there.

## Apexlegends, Buzzfeed and Flickr were fingerprint-blocking httpx

| Module | httpx | curl_cffi |
| --- | --- | --- |
| api.tracker.gg | 403 every request | 200 / 404 |
| flickr.com | 502 every request | 200 / 404 |
| buzzfeed.com | 406 on cache miss | 200 / 404 |

Buzzfeed's was the intermittent one, and it is a CDN artifact — the edge serves a cached response to anyone, so httpx only fails when it misses. Appending a cache-busting query makes it deterministic:

```
httpx  /<handle>        -> 404 404 404      # edge cache hit
httpx  /<handle>?i=N    -> 406 406 406      # cache miss, origin sees httpx
cffi   /<handle>?i=N    -> 404 404 404
```

## 7 Cups profile pages are behind an AWS WAF JS challenge

`/@handle` answers 202 with `x-amzn-waf-action: challenge` for real and fake handles alike, under both transports. So do `/forum/`, `/qa/` and the forum sitemap; the homepage and `/community/` are unprotected.

`/apiv2/user/<name>` backs the same profile page, is not challenged, and needs no auth:

```
/apiv2/user/<real-listener>      -> 200  {"listID":"...","listType":"listener",...}
/apiv2/user/<real-member>        -> 200  {"memID":"...","memberLevel":"...",...}
/apiv2/user/zzznotarealuser99xzq -> 404  {}
```

It also distinguishes the two account types, which the module now reports: listeners carry `listID`/`listType`, plain members carry `memID`. `extra` goes from empty to `screen_name`, `type`, `user_id`, `bio`, `quote`, `age`, `country`, `language`, `joined`, `listener_since`, `level`, `points`, `conversations`, `compassion_hearts`, `forum_upvotes`, `rating`, `last_active`, `online`, `badges` and an avatar.

`robots.txt` disallows `/apiv2/`. This is a single targeted lookup rather than crawling, and it is the only path that yields a verdict at all, but it is a deliberate choice worth naming — the alternative is a module that always errors.

## Apexlegends now costs 3 requests per handle

tracker.gg is rate-limited at the Cloudflare edge and answers 429 with `retry-after: 44` after roughly 15 lookups. Tripling the per-handle request count brings that on three times sooner during bulk scans. A 429 returns `Result.error`, so it never becomes a false verdict — but a large `-uf` run will see more Apex errors than before.

## Before / after

| Module | Handle | Before | After |
| --- | --- | --- | --- |
| Apexlegends | `<real-psn-only>` | Error (403) | Found — PlayStation only |
| Apexlegends | `<real-multi-platform>` | Error (403) | Found — EA + PSN + Xbox |
| Buzzfeed | `<real-contributor>` | Error (406) | Found — name, bio, join date, post count |
| Buzzfeed | `quizzes` | Found | Error (no profile data) |
| Cups7 | `<real-listener>` | Error (WAF challenge) | Found — listener, rating, conversation count |
| Cups7 | `<real-member>` | Error (WAF challenge) | Found — member, level, join date |
| Flickr | `<real>` | Error (502) | Found — photo, follower and following counts |
| Flickr | `search`, `me` | Found | Error (no matching owner) |
| all four | `zzznotarealuser99xzq` | Error / Found | Available |

## Testing

Live-tested against real and nonexistent handles on every namespace each module checks, plus one handle per account type: Apex on origin / psn / xbl, 7 Cups listener and member, Flickr path-alias and NSID, Buzzfeed contributor and section pages. `extra` was read back against the live pages.

Not verified:

- **7 Cups therapist accounts.** `userType` `"t"` is mapped to `therapist` by inference from the `"l"` / `"m"` pattern; no confirmed-real therapist handle was available to test.
- **7 Cups invalid handles.** There is no name-check endpoint, so a too-short name returns the same 404 as a free one and is reported available.
- **Apex profiles that are neither thin nor a pro's.** The psn/xbl legs were checked against invented handles, real-but-unrelated PSN IDs and an independent Xbox directory (above); mid-range accounts were not sampled specifically.


