### PR TITLE
fix(user_scan): restore 5 modules that could not return a verdict, report 4 blocked ones honestly

### DIFF
--- a/user_scanner/user_scan/adult/spankbang.py
+++ b/user_scanner/user_scan/adult/spankbang.py
@@ -5,11 +5,19 @@ from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
 
+# Cloudflare serves a managed challenge to the Chrome fingerprint on every
+# path of this domain; the Firefox one is let through.
+IMPERSONATE = "firefox133"
+
+
 def validate_spankbang(user):
     url = f"https://spankbang.com/profile/{user}"
     show_url = url
 
     def process(response):
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error("Cloudflare challenge, cannot be solved without a browser", url=show_url)
+
         if response.status_code == 404:
             return Result.available(url=show_url)
 
@@ -24,7 +32,7 @@ def validate_spankbang(user):
 
         return Result.error("Profile confirmation not found", url=show_url)
 
-    return impersonate_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, impersonate=IMPERSONATE, show_url=show_url)
 
 
 def _is_profile(html_text: str, user: str) -> bool:

--- a/user_scanner/user_scan/adult/spankbang.py
+++ b/user_scanner/user_scan/adult/spankbang.py
@@ -6,8 +6,8 @@ from user_scanner.core.result import Result
 
 
 # Cloudflare serves a managed challenge to the Chrome fingerprint on every
-# path of this domain; the Firefox one is let through.
-IMPERSONATE = "firefox133"
+# path of this domain; the Safari one is let through.
+IMPERSONATE = "safari17_0"
 
 
 def validate_spankbang(user):

--- a/user_scanner/user_scan/community/defensivecarry.py
+++ b/user_scanner/user_scan/community/defensivecarry.py
@@ -1,73 +1,78 @@
 import hashlib
 import re
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+from typing import Optional
+
+from user_scanner.core.impersonate import impersonate_request
+from user_scanner.core.result import Result
+
+BASE_URL = "https://www.defensivecarry.com"
+
+CHALLENGE_RE = re.compile(r"(\w+):'([^']*)'")
+CHALLENGE_KEYS = (
+    "challenge_nonce",
+    "challenge_hmac",
+    "difficulty",
+    "difficulty_char",
+    "issued_at",
+)
+NOT_FOUND_MARKER = "The specified member cannot be found"
+PROFILE_PATH_RE = re.compile(r"/members/([^/]+)\.(\d+)/?$")
+
 
 def validate_defensivecarry(user: str) -> Result:
-    url = f"https://www.defensivecarry.com/members/?username={user}"
-    
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    
+    url = f"{BASE_URL}/members/?username={user}"
+
     try:
-        response = make_request(url, follow_redirects=False, http2=False, headers=headers)
-        
+        response = impersonate_request(url)
+
+        # The site answers 202 with a JavaScript proof-of-work page; solving it
+        # and replaying with the pow_bypass cookie returns the real response.
         if response.status_code == 202:
-            html_text = response.text
-            nonce_match = re.search(r"challenge_nonce:'([^']+)'", html_text)
-            hmac_match = re.search(r"challenge_hmac:'([^']+)'", html_text)
-            diff_match = re.search(r"difficulty:'([^']+)'", html_text)
-            char_match = re.search(r"difficulty_char:'([^']+)'", html_text)
-            issued_match = re.search(r"issued_at:'([^']+)'", html_text)
-            
-            if (
-                nonce_match is None or
-                hmac_match is None or
-                diff_match is None or
-                char_match is None or
-                issued_match is None
-            ):
-                return Result.error("Failed to parse PoW challenge parameters", url=url)
-                
-            nonce = nonce_match.group(1)
-            hmac = hmac_match.group(1)
-            diff = int(diff_match.group(1))
-            char = char_match.group(1)
-            issued = issued_match.group(1)
-            
-            target_prefix = char * diff
-            prefix_str = nonce + issued
-            
-            pow_bypass = None
-            for i in range(1, 10000000):
-                u = str(i)
-                data = (prefix_str + u).encode('utf-8')
-                hash_hex = hashlib.sha256(data).hexdigest()
-                
-                if hash_hex.startswith(target_prefix):
-                    pow_bypass = f"{nonce}|{issued}|{u}|{hash_hex}|{hmac}"
-                    break
-                    
-            if pow_bypass:
-                response = make_request(
-                    url, 
-                    follow_redirects=False, 
-                    http2=False,
-                    headers=headers,
-                    cookies={"pow_bypass": pow_bypass}
-                )
-            else:
+            cookie = _solve_challenge(response.text)
+            if not cookie:
                 return Result.error("Failed to solve PoW challenge", url=url)
