### PR TITLE
fix(wordpress): treat email_login_not_allowed as a registered account

### DIFF
--- a/user_scanner/email_scan/dev/wordpress.py
+++ b/user_scanner/email_scan/dev/wordpress.py
@@ -34,14 +34,24 @@ async def _check(email: str) -> Result:
 
             inner_code = data.get("code")
             body = data.get("body", {})
+            inner_error = body.get("error")
 
             if inner_code == 200:
                 return Result.taken(url=show_url)
-            elif inner_code == 404 and body.get("error") == "unknown_user":
+
+            # WordPress.com answers 403 email_login_not_allowed only for an
+            # address that maps to a real account whose owner must sign in with
+            # their username; an unknown address 404s instead.
+            if inner_code == 403 and inner_error == "email_login_not_allowed":
+                return Result.taken(
+                    url=show_url, extra={"login_method": "username only"}
+                )
+
+            if inner_code == 404 and inner_error == "unknown_user":
                 return Result.available(url=show_url)
-            else:
-                error_msg = body.get("message", "Unknown API response")
-                return Result.error(f"WordPress Error: {error_msg}")
+
+            error_msg = body.get("message", "Unknown API response")
+            return Result.error(f"WordPress Error: {error_msg}")
 
     except httpx.TimeoutException:
         return Result.error("Connection timed out")


### PR DESCRIPTION
`GET /rest/v1.1/users/<email>/auth-options` answers `403 email_login_not_allowed` only for an address that maps to a real account whose owner has to sign in with their username. The module treated that as a failure, so every such account came back as an error rather than a hit.

```
registered address    -> {"code":403,"body":{"error":"email_login_not_allowed", ...}}   was: Error
unknown address       -> {"code":404,"body":{"error":"unknown_user", ...}}              Not Registered
```

An unknown address 404s `unknown_user`, so the two states stay cleanly separable; anything else is still an error. The account's `login_method` is surfaced in `extra`. Both branches live-tested.
