### PR TITLE
fix(email_scan): restore 11 modules broken by parser rot and bot walls

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/adult/fapfolder.py
+++ b/user_scanner/email_scan/adult/fapfolder.py
@@ -1,4 +1,4 @@
-import httpx
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -32,22 +32,23 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, data=payload, headers=headers)
+        response = await impersonate_request_async(
+            url, "POST", data=payload, headers=headers
+        )
 
-            if response.status_code == 403:
-                return Result.error("403")
+        if response.status_code == 403:
+            return Result.error("403")
 
-            data = response.json()
-            message = data.get("message", "")
+        data = response.json()
+        message = data.get("message", "")
 
-            if "belongs to an existing account" in message:
-                return Result.taken(url=show_url)
+        if "belongs to an existing account" in message:
+            return Result.taken(url=show_url)
 
-            if "password must be at least" in message:
-                return Result.available(url=show_url)
+        if "password must be at least" in message:
+            return Result.available(url=show_url)
 
-            return Result.error(f"Unexpected: {message[:50]}")
+        return Result.error(f"Unexpected: {message[:50]}")
 
     except Exception as e:
         return Result.error(e)

--- a/user_scanner/email_scan/adult/pornhub.py
+++ b/user_scanner/email_scan/adult/pornhub.py
@@ -70,6 +70,14 @@ async def _check(email: str) -> Result:
         if "delivery issues" in error_msg:
             return Result.error(url=SHOW_URL, reason="The email is experiencing email delivery issues")
 
+        # Pornhub refuses to check some providers at all (proton.me, zoho.com),
+        # which is a rule about the domain rather than a verdict on the address.
+        if "is not allowed" in error_msg:
+            return Result.error(
+                url=SHOW_URL,
+                reason=f"Pornhub does not accept registrations from '{domain}'",
+            )
+
         # Sub-addressing is only accepted for mailboxes that actually resolve,
         # so an unusable alias says nothing about the address it derives from.
         if "invalid or cannot be used" in error_msg:

--- a/user_scanner/email_scan/adult/pornhub.py
+++ b/user_scanner/email_scan/adult/pornhub.py
@@ -1,71 +1,87 @@
-import httpx
 import re
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+BASE_URL = "https://www.pornhub.com"
+SHOW_URL = "https://pornhub.com"
+CHECK_API = f"{BASE_URL}/api/v1/user/create_account_check"
+
+# The token is only reachable through the create_account_check URL Pornhub
+# embeds (HTML-escaped) in the page's signup config.
+TOKEN_RE = re.compile(r"create_account_check\?token=([A-Za-z0-9_.\-]+)")
+
+# Pornhub no longer discloses registration for the address as typed: a
+# deliverable address always gets the same "if this email is already
+# registered" placeholder, and that path is what mails the account holder.
+# Probing a sub-addressed alias sidesteps both problems, because Pornhub
+# normalises the "+tag" away and then answers plainly.
+PROBE_TAG = "+phck"
+
+HEADERS = {
+    "x-requested-with": "XMLHttpRequest",
+    "origin": BASE_URL,
+    "referer": BASE_URL + "/",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+}
 
 
 async def _check(email: str) -> Result:
-    base_url = "https://www.pornhub.com"
-    show_url = "https://pornhub.com"
-    check_api = f"{base_url}/api/v1/user/create_account_check"
+    local, _, domain = email.rpartition("@")
+    if not local or not domain:
+        return Result.error("Not a valid email address")
 
-    headers = {
-        "user-agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
-        "x-requested-with": "XMLHttpRequest",
-        "origin": base_url,
-        "referer": base_url + "/",
-        "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
-    }
+    if "+" in local:
+        return Result.error(
+            "Address is already sub-addressed; Pornhub cannot be probed for it"
+        )
 
-    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=15.0) as client:
-        try:
-            landing_resp = await client.get(base_url, headers=headers)
-            token_match = re.search(
-                r'var\s+token\s*=\s*"([^"]+)"', landing_resp.text)
+    try:
+        landing = await impersonate_request_async(BASE_URL + "/", allow_redirects=True)
+        token_match = TOKEN_RE.search(landing.text)
 
-            if not token_match:
-                return Result.error("Failed to extract dynamic token from HTML")
+        if not token_match:
+            return Result.error("Failed to extract dynamic token from HTML")
 
-            token = token_match.group(1)
+        response = await impersonate_request_async(
+            CHECK_API,
+            "POST",
+            params={"token": token_match.group(1)},
+            headers=HEADERS,
+            data={"check_what": "email", "email": f"{local}{PROBE_TAG}@{domain}"},
+        )
 
-            params = {"token": token}
-            payload = {
-                "check_what": "email",
-                "email": email
-            }
+        if response.status_code == 429:
+            return Result.error("Rate limited, wait for a few minutes")
 
