### PR TITLE
fix(patreon): clear the 403 and recognise the sso_required auth step

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/creator/patreon.py
+++ b/user_scanner/email_scan/creator/patreon.py
@@ -1,63 +1,78 @@
-import httpx
+import json
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+# Auth steps Patreon returns for an address that already has an account:
+# "password" for a local login, "sso_required" when the account can only be
+# reached through a social provider.
+_TAKEN_STEPS = ("password", "sso_required")
 
 
 async def _check(email: str) -> Result:
-    async with httpx.AsyncClient(timeout=15.0, http2=False) as client:
-        try:
-            url = "https://www.patreon.com/api/auth"
-            show_url = "https://patreon.com"
+    url = "https://www.patreon.com/api/auth"
+    show_url = "https://patreon.com"
 
-            params = {
-                'include': "user.null",
-                'fields[user]': "[]",
-                'json-api-version': "1.0",
-                'json-api-use-default-includes': "false"
-            }
+    params = {
+        'include': "user.null",
+        'fields[user]': "[]",
+        'json-api-version': "1.0",
+        'json-api-use-default-includes': "false"
+    }
 
-            payload = "{\"data\":{\"type\":\"genericPatreonApi\",\"attributes\":{\"patreon_auth\":{\"email\":\"" + email + \
-                "\",\"allow_account_creation\":false},\"auth_context\":\"auth\",\"ru\":\"https://www.patreon.com/home\"},\"relationships\":{}}}"
+    payload = json.dumps({
+        "data": {
+            "type": "genericPatreonApi",
+            "attributes": {
+                "patreon_auth": {"email": email, "allow_account_creation": False},
+                "auth_context": "auth",
+                "ru": "https://www.patreon.com/home",
+            },
+            "relationships": {},
+        }
+    })
 
-            headers = {
-                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
-                'sec-ch-ua-platform': '"Linux"',
-                'sec-ch-ua': '"Brave";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
-                'content-type': "application/vnd.api+json",
-                'sec-ch-ua-mobile': "?0",
-                'sec-gpc': "1",
-                'accept-language': "en-US,en;q=0.7",
-                'origin': "https://www.patreon.com",
-                'sec-fetch-site': "same-origin",
-                'sec-fetch-mode': "cors",
-                'sec-fetch-dest': "empty",
-                'referer': "https://www.patreon.com/login"
-            }
+    headers = {
+        'Accept-Encoding': "gzip, deflate, br, zstd",
+        'content-type': "application/vnd.api+json",
+        'sec-gpc': "1",
+        'accept-language': "en-US,en;q=0.7",
+        'origin': "https://www.patreon.com",
+        'sec-fetch-site': "same-origin",
+        'sec-fetch-mode': "cors",
+        'sec-fetch-dest': "empty",
+        'referer': "https://www.patreon.com/login"
+    }
 
-            response = await client.post(
-                url,
-                params=params,
-                content=payload,
-                headers=headers,
-                timeout=15.0
+    try:
+        response = await impersonate_request_async(
+            url, "POST", params=params, data=payload, headers=headers
+        )
+
+        if response.status_code != 200:
+            return Result.error(f"Status {response.status_code}, report it via GitHub issues")
+
+        data = response.json()
+        attributes = (data.get("data") or {}).get("attributes") or {}
+        next_step = attributes.get("next_auth_step")
+
+        if next_step in _TAKEN_STEPS:
+            providers = attributes.get("supported_sso_providers") or []
+            return Result.taken(
+                url=show_url,
+                extra={
+                    "login_method": "SSO" if next_step == "sso_required" else "password",
+                    "sso_providers": ", ".join(providers),
+                },
             )
 
-            if response.status_code != 200:
-                return Result.error(f"Status {response.status_code}, report it via GitHub issues")
+        if next_step == "signup":
+            return Result.available(url=show_url)
 
-            data = response.json()
-            next_step = data.get("data", {}).get(
-                "attributes", {}).get("next_auth_step")
+        return Result.error("Unexpected auth step, report it via GitHub issues")
 
-            if next_step == "password":
-                return Result.taken(url=show_url)
-            elif next_step == "signup":
-                return Result.available(url=show_url)
-            else:
-                return Result.error("Unexpected auth step, report it via GitHub issues")
-
-        except Exception as e:
-            return Result.error(f"unexpected exception: {e}")
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")
 
 
 async def validate_patreon(email: str) -> Result:


### PR DESCRIPTION
Two faults. httpx is fingerprint-blocked, so every address returned `Status 403`. Behind that, an account reachable only through a social provider returns a new auth step that fell through to the unexpected-step error.

```
SSO-only account   -> next_auth_step: sso_required, supported_sso_providers: ["google_sso"]   was: Error
password account   -> next_auth_step: password                                                Registered
unknown address    -> next_auth_step: signup                                                  Not Registered
```

`sso_required` now reads as registered and the providers are surfaced in `extra`. The request keeps `allow_account_creation: false`, so it stays a read-only auth probe. Both branches live-tested.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
