### PR TITLE
fix(nextdoor): name the geo null-route instead of a raw resolver error

### DIFF
--- a/user_scanner/email_scan/community/nextdoor.py
+++ b/user_scanner/email_scan/community/nextdoor.py
@@ -28,7 +28,18 @@ async def _check(email: str) -> Result:
 
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, data=payload, headers=headers)
+            try:
+                response = await client.post(url, data=payload, headers=headers)
+            except httpx.ConnectError as e:
+                # Outside the countries Nextdoor operates in, its own
+                # nameservers answer 0.0.0.0, so the host never resolves to a
+                # usable address and the check cannot run at all.
+                if "getaddrinfo" in str(e) or "11001" in str(e) or "11004" in str(e):
+                    return Result.error(
+                        "auth.nextdoor.com does not resolve from here; "
+                        "Nextdoor null-routes its DNS outside supported regions"
+                    )
+                raise
 
             if response.status_code == 403:
                 return Result.error("403")


### PR DESCRIPTION
Outside the countries Nextdoor operates in, its own nameservers answer `0.0.0.0` for `auth.nextdoor.com`, so the module surfaced a bare `ConnectError: [errno 11004] getaddrinfo failed` that reads like a broken local network.

```
$ dig +short auth.nextdoor.com     # from an unsupported region
0.0.0.0
```

The module itself is fine — verified from a US exit, where DNS resolves normally and both branches work over plain httpx (`invalid_grant` → Registered, `not_found` → Not Registered). This only replaces the resolver error with the actual reason, so the failure isn't mistaken for a module bug or a local DNS problem.