-            response = await client.post(
-                check_api,
-                params=params,
-                headers=headers,
-                data=payload
+        if response.status_code != 200:
+            return Result.error(f"HTTP Error: {response.status_code}")
+
+        data = response.json()
+        status = data.get("email")
+        error_msg = data.get("error_message", "")
+
+        if status == "create_account_passed":
+            return Result.available(url=SHOW_URL)
+
+        if "has been taken" in error_msg:
+            return Result.taken(url=SHOW_URL)
+
+        if "delivery issues" in error_msg:
+            return Result.error(url=SHOW_URL, reason="The email is experiencing email delivery issues")
+
+        # Sub-addressing is only accepted for mailboxes that actually resolve,
+        # so an unusable alias says nothing about the address it derives from.
+        if "invalid or cannot be used" in error_msg:
+            return Result.error(
+                url=SHOW_URL,
+                reason=f"Domain '{domain}' does not support the sub-address probe",
             )
 
-            if response.status_code == 429:
-                return Result.error("Rate limited, wait for a few minutes")
+        return Result.error(f"Unexpected API response: {status}: {error_msg}")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
-
-            data = response.json()
-            status = data.get("email")
-            error_msg = data.get("error_message", "")
-            email_dom = email.split("@")[-1]
-
-            if status == "create_account_failed":
-                if "Email extension" in error_msg:
-                    return Result.available(url=show_url, reason=f"Domain '{email_dom}' is not allowed by PornHub")
-                if "delivery issues" in error_msg:
-                    return Result.error(url=show_url, reason="The email is experiencing email delivery issues")
-
-            if status == "create_account_passed" and error_msg == "":
-                return Result.available(url=show_url)
-            elif status == "create_account_failed" and "already registered" in error_msg:
-                return Result.taken(url=show_url)
-            else:
-                return Result.error(f"Unexpected API response: {status}: {error_msg}")
-
-        except Exception as e:
-            return Result.error(e)
+    except Exception as e:
+        return Result.error(e)
 
 
 async def validate_pornhub(email: str) -> Result:

--- a/user_scanner/email_scan/community/nextdoor.py
+++ b/user_scanner/email_scan/community/nextdoor.py
@@ -28,7 +28,18 @@ async def _check(email: str) -> Result:
 
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, data=payload, headers=headers)
+            try:
+                response = await client.post(url, data=payload, headers=headers)
+            except httpx.ConnectError as e:
+                # Outside the countries Nextdoor operates in, its own
+                # nameservers answer 0.0.0.0, so the host never resolves to a
+                # usable address and the check cannot run at all.
+                if "getaddrinfo" in str(e) or "11001" in str(e) or "11004" in str(e):
+                    return Result.error(
+                        "auth.nextdoor.com does not resolve from here; "
+                        "Nextdoor null-routes its DNS outside supported regions"
+                    )
+                raise
 
             if response.status_code == 403:
                 return Result.error("403")

--- a/user_scanner/email_scan/creator/kick.py
+++ b/user_scanner/email_scan/creator/kick.py
@@ -1,5 +1,7 @@
-import httpx
+import json
 import secrets
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 def _generate_trace_id() -> str:
@@ -22,36 +24,33 @@ async def _check(email: str) -> Result:
         'x-req-trace': _generate_trace_id()
     }
 
-    payload = {
-        "email": email
-    }
-
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, json=payload, headers=headers)
+        response = await impersonate_request_async(
+            url, "POST", data=json.dumps({"email": email}), headers=headers
+        )
 
-            # Check for generic perimeter blocks
-            if response.status_code == 403:
-                return Result.error("Caught by Cloudflare WAF (403)")
-            if response.status_code == 429:
-                return Result.error("Rate limited by Kick (429)")
+        # Check for generic perimeter blocks
+        if response.status_code == 403:
+            return Result.error("Caught by Cloudflare WAF (403)")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Kick (429)")
 
-            # Target validation logic (Status 204 No Content -> Email is available)
-            if response.status_code == 204:
-                return Result.available(url=show_url)
+        # Target validation logic (Status 204 No Content -> Email is available)
+        if response.status_code == 204:
+            return Result.available(url=show_url)
 
-            if response.status_code == 422:
-                try:
-                    data = response.json()
-                    errors = data.get("errors", {})
-                    email_errors = errors.get("email", [])
+        if response.status_code == 422:
+            try:
+                data = response.json()
+                errors = data.get("errors", {})
+                email_errors = errors.get("email", [])
 
-                    if any("already been taken" in str(err).lower() for err in email_errors):
-                        return Result.taken(url=show_url)
-                except Exception:
-                    return Result.error("Failed to parse 422 validation content")
+                if any("already been taken" in str(err).lower() for err in email_errors):
+                    return Result.taken(url=show_url)
+            except Exception:
+                return Result.error("Failed to parse 422 validation content")
 
-            return Result.error(f"Unexpected response state (HTTP {response.status_code})")
+        return Result.error(f"Unexpected response state (HTTP {response.status_code})")
 
     except Exception as e:
         return Result.error(str(e))

--- a/user_scanner/email_scan/creator/patreon.py
+++ b/user_scanner/email_scan/creator/patreon.py
@@ -1,63 +1,78 @@
-import httpx
+import json
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+# Auth steps Patreon returns for an address that already has an account:
+# "password" for a local login, "sso_required" when the account can only be
+# reached through a social provider.
+_TAKEN_STEPS = ("password", "sso_required")
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(timeout=15.0, http2=False) as client:
-        try:
-            url = "https://www.patreon.com/api/auth"
-            show_url = "https://patreon.com"
+    url = "https://www.patreon.com/api/auth"
+    show_url = "https://patreon.com"
 
-            params = {
-                'include': "user.null",
-                'fields[user]': "[]",
-                'json-api-version': "1.0",
-                'json-api-use-default-includes': "false"
-            }
+    params = {
+        'include': "user.null",
+        'fields[user]': "[]",
+        'json-api-version': "1.0",
+        'json-api-use-default-includes': "false"
+    }
 
-            payload = "{\"data\":{\"type\":\"genericPatreonApi\",\"attributes\":{\"patreon_auth\":{\"email\":\"" + email + \
-                "\",\"allow_account_creation\":false},\"auth_context\":\"auth\",\"ru\":\"https://www.patreon.com/home\"},\"relationships\":{}}}"
+    payload = json.dumps({
+        "data": {
+            "type": "genericPatreonApi",
+            "attributes": {
+                "patreon_auth": {"email": email, "allow_account_creation": False},
+                "auth_context": "auth",
+                "ru": "https://www.patreon.com/home",
+            },
+            "relationships": {},
+        }
+    })
 
