### PR TITLE
fix(fapfolder): route the signup check through the impersonating transport

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/adult/fapfolder.py
+++ b/user_scanner/email_scan/adult/fapfolder.py
@@ -1,4 +1,4 @@
-import httpx
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -32,22 +32,23 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(url, data=payload, headers=headers)
+        response = await impersonate_request_async(
+            url, "POST", data=payload, headers=headers
+        )
 
-            if response.status_code == 403:
-                return Result.error("403")
+        if response.status_code == 403:
+            return Result.error("403")
 
-            data = response.json()
-            message = data.get("message", "")
+        data = response.json()
+        message = data.get("message", "")
 
-            if "belongs to an existing account" in message:
-                return Result.taken(url=show_url)
+        if "belongs to an existing account" in message:
+            return Result.taken(url=show_url)
 
-            if "password must be at least" in message:
-                return Result.available(url=show_url)
+        if "password must be at least" in message:
+            return Result.available(url=show_url)
 
-            return Result.error(f"Unexpected: {message[:50]}")
+        return Result.error(f"Unexpected: {message[:50]}")
 
     except Exception as e:
         return Result.error(e)


### PR DESCRIPTION
httpx is fingerprint-blocked — the homepage 403s too, so this is the site rejecting the client rather than the endpoint changing. curl_cffi returns 200 and the existing branches resolve unchanged.

The module's request shape is untouched: it still posts a deliberately invalid password so the signup handler rejects the submission and only reports on the email. Both branches live-tested.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
