### PR TITLE
fix(nytimes): recognise show-welcome-back as a registered account

### DIFF
--- a/user_scanner/email_scan/news/nytimes.py
+++ b/user_scanner/email_scan/news/nytimes.py
@@ -75,12 +75,26 @@ async def _check(email: str) -> Result:
                 return Result.error(f"API acted up: {response.status_code}")
 
             res_data = response.json()
-            further_action = res_data.get("data", {}).get("further_action", "")
+            data = res_data.get("data", {})
+            further_action = data.get("further_action", "")
 
             # If it says show-login, they have an account. If show-register, they don't.
             if further_action == "show-login":
                 return Result.taken(url=show_url)
-            elif further_action == "show-register":
+
+            # An account whose only sign-in method is a social provider gets the
+            # welcome-back screen instead of the password prompt.
+            if further_action == "show-welcome-back":
+                return Result.taken(
+                    url=show_url,
+                    extra={
+                        "login_method": "SSO",
+                        "sso_provider": data.get("provider"),
+                        "sso_methods": data.get("ssoMethodsCount"),
+                    },
+                )
+
+            if further_action == "show-register":
                 return Result.available(url=show_url)
 
             return Result.error(f"Got an weird action: {further_action}")


### PR DESCRIPTION
An account whose only sign-in method is a social provider gets the welcome-back screen instead of the password prompt, and that action fell through to the catch-all error.

```
SSO-only account  -> further_action: show-welcome-back, provider: google   was: Error
password account  -> further_action: show-login                           Registered
unknown address   -> further_action: show-register                        Not Registered
```

`show-welcome-back` now reads as registered, and the provider it names is surfaced in `extra` alongside `ssoMethodsCount`. All three states live-tested.