-                
-        if response.status_code in [301, 302, 303]:
-            return Result.taken(url=url)
-        elif response.status_code == 200 or response.status_code == 404:
-            return Result.available(url=url)
-            
-        return Result.error(f"Unexpected status code: {response.status_code}", url=url)
-        
+            response = impersonate_request(url, cookies={"pow_bypass": cookie})
     except Exception as e:
         return Result.error(e, url=url)
+
+    # A hit redirects to /members/<slug>.<id>/; a miss re-renders the search page.
+    if response.status_code in (301, 302, 303):
+        location = response.headers.get("location", "")
+        match = PROFILE_PATH_RE.search(location.split("?")[0])
+        if not match:
+            return Result.error(f"Unexpected redirect target: {location}", url=url)
+
+        profile_url = location if location.startswith("http") else f"{BASE_URL}{location}"
+        return Result.taken(
+            extra={"handle": match.group(1), "user_id": match.group(2)},
+            url=profile_url,
+        )
+
+    if response.status_code == 200 and NOT_FOUND_MARKER in response.text:
+        return Result.available(url=url)
+
+    return Result.error(f"Unexpected status code: {response.status_code}", url=url)
+
+
+def _solve_challenge(html_text: str) -> Optional[str]:
+    data = dict(CHALLENGE_RE.findall(html_text))
+    if any(key not in data for key in CHALLENGE_KEYS):
+        return None
+
+    try:
+        difficulty = int(data["difficulty"])
+    except ValueError:
+        return None
+
+    target = data["difficulty_char"] * difficulty
+    prefix = data["challenge_nonce"] + data["issued_at"]
+
+    for i in range(1, 10000000):
+        digest = hashlib.sha256(f"{prefix}{i}".encode()).hexdigest()
+        if digest.startswith(target):
+            return (
+                f"{data['challenge_nonce']}|{data['issued_at']}|{i}"
+                f"|{digest}|{data['challenge_hmac']}"
+            )
+
+    return None

--- a/user_scanner/user_scan/community/thefirearmsforum.py
+++ b/user_scanner/user_scan/community/thefirearmsforum.py
@@ -1,73 +1,78 @@
 import hashlib
 import re
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+from typing import Optional
+
+from user_scanner.core.impersonate import impersonate_request
+from user_scanner.core.result import Result
+
+BASE_URL = "https://www.thefirearmsforum.com"
+
+CHALLENGE_RE = re.compile(r"(\w+):'([^']*)'")
+CHALLENGE_KEYS = (
+    "challenge_nonce",
+    "challenge_hmac",
+    "difficulty",
+    "difficulty_char",
+    "issued_at",
+)
+NOT_FOUND_MARKER = "The specified member cannot be found"
+PROFILE_PATH_RE = re.compile(r"/members/([^/]+)\.(\d+)/?$")
+
 
 def validate_thefirearmsforum(user: str) -> Result:
-    url = f"https://www.thefirearmsforum.com/members/?username={user}"
-    
-    headers = {
-        "User-Agent": get_random_user_agent(),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    
+    url = f"{BASE_URL}/members/?username={user}"
+
     try:
-        response = make_request(url, follow_redirects=False, http2=False, headers=headers)
-        
+        response = impersonate_request(url)
+
+        # The site answers 202 with a JavaScript proof-of-work page; solving it
+        # and replaying with the pow_bypass cookie returns the real response.
         if response.status_code == 202:
-            html_text = response.text
-            nonce_match = re.search(r"challenge_nonce:'([^']+)'", html_text)
-            hmac_match = re.search(r"challenge_hmac:'([^']+)'", html_text)
-            diff_match = re.search(r"difficulty:'([^']+)'", html_text)
-            char_match = re.search(r"difficulty_char:'([^']+)'", html_text)
-            issued_match = re.search(r"issued_at:'([^']+)'", html_text)
-            
-            if (
-                nonce_match is None or
-                hmac_match is None or
-                diff_match is None or
-                char_match is None or
-                issued_match is None
-            ):
-                return Result.error("Failed to parse PoW challenge parameters", url=url)
-                
-            nonce = nonce_match.group(1)
-            hmac = hmac_match.group(1)
-            diff = int(diff_match.group(1))
-            char = char_match.group(1)
-            issued = issued_match.group(1)
-            
-            target_prefix = char * diff
-            prefix_str = nonce + issued
-            
-            pow_bypass = None
-            for i in range(1, 10000000):
-                u = str(i)
-                data = (prefix_str + u).encode('utf-8')
-                hash_hex = hashlib.sha256(data).hexdigest()
-                
-                if hash_hex.startswith(target_prefix):
-                    pow_bypass = f"{nonce}|{issued}|{u}|{hash_hex}|{hmac}"
-                    break
-                    
-            if pow_bypass:
-                response = make_request(
-                    url, 
-                    follow_redirects=False, 
-                    http2=False,
-                    headers=headers,
-                    cookies={"pow_bypass": pow_bypass}
-                )
-            else:
+            cookie = _solve_challenge(response.text)
+            if not cookie:
                 return Result.error("Failed to solve PoW challenge", url=url)
-                
-        if response.status_code in [301, 302, 303]:
-            return Result.taken(url=url)
-        elif response.status_code == 200 or response.status_code == 404:
-            return Result.available(url=url)
-            
-        return Result.error(f"Unexpected status code: {response.status_code}", url=url)
-        
+            response = impersonate_request(url, cookies={"pow_bypass": cookie})
     except Exception as e:
         return Result.error(e, url=url)
+
+    # A hit redirects to /members/<slug>.<id>/; a miss re-renders the search page.
+    if response.status_code in (301, 302, 303):
+        location = response.headers.get("location", "")
+        match = PROFILE_PATH_RE.search(location.split("?")[0])
+        if not match:
+            return Result.error(f"Unexpected redirect target: {location}", url=url)
+
+        profile_url = location if location.startswith("http") else f"{BASE_URL}{location}"
+        return Result.taken(
+            extra={"handle": match.group(1), "user_id": match.group(2)},
+            url=profile_url,
+        )
+
+    if response.status_code == 200 and NOT_FOUND_MARKER in response.text:
+        return Result.available(url=url)
+
+    return Result.error(f"Unexpected status code: {response.status_code}", url=url)
+
+
+def _solve_challenge(html_text: str) -> Optional[str]:
+    data = dict(CHALLENGE_RE.findall(html_text))
+    if any(key not in data for key in CHALLENGE_KEYS):
+        return None
+
+    try:
+        difficulty = int(data["difficulty"])
+    except ValueError:
+        return None
+
+    target = data["difficulty_char"] * difficulty
+    prefix = data["challenge_nonce"] + data["issued_at"]
+
+    for i in range(1, 10000000):
+        digest = hashlib.sha256(f"{prefix}{i}".encode()).hexdigest()
+        if digest.startswith(target):
+            return (
+                f"{data['challenge_nonce']}|{data['issued_at']}|{i}"
+                f"|{digest}|{data['challenge_hmac']}"
+            )
+
+    return None

--- a/user_scanner/user_scan/creator/producthunt.py
+++ b/user_scanner/user_scan/creator/producthunt.py
@@ -1,6 +1,8 @@
-import re
 import json
-from user_scanner.core.orchestrator import Result, make_request
+import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
 
 def validate_producthunt(user: str) -> Result:
@@ -12,45 +14,50 @@ def validate_producthunt(user: str) -> Result:
         return Result.error("Only use letters, numbers, and underscores.")
 
     url = f"https://www.producthunt.com/@{user}"
-    show_url = f"https://www.producthunt.com/@{user}"
 
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Cache-Control": "max-age=0",
-        "Upgrade-Insecure-Requests": "1",
-    }
+    def process(response):
+        # Cloudflare serves a managed challenge on every path of this domain in
+        # some regions; no HTTP client can clear it, so never call it a verdict.
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error("Cloudflare challenge, cannot be solved without a browser")
 
-    try:
-        response = make_request(url, headers=headers, follow_redirects=True)
-        if response.status_code == 200:
-            html = response.text
-            extra = {}
-            
-            ld = re.search(r'<script type=\"application/ld\+json\">(.*?)</script>', html, re.DOTALL)
-            if ld:
-                try:
-                    data = json.loads(ld.group(1))
-                    if isinstance(data, list): data = data[0]
-                    if name := data.get("name"): extra["name"] = name
-                    if curl := data.get("url"): extra["url"] = curl
-                except Exception:
-                    pass
-                    
-            if "name" not in extra:
-                title_match = re.search(r'<title>([^<]+?)(?:&#x27;s|\'s) profile', html)
-                if title_match:
-                    extra["name"] = title_match.group(1).strip()
-                else:
-                    meta = re.search(r'See what kind of products\s+([^\(]+)', html)
-                    if meta:
-                        extra["name"] = meta.group(1).strip()
-                        
-            return Result.taken(extra=extra, url=show_url)
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        if response.status_code == 404:
+            return Result.available()
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        return Result.taken(extra=_extract(response.text))
+
+    return impersonate_validate(url, process, show_url=url, allow_redirects=True)
+
+
+def _extract(body: str) -> dict:
+    extra = {}
+
+    ld = re.search(r'<script type="application/ld\+json">(.*?)</script>', body, re.DOTALL)
+    if ld:
+        try:
+            data = json.loads(ld.group(1))
+            if isinstance(data, list):
+                data = data[0]
+            if name := data.get("name"):
+                extra["name"] = name
+            if profile_url := data.get("url"):
+                extra["url"] = profile_url
+        except (json.JSONDecodeError, AttributeError, IndexError, KeyError):
+            pass
+
+    if "name" in extra:
+        return extra
+
+    title = re.search(r"<title>([^<]+?)(?:&#x27;s|'s) profile", body)
+    if title:
+        extra["name"] = title.group(1).strip()
+        return extra
+
+    meta = re.search(r"See what kind of products\s+([^\(]+)", body)
+    if meta:
+        extra["name"] = meta.group(1).strip()
+
+    return extra