-            headers = {
-                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
-                'sec-ch-ua-platform': '"Linux"',
-                'sec-ch-ua': '"Brave";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
-                'content-type': "application/vnd.api+json",
-                'sec-ch-ua-mobile': "?0",
-                'sec-gpc': "1",
-                'accept-language': "en-US,en;q=0.7",
-                'origin': "https://www.patreon.com",
-                'sec-fetch-site': "same-origin",
-                'sec-fetch-mode': "cors",
-                'sec-fetch-dest': "empty",
-                'referer': "https://www.patreon.com/login"
-            }
+    headers = {
+        'Accept-Encoding': "gzip, deflate, br, zstd",
+        'content-type': "application/vnd.api+json",
+        'sec-gpc': "1",
+        'accept-language': "en-US,en;q=0.7",
+        'origin': "https://www.patreon.com",
+        'sec-fetch-site': "same-origin",
+        'sec-fetch-mode': "cors",
+        'sec-fetch-dest': "empty",
+        'referer': "https://www.patreon.com/login"
+    }
 
-            response = await client.post(
-                url,
-                params=params,
-                content=payload,
-                headers=headers,
-                timeout=15.0
+    try:
+        response = await impersonate_request_async(
+            url, "POST", params=params, data=payload, headers=headers
+        )
+
+        if response.status_code != 200:
+            return Result.error(f"Status {response.status_code}, report it via GitHub issues")
+
+        data = response.json()
+        attributes = (data.get("data") or {}).get("attributes") or {}
+        next_step = attributes.get("next_auth_step")
+
+        if next_step in _TAKEN_STEPS:
+            providers = attributes.get("supported_sso_providers") or []
+            return Result.taken(
+                url=show_url,
+                extra={
+                    "login_method": "SSO" if next_step == "sso_required" else "password",
+                    "sso_providers": ", ".join(providers),
+                },
             )
 
-            if response.status_code != 200:
-                return Result.error(f"Status {response.status_code}, report it via GitHub issues")
+        if next_step == "signup":
+            return Result.available(url=show_url)
 
-            data = response.json()
-            next_step = data.get("data", {}).get(
-                "attributes", {}).get("next_auth_step")
+        return Result.error("Unexpected auth step, report it via GitHub issues")
 
-            if next_step == "password":
-                return Result.taken(url=show_url)
-            elif next_step == "signup":
-                return Result.available(url=show_url)
-            else:
-                return Result.error("Unexpected auth step, report it via GitHub issues")
-
-        except Exception as e:
-            return Result.error(f"unexpected exception: {e}")
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")
 
 
 async def validate_patreon(email: str) -> Result:

--- a/user_scanner/email_scan/dev/github.py
+++ b/user_scanner/email_scan/dev/github.py
@@ -9,7 +9,13 @@ SEARCH_API = "https://api.github.com/search/users"
 SIGNUP_URL = "https://github.com/signup"
 VALIDITY_URL = "https://github.com/email_validity_checks"
 
-CSRF_RE = re.compile(r'data-csrf="true"\s+value="([^"]+)"')
+# The signup form carries one CSRF token per auto-check endpoint and emits the
+# value before the data-csrf marker, so the token has to be taken from inside
+# the email_validity_checks block rather than from the first match on the page.
+CSRF_RE = re.compile(
+    r'<auto-check[^>]*src="/email_validity_checks"'
+    r'[\s\S]*?<input[^>]*value="([^"]+)"[^>]*data-csrf="true"'
+)
 
 
 async def _check(email: str) -> Result:

--- a/user_scanner/email_scan/dev/github.py
+++ b/user_scanner/email_scan/dev/github.py
@@ -1,74 +1,95 @@
-import httpx
 import re
+from urllib.parse import quote
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+SHOW_URL = "https://github.com"
+SEARCH_API = "https://api.github.com/search/users"
+SIGNUP_URL = "https://github.com/signup"
+VALIDITY_URL = "https://github.com/email_validity_checks"
+
+CSRF_RE = re.compile(r'data-csrf="true"\s+value="([^"]+)"')
 
 
 async def _check(email: str) -> Result:
-    show_url = "https://github.com"
-    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=True) as client:
-        try:
-            url1 = "https://github.com/signup"
-            headers1 = {
-                'host': 'github.com',
-                'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"',
-                'sec-ch-ua-mobile': '?0',
-                'sec-ch-ua-platform': '"Linux"',
-                'upgrade-insecure-requests': '1',
-                'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36',
-                'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-                'sec-fetch-site': 'cross-site',
-                'sec-fetch-mode': 'navigate',
-                'sec-fetch-user': '?1',
-                'sec-fetch-dest': 'document',
-                'referer': 'https://www.google.com/',
-                'accept-encoding': 'gzip, deflate, br, zstd',
-                'accept-language': 'en-US,en;q=0.9',
-                'priority': 'u=0, i'
-            }
+    # The search API confirms a hit outright and costs one request, so it runs
+    # before the signup probe. It only sees accounts that publish the address
+    # on their profile, so a miss still has to fall through.
+    found = await _search_public_profiles(email)
+    if found is not None:
+        return found
 
-            res1 = await client.get(url1, headers=headers1)
-            html = res1.text
+    return await _check_signup_availability(email)
 
-            csrf_match = re.search(r'data-csrf="true"\s+value="([^"]+)"', html)
 
