### PR TITLE
fix(classmates): clear the WAF 403 on the login handshake

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/social/classmates.py
+++ b/user_scanner/email_scan/social/classmates.py
@@ -1,5 +1,6 @@
-import httpx
 import re
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -7,60 +8,55 @@ async def _check(email: str) -> Result:
     show_url = "https://www.classmates.com"
     login_url = "https://www.classmates.com/auth/login"
 
+    # No User-Agent or client hints: the impersonating transport supplies a set
+    # that matches its TLS fingerprint, and overriding half of it re-trips the WAF.
     headers = {
-        'User-Agent': "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Mobile Safari/537.36",
         'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        'Accept-Encoding': "identity",
-        'sec-ch-ua-platform': '"Android"',
         'Origin': "https://www.classmates.com",
         'Referer': login_url,
         'Accept-Language': "en-US,en;q=0.9"
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-            r_init = await client.get(login_url, headers=headers)
+        # The login page is fetched as a plain navigation; sending the form's
+        # Origin/Referer on it is what the WAF answers 403 to.
+        r_init = await impersonate_request_async(login_url, allow_redirects=True)
 
-            if r_init.status_code == 403:
-                return Result.error("Caught by WAF (403) during Handshake")
+        if r_init.status_code == 403:
+            return Result.error("Caught by WAF (403) during Handshake")
 
-            csrf_match = re.search(
-                r'name="_csrf" value="([^"]+)"', r_init.text)
-            if not csrf_match:
-                return Result.error("Failed to extract CSRF token from login page")
+        csrf_match = re.search(r'name="_csrf" value="([^"]+)"', r_init.text)
+        if not csrf_match:
+            return Result.error("Failed to extract CSRF token from login page")
 
-            csrf_token = csrf_match.group(1)
+        payload = {
+            '_csrf': csrf_match.group(1),
+            'successUrl': "",
+            'emailOrRegId': email,
+            'password': "SafetyMismatch_123!",
+            'rememberme': "no"
+        }
 
-            payload = {
-                '_csrf': csrf_token,
-                'successUrl': "",
-                'emailOrRegId': email,
-                'password': "SafetyMismatch_123!",
-                'rememberme': "no"
-            }
+        response = await impersonate_request_async(
+            login_url, "POST", data=payload, headers=headers, allow_redirects=True
+        )
 
-            response = await client.post(login_url, data=payload, headers=headers)
+        if response.status_code == 403:
+            return Result.error("Caught by WAF or IP Block (403) during Check")
 
-            if response.status_code == 403:
-                return Result.error("Caught by WAF or IP Block (403) during Check")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Classmates (429)")
 
-            if response.status_code == 429:
-                return Result.error("Rate limited by Classmates (429)")
+        res_text = response.text
 
-            res_text = response.text
+        if "invalid registration/password" in res_text:
+            return Result.taken(url=show_url)
 
-            if "invalid registration/password" in res_text:
-                return Result.taken(url=show_url)
+        if "did not find an account for the email address" in res_text:
+            return Result.available(url=show_url)
 
-            if "did not find an account for the email address" in res_text:
-                return Result.available(url=show_url)
+        return Result.error("Unexpected response body structure")
 
-            return Result.error("Unexpected response body structure")
-
-    except httpx.ConnectTimeout:
-        return Result.error("Connection timed out! maybe region blocks")
-    except httpx.ReadTimeout:
-        return Result.error("Server took too long to respond (Read Timeout)")
     except Exception as e:
         return Result.error(e)
 


### PR DESCRIPTION
httpx is fingerprint-blocked on the login handshake. Switching transport alone was not enough: the module also sent the form's `Origin` and `Referer` on the initial page **GET**, and that combination is itself what the WAF answers 403 to. The login page is now fetched as a plain navigation, with those headers kept for the POST where they belong.

```
registered address  -> "invalid registration/password"                       Registered
unknown address     -> "did not find an account for the email address"       Not Registered
```

Both live-tested. Worth knowing: Classmates rate-limits after roughly four rapid attempts and answers 429, which the module already reports as an error rather than a verdict.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
