### PR TITLE
fix(kick): route the signup check through the impersonating transport

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/creator/kick.py
+++ b/user_scanner/email_scan/creator/kick.py
@@ -1,5 +1,7 @@
-import httpx
+import json
 import secrets
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 def _generate_trace_id() -> str:
@@ -22,36 +24,33 @@ async def _check(email: str) -> Result:
         'x-req-trace': _generate_trace_id()
     }
 
-    payload = {
-        "email": email
-    }
-
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, json=payload, headers=headers)
+        response = await impersonate_request_async(
+            url, "POST", data=json.dumps({"email": email}), headers=headers
+        )
 
-            # Check for generic perimeter blocks
-            if response.status_code == 403:
-                return Result.error("Caught by Cloudflare WAF (403)")
-            if response.status_code == 429:
-                return Result.error("Rate limited by Kick (429)")
+        # Check for generic perimeter blocks
+        if response.status_code == 403:
+            return Result.error("Caught by Cloudflare WAF (403)")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Kick (429)")
 
-            # Target validation logic (Status 204 No Content -> Email is available)
-            if response.status_code == 204:
-                return Result.available(url=show_url)
+        # Target validation logic (Status 204 No Content -> Email is available)
+        if response.status_code == 204:
+            return Result.available(url=show_url)
 
-            if response.status_code == 422:
-                try:
-                    data = response.json()
-                    errors = data.get("errors", {})
-                    email_errors = errors.get("email", [])
+        if response.status_code == 422:
+            try:
+                data = response.json()
+                errors = data.get("errors", {})
+                email_errors = errors.get("email", [])
 
-                    if any("already been taken" in str(err).lower() for err in email_errors):
-                        return Result.taken(url=show_url)
-                except Exception:
-                    return Result.error("Failed to parse 422 validation content")
+                if any("already been taken" in str(err).lower() for err in email_errors):
+                    return Result.taken(url=show_url)
+            except Exception:
+                return Result.error("Failed to parse 422 validation content")
 
-            return Result.error(f"Unexpected response state (HTTP {response.status_code})")
+        return Result.error(f"Unexpected response state (HTTP {response.status_code})")
 
     except Exception as e:
         return Result.error(str(e))


### PR DESCRIPTION
httpx is fingerprint-blocked by Kick's Cloudflare edge, so every address came back as a 403. The impersonating transport clears it and both existing branches resolve unchanged.

```
registered address  -> 422 {"errors":{"email":["The email has already been taken."]}}   Registered
unknown address     -> 204 No Content                                                   Not Registered
```

Both live-tested.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