-            if not csrf_match:
-                return Result.error("Failed to extract GitHub authenticity_token")
+async def _search_public_profiles(email: str) -> Result | None:
+    try:
+        response = await impersonate_request_async(
+            f"{SEARCH_API}?q={quote(email)}+in:email",
+            headers={"accept": "application/vnd.github+json"},
+        )
+    except Exception:
+        return None
 
-            csrf_token = csrf_match.group(1)
+    if response.status_code != 200:
+        return None
 
-            url2 = "https://github.com/email_validity_checks"
-            payload = {
-                'authenticity_token': csrf_token,
-                'value': email
-            }
+    items = response.json().get("items") or []
+    if not items:
+        return None
 
-            headers2 = {
-                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
-                'sec-ch-ua-platform': '"Linux"',
-                'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"',
-                'sec-ch-ua-mobile': "?0",
-                'origin': "https://github.com",
-                'sec-fetch-site': "same-origin",
-                'sec-fetch-mode': "cors",
-                'sec-fetch-dest': "empty",
-                'referer': "https://github.com/signup",
-                'accept-language': "en-US,en;q=0.9",
-                'priority': "u=1, i"
-            }
+    user = items[0]
+    return Result.taken(
+        url=SHOW_URL,
+        extra={
+            "login": user.get("login"),
+            "user_id": user.get("id"),
+            "profile": user.get("html_url"),
+            "account_type": user.get("type"),
+            "matched_by": "public profile email",
+        },
+        media={"avatar": user.get("avatar_url")},
+    )
 
-            response = await client.post(url2, data=payload, headers=headers2)
-            body = response.text
 
-            if "already associated with an account" in body:
-                return Result.taken(url=show_url)
-            elif response.status_code == 200 and "Email is available" in body:
-                return Result.available(url=show_url)
-            else:
-                return Result.error(f"Unexpected status code: {response.status_code}, report this via GitHub issues")
+async def _check_signup_availability(email: str) -> Result:
+    try:
+        signup = await impersonate_request_async(SIGNUP_URL, allow_redirects=True)
+        csrf_match = CSRF_RE.search(signup.text)
 
-        except Exception as e:
-            return Result.error(f"unexpected exception: {e}")
+        if not csrf_match:
+            # GitHub fronts /signup with DataDome, whose interstitial no HTTP
+            # client can clear; the address may still be registered privately.
+            return Result.error(
+                "GitHub's signup form is behind a bot challenge, and the address "
+                "is not on any public profile"
+            )
+
+        response = await impersonate_request_async(
+            VALIDITY_URL,
+            "POST",
+            data={"authenticity_token": csrf_match.group(1), "value": email},
+            headers={
+                "origin": SHOW_URL,
+                "referer": SIGNUP_URL,
+                "accept": "*/*",
+            },
+        )
+        body = response.text
+
+        if "already associated with an account" in body:
+            return Result.taken(url=SHOW_URL)
+
+        if response.status_code == 200 and "Email is available" in body:
+            return Result.available(url=SHOW_URL)
+
+        return Result.error(
+            f"Unexpected status code: {response.status_code}, report this via GitHub issues"
+        )
+
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")
 
 
 async def validate_github(email: str) -> Result:

--- a/user_scanner/email_scan/dev/wordpress.py
+++ b/user_scanner/email_scan/dev/wordpress.py
@@ -34,14 +34,24 @@ async def _check(email: str) -> Result:
 
             inner_code = data.get("code")
             body = data.get("body", {})
+            inner_error = body.get("error")
 
             if inner_code == 200:
                 return Result.taken(url=show_url)
-            elif inner_code == 404 and body.get("error") == "unknown_user":
+
+            # WordPress.com answers 403 email_login_not_allowed only for an
+            # address that maps to a real account whose owner must sign in with
+            # their username; an unknown address 404s instead.
+            if inner_code == 403 and inner_error == "email_login_not_allowed":
+                return Result.taken(
+                    url=show_url, extra={"login_method": "username only"}
+                )
+
+            if inner_code == 404 and inner_error == "unknown_user":
                 return Result.available(url=show_url)
-            else:
-                error_msg = body.get("message", "Unknown API response")
-                return Result.error(f"WordPress Error: {error_msg}")
+
+            error_msg = body.get("message", "Unknown API response")
+            return Result.error(f"WordPress Error: {error_msg}")
 
     except httpx.TimeoutException:
         return Result.error("Connection timed out")

--- a/user_scanner/email_scan/entertainment/letterboxd.py
+++ b/user_scanner/email_scan/entertainment/letterboxd.py
@@ -1,4 +1,4 @@
-import httpx
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -16,40 +16,53 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-            await client.get(home_url, headers={'User-Agent': headers['User-Agent']})
-            csrf_token = client.cookies.get("com.xk72.webparts.csrf")
+        init = await impersonate_request_async(
+            home_url,
+            headers={'User-Agent': headers['User-Agent']},
+            allow_redirects=True,
+        )
+        csrf_token = init.cookies.get("com.xk72.webparts.csrf")
 
-            if not csrf_token:
-                return Result.error("Could not extract Letterboxd CSRF token")
+        if not csrf_token:
+            return Result.error("Could not extract Letterboxd CSRF token")
 
-            payload = {
-                '__csrf': csrf_token,
-                'token': "",
-                'emailAddress': email,
-                'username': "th3_t3erminal_w0rri0r",
-                'password': "n3v3r_F3lt_softn3ss",
-                'termsAndAge': "true",
-                'g-recaptcha-response': "",
-                'h-captcha-response': ""
-            }
+        payload = {
+            '__csrf': csrf_token,
+            'token': "",
+            'emailAddress': email,
+            'username': "th3_t3erminal_w0rri0r",
+            'password': "n3v3r_F3lt_softn3ss",
+            'termsAndAge': "true",
+            'g-recaptcha-response': "",
+            'h-captcha-response': ""
+        }
 