--- a/user_scanner/user_scan/donation/donatello.py
+++ b/user_scanner/user_scan/donation/donatello.py
@@ -1,9 +1,13 @@
-from user_scanner.core.orchestrator import generic_validate, Result
 import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+CLOUDFLARE_BLOCK_MARKER = "Attention Required! | Cloudflare"
+
 
 def validate_donatello(user):
     url = f"https://donatello.to/{user}"
-    show_url = f"https://donatello.to/{user}"
 
     def process(response):
         if response.status_code == 200:
@@ -14,8 +18,14 @@ def validate_donatello(user):
                 if name.lower() != user.lower():
                     extra["name"] = name
             return Result.taken(extra=extra)
-        elif response.status_code == 404:
+
+        if response.status_code == 404:
             return Result.available()
+
+        # Cloudflare blocks whole regions from this domain; that is not a verdict.
+        if response.status_code == 403 and CLOUDFLARE_BLOCK_MARKER in response.text:
+            return Result.error("Blocked by Cloudflare, the site is unreachable from here")
+
         return Result.error(f"Unexpected status {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, show_url=url)

--- a/user_scanner/user_scan/learning/annaabi.py
+++ b/user_scanner/user_scan/learning/annaabi.py
@@ -1,4 +1,4 @@
-from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
 
@@ -6,6 +6,11 @@ def validate_annaabi(user: str) -> Result:
     show_url = "https://annaabi.ee"
 
     def process(response):
+        # Cloudflare serves a managed challenge to some regions; no HTTP client
+        # can clear it, so never turn it into a verdict.
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error("Cloudflare challenge, cannot be solved without a browser")
+
         if response.status_code != 200:
             return Result.error(f"Unexpected response status: {response.status_code}")
 
@@ -22,7 +27,7 @@ def validate_annaabi(user: str) -> Result:
             return Result.taken() if taken else Result.available()
         return Result.error("Unexpected response body")
 
-    return generic_validate(
+    return impersonate_validate(
         f"{show_url}/register.php",
         process,
         params={"go": "1", "usernamecheck": user},

--- a/user_scanner/user_scan/shopping/yaga_co_za.py
+++ b/user_scanner/user_scan/shopping/yaga_co_za.py
@@ -8,6 +8,9 @@ from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
 
+GEO_BLOCK_MARKER = "configured to block access from your country"
+
+
 def validate_yaga_co_za(user: str) -> Result:
     user = user.lower()
     url = f"https://www.yaga.co.za/{quote(user, safe='')}"
@@ -23,6 +26,11 @@ def validate_yaga_co_za(user: str) -> Result:
             return Result.available()
 
         if response.status_code != 200:
+            # CloudFront fronts this shop and refuses whole countries outright;
+            # that 403 says nothing about the handle.
+            if response.status_code == 403 and GEO_BLOCK_MARKER in response.text:
+                return Result.error("CloudFront blocks this country, the site is unreachable from here")
+
             return Result.error(
                 f"Unexpected response status: {response.status_code}",
             )

--- a/user_scanner/user_scan/shopping/yaga_ee.py
+++ b/user_scanner/user_scan/shopping/yaga_ee.py
@@ -8,6 +8,9 @@ from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
 
+GEO_BLOCK_MARKER = "configured to block access from your country"
+
+
 def validate_yaga_ee(user: str) -> Result:
     user = user.lower()
     url = f"https://www.yaga.ee/{quote(user, safe='')}"
@@ -23,6 +26,11 @@ def validate_yaga_ee(user: str) -> Result:
             return Result.available()
 
         if response.status_code != 200:
+            # CloudFront fronts this shop and refuses whole countries outright;
+            # that 403 says nothing about the handle.
+            if response.status_code == 403 and GEO_BLOCK_MARKER in response.text:
+                return Result.error("CloudFront blocks this country, the site is unreachable from here")
+
             return Result.error(
                 f"Unexpected response status: {response.status_code}",
             )

--- a/user_scanner/user_scan/social/facebook.py
+++ b/user_scanner/user_scan/social/facebook.py
@@ -10,7 +10,7 @@ PROFILE_URL_RE = re.compile(
 )
 DESCRIPTION_RE = re.compile(r'<meta property="og:description" content="([^"]*)"')
 COUNTS_RE = re.compile(
-    r"^(?P<name>.*?)\.\s*(?P<likes>[\d,.]+) likes"
+    r"^.*?\.\s*(?P<likes>[\d,.]+) likes"
     r"(?:\s*&#xb7;\s*(?P<talking>[\d,.]+) talking about this)?\.\s*(?P<bio>.*)$",
     re.DOTALL,
 )

--- a/user_scanner/user_scan/social/facebook.py
+++ b/user_scanner/user_scan/social/facebook.py
@@ -1,34 +1,22 @@
+import html
 import re
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
-PROFILE_TITLE_RE = re.compile(r'<meta property="og:title" content="[^"]+"')
+PROFILE_TITLE_RE = re.compile(r'<meta property="og:title" content="([^"]+)"')
 PROFILE_URL_RE = re.compile(
-    r'<meta property="og:url" content="https://www\.facebook\.com/[^"]+"'
+    r'<meta property="og:url" content="(https://www\.facebook\.com/[^"]+)"'
 )
-UNAVAILABLE_MARKER = "This content isn't available at the moment"
-
-def _process_profile_response(status_code: int, html: str) -> Result:
-    if status_code == 429:
-        return Result.error("Rate limited by Facebook")
-
-    if status_code >= 500:
-        return Result.error(f"Facebook returned HTTP {status_code}")
-
-    has_profile_markers = bool(
-        PROFILE_TITLE_RE.search(html) and PROFILE_URL_RE.search(html)
-    )
-    has_unavailable_marker = UNAVAILABLE_MARKER in html
-
-    if has_profile_markers and not has_unavailable_marker:
-        return Result.taken()
-
-    if has_unavailable_marker and not has_profile_markers:
-        return Result.available()
-
-    return Result.error("Unexpected response body, report it via GitHub issues.")
+DESCRIPTION_RE = re.compile(r'<meta property="og:description" content="([^"]*)"')
+COUNTS_RE = re.compile(
+    r"^(?P<name>.*?)\.\s*(?P<likes>[\d,.]+) likes"
+    r"(?:\s*&#xb7;\s*(?P<talking>[\d,.]+) talking about this)?\.\s*(?P<bio>.*)$",
+    re.DOTALL,
+)
+# Facebook ships this error in two wordings ("at the moment" / "right now"),
+# embedded in JSON where the apostrophe is backslash-escaped.
+UNAVAILABLE_RE = re.compile(r"This content isn\\?'t available")
 
 
 def validate_facebook(user: str) -> Result:
@@ -45,22 +33,55 @@ def validate_facebook(user: str) -> Result:
         return Result.error("Username cannot start or end with a period")
 
     show_url = f"https://www.facebook.com/{user}"
-    headers = {
-        "User-Agent": "Mozilla/5.0",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
 
-    request = Request(show_url, headers=headers)
+    def process(response):
+        return _process_profile_response(response.status_code, response.text)
 
-    try:
-        with urlopen(request, timeout=8.0) as response:
-            html = response.read().decode("utf-8", "ignore")
-            return _process_profile_response(response.status, html).update(url=show_url)
-    except HTTPError as exc:
-        html = exc.read().decode("utf-8", "ignore")
-        return _process_profile_response(exc.code, html).update(url=show_url)
-    except URLError as exc:
-        return Result.error(exc, url=show_url)
-    except Exception as exc:
-        return Result.error(exc, url=show_url)
+    # A handle in non-canonical casing 302s to its canonical form; a miss does not.
+    return impersonate_validate(show_url, process, show_url=show_url, allow_redirects=True)
+
+
+def _process_profile_response(status_code: int, body: str) -> Result:
+    if status_code == 429:
+        return Result.error("Rate limited by Facebook")
+
+    if status_code >= 500:
+        return Result.error(f"Facebook returned HTTP {status_code}")
+
+    title = PROFILE_TITLE_RE.search(body)
+    canonical = PROFILE_URL_RE.search(body)
+    has_unavailable_marker = bool(UNAVAILABLE_RE.search(body))
+
+    if title and canonical and not has_unavailable_marker:
+        return Result.taken(extra=_extract(title.group(1), canonical.group(1), body))
+
+    if has_unavailable_marker and not (title and canonical):
+        return Result.available()
+
+    return Result.error("Unexpected response body, report it via GitHub issues.")
+
+
+def _extract(title: str, canonical: str, body: str) -> dict:
+    extra = {"name": html.unescape(title).strip()}
+
+    # The canonical URL carries the handle's real casing, which the requested
+    # one does not — Facebook resolves handles case-insensitively.
+    handle = canonical.rsplit("/", 1)[-1]
+    if handle:
+        extra["handle"] = handle
+
+    description = DESCRIPTION_RE.search(body)
+    if not description:
+        return extra
+
+    counts = COUNTS_RE.match(description.group(1))
+    if not counts:
+        return extra
+
+    extra["likes"] = counts.group("likes")
+    if talking := counts.group("talking"):
+        extra["talking_about"] = talking
+    if bio := html.unescape(counts.group("bio")).strip():
+        extra["bio"] = bio
+
+    return extra

--- a/user_scanner/user_scan/social/livejournal.py
+++ b/user_scanner/user_scan/social/livejournal.py
@@ -27,7 +27,7 @@ def validate_livejournal(user: str) -> Result:
 
         # Guard against the generic profile shell: only the requested journal's
         # own page echoes its username back.
-        if str(journal.get("display_username", "")).lower() != user.lower():
+        if _canonical(journal.get("display_username", "")) != _canonical(user):
             return Result.error("200 response for a different journal")
 
         return Result.taken(extra=_extract(journal), media=_media(journal))
@@ -35,6 +35,12 @@ def validate_livejournal(user: str) -> Result:
     return impersonate_validate(
         PROFILE_URL, process, params={"user": user}, show_url=show_url
     )
+
+
+def _canonical(username) -> str:
+    # LiveJournal usernames are case-insensitive and treat "-" and "_" as the
+    # same character, so james-nicoll and JAMES_NICOLL are one journal.
+    return str(username).lower().replace("-", "_")
 
 
 def _journal(body: str) -> dict:

--- a/user_scanner/user_scan/social/livejournal.py
+++ b/user_scanner/user_scan/social/livejournal.py
@@ -1,38 +1,80 @@
-import re
 import json
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+import re
 
-def validate_livejournal(user):
-    url = f"https://{user}.livejournal.com"
-    show_url = url
-    headers = {"User-Agent": get_random_user_agent()}
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
+# The journal subdomain answers a ~750 KB page and stalls Python's TLS stack;
+# the profile page carries the same Site.journal payload and always resolves.
+PROFILE_URL = "https://www.livejournal.com/profile/"
+JOURNAL_RE = re.compile(r"Site\.journal\s*=\s*(\{.+?\});")
+NOT_FOUND_MARKER = "The page was not found!"
+
+
+def validate_livejournal(user: str) -> Result:
+    show_url = f"https://{user}.livejournal.com"
+
+    def process(response):
+        if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
+            return Result.available()
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        journal = _journal(response.text)
+        if not journal:
+            return Result.error("200 response with no journal data")
+
+        # Guard against the generic profile shell: only the requested journal's
+        # own page echoes its username back.
+        if str(journal.get("display_username", "")).lower() != user.lower():
+            return Result.error("200 response for a different journal")
+
+        return Result.taken(extra=_extract(journal), media=_media(journal))
+
+    return impersonate_validate(
+        PROFILE_URL, process, params={"user": user}, show_url=show_url
+    )
+
+
+def _journal(body: str) -> dict:
+    match = JOURNAL_RE.search(body)
+    if not match:
+        return {}
     try:
-        response = make_request(url, headers=headers)
-        if response.status_code == 200:
-            extra = {}
-            match = re.search(r'Site\.journal\s*=\s*({.+?});', response.text)
-            if match:
-                try:
-                    data = json.loads(match.group(1))
-                    if 'id' in data: extra['uid'] = data['id']
-                    if 'display_username' in data: extra['name'] = data['display_username']
-                    if 'is_paid' in data: extra['is_paid'] = data['is_paid']
-                    if 'is_community' in data: extra['is_community'] = data['is_community']
-                except Exception:
-                    pass
-            return Result.taken(extra=extra, url=show_url)
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        elif response.status_code in [403, 410, 302, 301]:
-            # Non-existent user might redirect or give 404
-            # If 403, usually suspended (which means taken)
-            if response.status_code == 403:
-                return Result.taken(extra={"status": "suspended or forbidden"}, url=show_url)
-            # Fallback for others
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        data = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _extract(journal: dict) -> dict:
+    extra: dict = {}
+
+    if uid := journal.get("id"):
+        extra["uid"] = uid
+    if name := journal.get("display_username"):
+        extra["name"] = name
+    if subtitle := journal.get("journal_subtitle"):
+        extra["subtitle"] = subtitle
+    if url := journal.get("journal_url"):
+        extra["journal_url"] = url
+
+    extra["type"] = _account_type(journal)
+    if journal.get("is_paid"):
+        extra["is_paid"] = True
+
+    return extra
+
+
+def _account_type(journal: dict) -> str:
+    if journal.get("is_syndicated"):
+        return "syndicated feed"
+    if journal.get("is_news"):
+        return "news"
+    return "personal" if journal.get("is_personal") else "community"
+
+
+def _media(journal: dict) -> dict:
+    userhead = journal.get("userhead_url")
+    return {"userhead": userhead} if userhead else {}

--- a/user_scanner/user_scan/social/livejournal.py
+++ b/user_scanner/user_scan/social/livejournal.py
@@ -10,6 +10,11 @@ PROFILE_URL = "https://www.livejournal.com/profile/"
 JOURNAL_RE = re.compile(r"Site\.journal\s*=\s*(\{.+?\});")
 NOT_FOUND_MARKER = "The page was not found!"
 
+# A purged journal frees its username for re-registration ("You can rename your
+# account with this username"); a suspended one keeps it.
+PURGED_MARKER = "This journal has been deleted and purged"
+SUSPENDED_MARKER = "This journal has been suspended"
+
 
 def validate_livejournal(user: str) -> Result:
     show_url = f"https://{user}.livejournal.com"
@@ -17,6 +22,12 @@ def validate_livejournal(user: str) -> Result:
     def process(response):
         if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
             return Result.available()
+
+        if response.status_code == 410 and PURGED_MARKER in response.text:
+            return Result.available()
+
+        if response.status_code == 403 and SUSPENDED_MARKER in response.text:
+            return Result.taken(extra={"status": "suspended"})
 
         if response.status_code != 200:
             return Result.error(f"Unexpected status: {response.status_code}")


### PR DESCRIPTION
## tl;dr

- **Five username modules could not return a verdict at all; they can now.** SpankBang, Facebook, LiveJournal, DefensiveCarry and TheFirearmsForum each errored on every handle. All five are live-verified against a real and an invented handle.
- **Facebook had two verdict bugs beyond the transport.** Non-canonical casing 302s were never followed, and the not-found marker has a second wording the exact-string check missed.
- **DefensiveCarry and TheFirearmsForum inferred availability from a bare 200.** They now require the explicit "member cannot be found" marker.
- **LiveJournal usernames treat `-` and `_` as one character.** The username guard normalises both sides, or `james-nicoll` would error while `james_nicoll` resolves.
- **Purged and suspended LiveJournal accounts get opposite verdicts, and both used to error.** A purged journal frees its username; a suspended one keeps it.
- **Four modules are unreachable behind Cloudflare/CloudFront walls and stay that way.** They now name the wall instead of emitting a bare 403. Annaabi's verdict logic was verified through a real browser; the other three could not be exercised at all.
- **Product Hunt still returns `taken` on any 200.** Deliberate: the site is challenge-walled from here, so a stricter marker could not be verified.

## Five username modules could not return a verdict at all; they can now

| Module | Before | After (real handle) | After (invented handle) |
| --- | --- | --- | --- |
| `adult/spankbang.py` | `Unexpected status: 403` | `brunolm7` → Found | Not Found |
| `social/facebook.py` | `Unexpected response body` | `zuck`, `cristiano`, `bill.gates` → Found | Not Found |
| `community/defensivecarry.py` | `ReadTimeout` | `admin`, `Jeff` → Found | Not Found |
| `community/thefirearmsforum.py` | `ReadTimeout` | `admin`, `Bob` → Found | Not Found |
| `social/livejournal.py` | TLS handshake timeout | `ohnotheydidnt`, `james_nicoll` → Found | Not Found |

What each needed:

- **SpankBang** — Cloudflare now challenges the *Chrome* fingerprint on every path of the domain. `safari17_0` is let through; every `chrome*` and `edge*` target returns `cf-mitigated: challenge`.
- **Facebook** — urllib got a body with neither marker; curl_cffi gets the real page.
- **The two XenForo forums** — the proof-of-work solver was already correct, httpx just stalled on it. Over curl_cffi the full solve-and-replay runs in under a second.
- **LiveJournal** — the journal subdomain serves ~750 KB and stalls Python's TLS stack. `www.livejournal.com/profile/?user=` carries the same `Site.journal` payload.

All five now populate `extra` — numeric ids, display names, account type, member counts:

```
spankbang  mia_khalifa   {'name': 'mia_khalifa', 'user_id': '51279794'}
livejournal ohnotheydidnt {'uid': 3616053, 'name': 'ohnotheydidnt', 'type': 'community', 'is_paid': True, ...}
facebook   bill.gates    {'name': 'Bill Gates', 'handle': 'BillGates', 'likes': '41,470,070', ...}
```

## Facebook had two verdict bugs beyond the transport

| Fault | Effect |
| --- | --- |
| 302 to canonical casing never followed | `bill.gates` (→ `BillGates`) missed entirely |
| Marker matched as one exact string | Facebook also ships "This content isn't available **right now**", apostrophe backslash-escaped inside JSON |

The marker is now a regex covering both wordings and the escaped form; the canonical `og:url` also supplies the handle's real casing.

## DefensiveCarry and TheFirearmsForum inferred availability from a bare 200

```python
elif response.status_code == 200 or response.status_code == 404:
    return Result.available(url=url)   # fires for the challenge page too
```

A miss is now confirmed on `"The specified member cannot be found"`, and a hit is confirmed by a redirect matching `/members/<slug>.<id>/` — an unrecognised redirect target returns an error rather than a hit. The member id and canonical slug come out of that redirect, so no extra request is needed.

The two files stay near-identical copies rather than sharing a helper: `load_modules()` globs every `*.py` under `user_scan/<category>/` and would load a shared helper as a site module with no `validate_` function.

## LiveJournal usernames treat `-` and `_` as one character

```
james-nicoll -> TAKEN (uid 86776258)   # same journal
james_nicoll -> TAKEN (uid 86776258)
JAMES_NICOLL -> TAKEN (uid 86776258)
```

The rewrite guards against the generic profile shell by checking the echoed `display_username`, so that comparison normalises case and `-`/`_` on both sides. Also removed: the old `302/301 → available` branch, which turned every redirect into "this name is free". The old `403 → taken (suspended)` branch was right for this site and is kept, but gated on an explicit marker instead of the bare status — see below.

## Purged and suspended LiveJournal accounts get opposite verdicts

```
deleted -> 410 "Purged Account"    "This journal has been deleted and purged.
                                    You can rename your account with this username."  -> AVAILABLE
abc     -> 403 "Suspended Journal" "This journal has been suspended."                 -> TAKEN
```

Both statuses fell through to `Unexpected status` before. The distinction is not cosmetic — a purged username is genuinely re-registrable, so calling it taken would be wrong in the other direction.

## Four modules are unreachable behind Cloudflare/CloudFront walls

| Module | Wall | Reported now |
| --- | --- | --- |
| `creator/producthunt.py` | Cloudflare managed challenge, whole domain | `Cloudflare challenge, cannot be solved without a browser` |
| `learning/annaabi.py` | Cloudflare managed challenge | same |
| `donation/donatello.py` | Cloudflare regional block ("Attention Required") | `Blocked by Cloudflare, the site is unreachable from here` |
| `shopping/yaga_co_za.py` | CloudFront: "configured to block access from your country" | `CloudFront blocks this country, the site is unreachable from here` |

These are network-level walls at my location, not module logic — no HTTP client clears a managed challenge, and every impersonation target returns the same `cf-mitigated: challenge`. Annaabi is the one case where that claim is proven rather than assumed: through a real browser its check endpoint answers normally and both of its markers still match (see the testing section). The first three moved to the impersonating transport anyway, which may be all they need where the site is reachable. `shopping/yaga_ee.py` got the same geo-block detection purely to keep the sibling pair identical; it is not defective.

## Product Hunt still returns `taken` on any 200

Deliberate, not an oversight. The module is rewritten onto the impersonating transport here, but the domain is challenge-walled from my location, so I could not see a real profile page or a miss page — adding a marker check would mean guessing at markup and risking a false `error` on every hit. The pre-existing soft-200 risk is left as it was, and flagged here rather than changed blind.

## Testing, and what was not tested

Live-tested against a real and an invented handle for every module that responds, plus a full 228-module scan before and after on both handles to check for collateral damage. No module moved in the wrong direction; the only regressions in that comparison (`fiverr`, `lastfm`, `nexusmods`, `discord`) are in files this branch does not touch and flip between consecutive runs on identical code.

The four walled sites were re-checked through a real browser, which separates "the module logic is wrong" from "the site will not talk to this location":

| Module | Real browser result | Verdict logic |
| --- | --- | --- |
| `learning/annaabi.py` | Reachable | Verified — `admin`, `test`, `marko` return the exact taken marker; invented handles the exact free marker |
| `donation/donatello.py` | Cloudflare block page | Unverifiable from here |
| `shopping/yaga_co_za.py` | CloudFront country block | Unverifiable from here |
| `creator/producthunt.py` | Challenge loops, never clears | Unverifiable from here by any means |

Remaining gaps:

- **Product Hunt's soft-200 risk stays untested** — the challenge does not clear in a real browser either, so neither a profile page nor a miss page is observable from this location.
- **LiveJournal connectivity is intermittent here** — 4 connection timeouts in 30 consecutive requests. Those surface as `Result.error`, never a verdict.
- **LiveJournal deleted-but-not-yet-purged journals** — purged (410) and suspended (403) are covered by real handles; the window between deletion and purge was not observed and may behave differently.
- **Facebook alias handles resolve to their canonical account** — `facebook.com/mark` redirects to Mark Zuckerberg's profile, so `mark` reports taken with `handle: zuck`. Accurate (the handle is not free), but `extra` names a different string than the one scanned.
- **Facebook profiles with no like count** — verified rather than assumed: `jack` returns `{'name': 'Jack Lindamood', 'handle': 'jack'}` and nothing else.

