### PR TITLE
feat(core): add impersonate_request_async for the email modules

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(


### PR DESCRIPTION
Groundwork for the per-module email fixes that follow; no behavior change on its own.

Every `email_scan` validator is `async def`, but curl_cffi's session API blocks, and `_run_batch` fans out up to 25 modules on a single event loop — so calling the existing `impersonate_request` directly from a module would stall every other module in flight. The orchestrator's `asyncio.to_thread` path only covers validators declared sync, and none of the email modules are.

`impersonate_request_async` delegates to `impersonate_request` in a worker thread, so session caching, cookie warm-up, proxy rotation and the `-t` timeout all stay in one place rather than being reimplemented against curl_cffi's `AsyncSession`.

**The consequence worth knowing:** the curl_cffi session cache is now shared across email and username scans rather than username only.

The alternative is inlining `asyncio.to_thread(impersonate_request, …)` at each call site — identical behavior, no core diff, roughly ten duplicated lines across the modules that need it. Happy to switch if the shared cache isn't wanted.