-            response = await client.post(register_url, data=payload, headers=headers)
+        response = await impersonate_request_async(
+            register_url, "POST", data=payload, headers=headers
+        )
+
+        try:
             data = response.json()
+        except ValueError:
+            # Letterboxd fronts the form endpoints with a Cloudflare managed
+            # challenge, which answers HTML where the form expects JSON.
+            return Result.error(
+                f"Non-JSON response (HTTP {response.status_code}), likely a bot challenge"
+            )
 
-            messages = data.get("messages", [])
-            error_fields = data.get("errorFields", [])
+        messages = data.get("messages", [])
+        error_fields = data.get("errorFields", [])
 
-            is_taken = any(
-                "already associated with an account" in msg for msg in messages)
+        is_taken = any(
+            "already associated with an account" in msg for msg in messages)
 
-            if is_taken or "emailAddress" in error_fields:
-                return Result.taken(url=show_url)
+        if is_taken or "emailAddress" in error_fields:
+            return Result.taken(url=show_url)
 
-            if "result" in data and not is_taken:
-                return Result.available(url=show_url)
+        if "result" in data and not is_taken:
+            return Result.available(url=show_url)
 
-            return Result.error("Unexpected response structure")
+        return Result.error("Unexpected response structure")
 
     except Exception as e:
         return Result.error(e)

--- a/user_scanner/email_scan/music/deezer.py
+++ b/user_scanner/email_scan/music/deezer.py
@@ -67,16 +67,24 @@ async def _check(email: str) -> Result:
                 return Result.error(f"HTTP Error: {response.status_code}")
 
             data = response.json()
-            errors = data.get("results", {}).get("errors", {})
+            results = data.get("results")
 
-            if errors.get("email", {}).get("error") == "email_already_used":
+            if not isinstance(results, dict) or "errors" not in results:
+                return Result.error("Unexpected response body structure, report it via GitHub issues")
+
+            errors = results.get("errors") or {}
+            email_error = (errors.get("email") or {}).get("error")
+
+            if email_error == "email_already_used":
                 return Result.taken(url=show_url)
 
-            elif "country" in errors and "email" not in errors:
+            # Deezer only reports an ``email`` constraint when the address is
+            # unusable; the sibling constraints it returns for the rest of the
+            # signup form say nothing about registration.
+            if not email_error:
                 return Result.available(url=show_url)
 
-            else:
-                return Result.error("Unexpected response body structure, report it via GitHub issues")
+            return Result.error(f"Deezer rejected the address: {email_error}")
 
     except httpx.ConnectTimeout:
         return Result.error("Connection timed out! maybe region blocks")

--- a/user_scanner/email_scan/news/nytimes.py
+++ b/user_scanner/email_scan/news/nytimes.py
@@ -75,12 +75,26 @@ async def _check(email: str) -> Result:
                 return Result.error(f"API acted up: {response.status_code}")
 
             res_data = response.json()
-            further_action = res_data.get("data", {}).get("further_action", "")
+            data = res_data.get("data", {})
+            further_action = data.get("further_action", "")
 
             # If it says show-login, they have an account. If show-register, they don't.
             if further_action == "show-login":
                 return Result.taken(url=show_url)
-            elif further_action == "show-register":
+
+            # An account whose only sign-in method is a social provider gets the
+            # welcome-back screen instead of the password prompt.
+            if further_action == "show-welcome-back":
+                return Result.taken(
+                    url=show_url,
+                    extra={
+                        "login_method": "SSO",
+                        "sso_provider": data.get("provider"),
+                        "sso_methods": data.get("ssoMethodsCount"),
+                    },
+                )
+
+            if further_action == "show-register":
                 return Result.available(url=show_url)
 
             return Result.error(f"Got an weird action: {further_action}")

--- a/user_scanner/email_scan/shopping/walmart.py
+++ b/user_scanner/email_scan/shopping/walmart.py
@@ -1,9 +1,9 @@
-import httpx
 import json
 import uuid
 import hashlib
 import base64
 import secrets
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 def generate_pkce_challenge():
@@ -40,19 +40,17 @@ async def _check(email: str) -> Result:
         }
     }
 
+    # No User-Agent or client hints: the impersonating transport supplies a set
+    # that matches its TLS fingerprint, and overriding half of it re-trips the
+    # 412 session-mismatch check.
     headers = {
-        'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
         'Accept': "application/json",
-        'Accept-Encoding': "identity",
         'Content-Type': "application/json",
         'x-o-mart': "B2C",
         'x-o-gql-query': "query GetLoginOptions",
-        'sec-ch-ua-platform': '"Windows"',
         'x-o-segment': "oaoh",
         'device_profile_ref_id': "xpmjgxfheteohb199lo0r5qewtwjywqaifje",
-        'sec-ch-ua': '"Not:A-Brand";v="99", "Google Chrome";v="124", "Chromium";v="124"',
         'x-enable-server-timing': "1",
-        'sec-ch-ua-mobile': "?0",
         'x-latency-trace': "1",
         'traceparent': trace_id,
         'wm_mp': "true",
@@ -76,57 +74,63 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-            # Step 1: Request the login page to initialize cookie sessions and bypass 412 errors
-            # MUST use the identical User-Agent to avoid session mismatches causing 412 errors.
-            await client.get(headers['wm_page_url'], headers={
-                'User-Agent': headers['User-Agent'],
+        # Step 1: Request the login page to seed the session cookies; the
+        # GraphQL endpoint answers 412 without them. The page URL carries this
+        # call's PKCE challenge, so it has to be fetched per check rather than
+        # through the shared once-per-session warm-up.
+        await impersonate_request_async(
+            headers['wm_page_url'],
+            headers={
                 'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 'Accept-Language': "en-US,en;q=0.9",
-            })
+            },
+            allow_redirects=True,
+        )
 
-            # Step 2: Post to the GraphQL endpoint
-            response = await client.post(url, content=json.dumps(payload), headers=headers)
+        # Step 2: Post to the GraphQL endpoint
+        response = await impersonate_request_async(
+            url, "POST", data=json.dumps(payload), headers=headers
+        )
 
-            if response.status_code == 429:
-                return Result.error("Rate limited")
+        if response.status_code == 429:
+            return Result.error("Rate limited")
 
-            if response.status_code == 412:
-                return Result.error("Precondition Failed (412) - Walmart detected session mismatch")
+        if response.status_code == 412:
+            return Result.error("Precondition Failed (412) - Walmart detected session mismatch")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+        if response.status_code != 200:
+            return Result.error(f"HTTP Error: {response.status_code}")
 
-            data = response.json()
-            errors = data.get("errors", [])
-            
-            # Check if there is an error stating Enum can't represent STEP_UP_REQUIRED
-            # This validation failure happens specifically on existing accounts requiring a step-up check
-            if errors and any("STEP_UP_REQUIRED" in err.get("message", "") for err in errors):
-                return Result.taken(url=show_url)
+        data = response.json()
+        errors = data.get("errors", [])
 
-            login_data = data.get("data", {}).get("getLoginOptions", {})
-            if login_data is None:
-                return Result.error("GraphQL getLoginOptions returned null")
+        # Check if there is an error stating Enum can't represent STEP_UP_REQUIRED
+        # This validation failure happens specifically on existing accounts requiring a step-up check
+        if errors and any("STEP_UP_REQUIRED" in err.get("message", "") for err in errors):
+            return Result.taken(url=show_url)
 
-            login_options = login_data.get("loginOptions", {}) or {}
-            login_errors = login_data.get("errors", []) or []
+        login_data = data.get("data", {}).get("getLoginOptions", {})
+        if login_data is None:
+            return Result.error("GraphQL getLoginOptions returned null")
 
-            # Check if errors indicates a non-existent email
-            if any(err.get("code") == "EMAIL_ID_INVALID" for err in login_errors):
-                return Result.available(url=show_url)
+        login_options = login_data.get("loginOptions", {}) or {}
+        login_errors = login_data.get("errors", []) or []
 
-            pref = login_options.get("signInPreference", "")
+        # Check if errors indicates a non-existent email
+        if any(err.get("code") == "EMAIL_ID_INVALID" for err in login_errors):
+            return Result.available(url=show_url)
 
-            if pref in ["PASSWORD", "CHOICE"]:
-                if any(err.get("code") == "COMPROMISED" for err in login_errors):
-                    return Result.taken("Account flagged as compromised")
-                return Result.taken(url=show_url)
+        pref = login_options.get("signInPreference", "")
 
-            elif pref == "CREATE":
-                return Result.available(url=show_url)
+        if pref in ["PASSWORD", "CHOICE"]:
+            if any(err.get("code") == "COMPROMISED" for err in login_errors):
+                return Result.taken("Account flagged as compromised")
+            return Result.taken(url=show_url)
 
-            return Result.error("Unexpected response structure")
+        if pref == "CREATE":
+            return Result.available(url=show_url)
+
+        return Result.error("Unexpected response structure")
 
     except Exception as e:
         return Result.error(e)

--- a/user_scanner/email_scan/social/classmates.py
+++ b/user_scanner/email_scan/social/classmates.py
@@ -1,5 +1,6 @@
-import httpx
 import re
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -7,60 +8,55 @@ async def _check(email: str) -> Result:
     show_url = "https://www.classmates.com"
     login_url = "https://www.classmates.com/auth/login"
 
+    # No User-Agent or client hints: the impersonating transport supplies a set
+    # that matches its TLS fingerprint, and overriding half of it re-trips the WAF.
     headers = {
-        'User-Agent': "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Mobile Safari/537.36",
         'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        'Accept-Encoding': "identity",
-        'sec-ch-ua-platform': '"Android"',
         'Origin': "https://www.classmates.com",
         'Referer': login_url,
         'Accept-Language': "en-US,en;q=0.9"
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-            r_init = await client.get(login_url, headers=headers)
+        # The login page is fetched as a plain navigation; sending the form's
+        # Origin/Referer on it is what the WAF answers 403 to.
+        r_init = await impersonate_request_async(login_url, allow_redirects=True)
 
-            if r_init.status_code == 403:
-                return Result.error("Caught by WAF (403) during Handshake")
+        if r_init.status_code == 403:
+            return Result.error("Caught by WAF (403) during Handshake")
 
-            csrf_match = re.search(
-                r'name="_csrf" value="([^"]+)"', r_init.text)
-            if not csrf_match:
-                return Result.error("Failed to extract CSRF token from login page")
+        csrf_match = re.search(r'name="_csrf" value="([^"]+)"', r_init.text)
+        if not csrf_match:
+            return Result.error("Failed to extract CSRF token from login page")
 
-            csrf_token = csrf_match.group(1)
+        payload = {
+            '_csrf': csrf_match.group(1),
+            'successUrl': "",
+            'emailOrRegId': email,
+            'password': "SafetyMismatch_123!",
+            'rememberme': "no"
+        }
 
-            payload = {
-                '_csrf': csrf_token,
-                'successUrl': "",
-                'emailOrRegId': email,
-                'password': "SafetyMismatch_123!",
-                'rememberme': "no"
-            }
+        response = await impersonate_request_async(
+            login_url, "POST", data=payload, headers=headers, allow_redirects=True
+        )
 
-            response = await client.post(login_url, data=payload, headers=headers)
+        if response.status_code == 403:
+            return Result.error("Caught by WAF or IP Block (403) during Check")
 
-            if response.status_code == 403:
-                return Result.error("Caught by WAF or IP Block (403) during Check")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Classmates (429)")
 
-            if response.status_code == 429:
-                return Result.error("Rate limited by Classmates (429)")
+        res_text = response.text
 
-            res_text = response.text
+        if "invalid registration/password" in res_text:
+            return Result.taken(url=show_url)
 
-            if "invalid registration/password" in res_text:
-                return Result.taken(url=show_url)
+        if "did not find an account for the email address" in res_text:
+            return Result.available(url=show_url)
 
-            if "did not find an account for the email address" in res_text:
-                return Result.available(url=show_url)
+        return Result.error("Unexpected response body structure")
 
-            return Result.error("Unexpected response body structure")
-
-    except httpx.ConnectTimeout:
-        return Result.error("Connection timed out! maybe region blocks")
-    except httpx.ReadTimeout:
-        return Result.error("Server took too long to respond (Read Timeout)")
     except Exception as e:
         return Result.error(e)
 


### PR DESCRIPTION
## tl;dr

- **Eleven email modules returned `Error` for every address, and five of them were sitting on accounts they could already see.** WordPress, NYTimes, Patreon, Pornhub and GitHub all had the answer in hand and threw it away.
- **Pornhub now leans on an enumeration leak that Pornhub can close at any time.** The check no longer discloses registration for the address as typed; the module probes a sub-addressed alias instead.
- **A GitHub miss no longer means "available".** The search API only sees addresses published on a public profile, so the module says so rather than returning Not Registered.
- **`core/impersonate.py` gains a transport bridge shared by both scan types.** Eight modules now route through it; a change there affects username scans too.
- **Five modules from the same report are deliberately untouched.** They are blocked by challenges and geo walls no HTTP client can clear.

## Eleven email modules returned `Error` for every address

Verified against a real address and an invented one. Real addresses are redacted; `test@gmail.com` stands in where a widely-registered address was needed to exercise the taken branch.

| Module | Fault | Before | After |
| --- | --- | --- | --- |
| wordpress | `403 email_login_not_allowed` **is** the exists signal, thrown as an error | `WordPress Error: Please log in using your username…` | Registered + `login_method: username only` |
| deezer | Keyed on a `country` error the API stopped returning, so nothing matched | `Unexpected response body structure` | verdict |
| nytimes | New `show-welcome-back` action for SSO-only accounts fell through to `else` | `Got an weird action: show-welcome-back` | Registered + `sso_provider: google` |
| patreon | New `sso_required` auth step, on top of a 403 | `Status 403` | Registered + `sso_providers` |
| kick | httpx fingerprint-blocked | `Caught by Cloudflare WAF (403)` | verdict |
| fapfolder | httpx fingerprint-blocked | `403` | verdict |
| letterboxd | Cloudflare served the challenge page where JSON was expected | `JSONDecodeError` | verdict |
| walmart | httpx fingerprint-blocked | `412 session mismatch` | verdict |
| classmates | httpx fingerprint-blocked | `WAF (403) during Handshake` | verdict |
| pornhub | Token relocated; homepage now 410s to httpx | `Failed to extract dynamic token` | Registered |
| github | `/signup` behind a DataDome interstitial | `Failed to extract authenticity_token` | Registered + login/id/profile/avatar |

Two of the transport swaps needed more than the swap. Walmart and classmates were re-tripping their own WAF because the module's hand-set `User-Agent` and client hints contradicted the impersonated TLS fingerprint — dropping them fixed both. Walmart also cannot use the shared `warmup_url`, which warms once per session key: its warm-up URL carries a per-call PKCE challenge, so it fetches explicitly.

## Pornhub now leans on an enumeration leak

For the address as typed, the check is deliberately uninformative — this is the same string for a registered address and for two that plainly are not:

```
<registered>@gmail.com -> "If this email is already registered, you'll receive a verification link."
support@github.com     -> "If this email is already registered, you'll receive a verification link."
postmaster@gmail.com   -> "If this email is already registered, you'll receive a verification link."
```

Pornhub strips `+tag` sub-addressing before the lookup, and forgot to apply the placeholder on that path:

```
<registered>+zz1@gmail.com   -> {"email":"create_account_failed","error_message":"Email has been taken."}
<unregistered>+zz1@gmail.com -> {"email":"create_account_passed","error_message":""}
```

Nobody registered `<registered>+zz1@gmail.com`, so "taken" can only be about the base address after normalisation. That is what makes the probe read the real account, and it is also why this is the most fragile thing in the diff: it is an undocumented inconsistency, not an API contract. If Pornhub applies the placeholder uniformly, the module returns `Unexpected API response` rather than a wrong verdict.

The probe needs the alias to be deliverable, so a dead mailbox or a provider without sub-addressing yields `Email is invalid or cannot be used` — reported as an error, never a guess. Addresses already containing `+` are rejected up front.

It also avoids the "you'll receive a verification link" path entirely, which is the only one that could plausibly mail the account holder.

## A GitHub miss no longer means "available"

`/signup` returns a DataDome interstitial on every impersonation target tried (`chrome`, `chrome131`, `chrome136`, `firefox135`, `safari184`, `edge101`), with and without the client hints the response asks for. The authenticity_token is unreachable, so the module leads with the unauthenticated search API:

```
GET https://api.github.com/search/users?q=<email>+in:email
```

A hit is definitive and carries `login`, `id`, `html_url`, `type` and the avatar. A miss is not — the API only sees addresses published on a profile — so the module falls through to the signup probe and, when that is blocked, returns an error naming both reasons instead of a verdict.

Search has its own rate-limit bucket, so this does not compete with `githubgist` for the 60/hr core-API budget.

## `core/impersonate.py` gains a transport bridge shared by both scan types

Every `email_scan` validator is `async def`; curl_cffi's session API blocks. `_run_batch` fans out up to 25 modules on one event loop, so a blocking call there stalls every module in flight.

`impersonate_request_async` is nine lines delegating to the existing `impersonate_request` via `asyncio.to_thread`, so session caching, cookie warm-up, proxy rotation and the `-t` timeout stay in one place. The consequence worth knowing: the curl_cffi session cache is now shared across email and username scans rather than username only.

The alternative is inlining `asyncio.to_thread(impersonate_request, …)` at each of the eight call sites — identical behavior, no core diff, ~10 duplicated lines. Happy to switch if the shared cache is not wanted.

## Five modules from the same report are deliberately untouched

Not oversights — each was investigated and found unreachable, so shipping churn against them would only add noise:

| Module | Wall |
| --- | --- |
| render | Non-enumerable by design. `signUp` answers `{"email":"invalid"}` for everything including the literal string `notanemail`; a junk `hcaptchaToken` short-circuits to `{"hcaptcha_token":"invalid"}` before email is evaluated; `signIn` returns one unified "incorrect or this account doesn't exist" for real and fake. No account was created while establishing this. |
| annaabi | Cloudflare managed challenge site-wide, homepage included; unchanged across httpx, curl_cffi and urllib |
| nykaaman | Akamai edge 403 on the whole host, homepage included |
| emirates | Akamai bot manager resets the stream even with warm `_abck`/`bm_sz` cookies |
| nextdoor | Nextdoor's own nameservers answer `0.0.0.0`, so the host never resolves |

`tube8` is also excluded: it fails on rate limiting, and probing it enough to fix it would mean tripping that limit repeatedly.

## Testing

Live, against a real address and an invented one, on all eleven modules.

```
<registered>@gmail.com          -> 6 Registered, 5 Not Registered, 0 Error
zzznotarealuser99xzq@gmail.com  -> 0 Registered, 0 false positives
```

Taken branches exercised separately via `test@gmail.com`, which flipped letterboxd, deezer, nytimes, wordpress, fapfolder, patreon, kick and walmart to Registered — so both branches are live-verified for those eight, plus pornhub and github from the real address.

### Verified after review

Four gaps flagged in the first revision have since been closed, and two of them turned up bugs now fixed in `2d993ce`.

| Gap | Result |
| --- | --- |
| classmates' taken branch | **Verified.** A registered address returns `invalid registration/password`; the module reports Registered. Note Classmates rate-limits after ~4 rapid attempts, which the module already handles as a 429. |
| github's available branch | **Verified via a real browser**, which clears the DataDome interstitial: `200` + `Email is available` for an unregistered address, `422` + `already associated with an account` for a registered one. |
| pornhub on non-gmail providers | **Verified** on outlook, hotmail, yahoo, icloud, gmx, yandex and fastmail. A nonsense local part returns `create_account_passed` at every one of them, with and without the tag, so the probe discriminates rather than blanket-reporting taken. proton.me and zoho.com are refused by Pornhub's own domain allowlist and now return a named error. |
| Do the five omitted modules work elsewhere | **Answered by re-testing from a US exit — see below.** Two of the five were purely geo and work unmodified; the other three fail regardless of location. |

Two bugs surfaced while verifying:

- **github's CSRF pattern was stale and unanchored.** The form now emits `value="…"` *before* `data-csrf="true"`, so `data-csrf="true"\s+value="…"` matched nothing — the fallback could never have fired even with the challenge cleared. The page also carries one token per auto-check endpoint, so a first-match grab risked the `password_validity_checks` token. Now anchored inside the `email_validity_checks` block.
- **pornhub reported disallowed domains as an unexpected API response.** proton.me and zoho.com are refused before any lookup; that is a rule about the provider, not a verdict.

### Re-tested from a US exit

The geo hypothesis was half right. With a New York exit:

| Module | Result |
| --- | --- |
| nextdoor | **Works, unmodified.** DNS resolves (`3.161.213.64`) instead of `0.0.0.0`, confirming the null-route was geo. `invalid_grant` → Registered, `not_found` → Not Registered, both verified over plain httpx. |
| nykaaman | **Works, unmodified.** The Akamai edge serves the site normally; `is_exists` true/false both verified. No transport change needed — httpx is fine. |
| emirates | **Still fails.** The page loads, but the validate-email POST is reset (`HTTP/2 INTERNAL_ERROR`) from the US too, and from inside a real browser same-origin. Akamai bot manager, not geo. |
| annaabi | **Still fails.** Cloudflare managed challenge from the US as well, and it does not clear in a stealth browser. |
| render | **Unchanged, and not location-dependent** — non-enumerable by design. |

So nextdoor and nykaaman were never broken modules; they were unreachable from the author's region. Neither needed a code change to work. The only thing added is a nextdoor diagnostic (`d66e2c6`): its own nameservers answering `0.0.0.0` produced a bare `getaddrinfo failed` that reads like a local network fault, so it now names the cause for anyone scanning from an unsupported region.

### Still not verified

- **pornhub against corporate and self-hosted domains.** Only the major consumer providers were exercised; sub-addressing support elsewhere varies.
- **emirates and annaabi from their own regions.** Both fail from US and the author's region, and both look like bot defence rather than geo, but neither was tested from an EE or AE exit.
