### PR TITLE
fix(walmart): clear the 412 session mismatch

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/shopping/walmart.py
+++ b/user_scanner/email_scan/shopping/walmart.py
@@ -1,9 +1,9 @@
-import httpx
 import json
 import uuid
 import hashlib
 import base64
 import secrets
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 def generate_pkce_challenge():
@@ -40,19 +40,17 @@ async def _check(email: str) -> Result:
         }
     }
 
+    # No User-Agent or client hints: the impersonating transport supplies a set
+    # that matches its TLS fingerprint, and overriding half of it re-trips the
+    # 412 session-mismatch check.
     headers = {
-        'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
         'Accept': "application/json",
-        'Accept-Encoding': "identity",
         'Content-Type': "application/json",
         'x-o-mart': "B2C",
         'x-o-gql-query': "query GetLoginOptions",
-        'sec-ch-ua-platform': '"Windows"',
         'x-o-segment': "oaoh",
         'device_profile_ref_id': "xpmjgxfheteohb199lo0r5qewtwjywqaifje",
-        'sec-ch-ua': '"Not:A-Brand";v="99", "Google Chrome";v="124", "Chromium";v="124"',
         'x-enable-server-timing': "1",
-        'sec-ch-ua-mobile': "?0",
         'x-latency-trace': "1",
         'traceparent': trace_id,
         'wm_mp': "true",
@@ -76,57 +74,63 @@ async def _check(email: str) -> Result:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-            # Step 1: Request the login page to initialize cookie sessions and bypass 412 errors
-            # MUST use the identical User-Agent to avoid session mismatches causing 412 errors.
-            await client.get(headers['wm_page_url'], headers={
-                'User-Agent': headers['User-Agent'],
+        # Step 1: Request the login page to seed the session cookies; the
+        # GraphQL endpoint answers 412 without them. The page URL carries this
+        # call's PKCE challenge, so it has to be fetched per check rather than
+        # through the shared once-per-session warm-up.
+        await impersonate_request_async(
+            headers['wm_page_url'],
+            headers={
                 'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 'Accept-Language': "en-US,en;q=0.9",
-            })
+            },
+            allow_redirects=True,
+        )
 
-            # Step 2: Post to the GraphQL endpoint
-            response = await client.post(url, content=json.dumps(payload), headers=headers)
+        # Step 2: Post to the GraphQL endpoint
+        response = await impersonate_request_async(
+            url, "POST", data=json.dumps(payload), headers=headers
+        )
 
-            if response.status_code == 429:
-                return Result.error("Rate limited")
+        if response.status_code == 429:
+            return Result.error("Rate limited")
 
-            if response.status_code == 412:
-                return Result.error("Precondition Failed (412) - Walmart detected session mismatch")
+        if response.status_code == 412:
+            return Result.error("Precondition Failed (412) - Walmart detected session mismatch")
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+        if response.status_code != 200:
+            return Result.error(f"HTTP Error: {response.status_code}")
 
-            data = response.json()
-            errors = data.get("errors", [])
-            
-            # Check if there is an error stating Enum can't represent STEP_UP_REQUIRED
-            # This validation failure happens specifically on existing accounts requiring a step-up check
-            if errors and any("STEP_UP_REQUIRED" in err.get("message", "") for err in errors):
-                return Result.taken(url=show_url)
+        data = response.json()
+        errors = data.get("errors", [])
 
-            login_data = data.get("data", {}).get("getLoginOptions", {})
-            if login_data is None:
-                return Result.error("GraphQL getLoginOptions returned null")
+        # Check if there is an error stating Enum can't represent STEP_UP_REQUIRED
+        # This validation failure happens specifically on existing accounts requiring a step-up check
+        if errors and any("STEP_UP_REQUIRED" in err.get("message", "") for err in errors):
+            return Result.taken(url=show_url)
 
-            login_options = login_data.get("loginOptions", {}) or {}
-            login_errors = login_data.get("errors", []) or []
+        login_data = data.get("data", {}).get("getLoginOptions", {})
+        if login_data is None:
+            return Result.error("GraphQL getLoginOptions returned null")
 
-            # Check if errors indicates a non-existent email
-            if any(err.get("code") == "EMAIL_ID_INVALID" for err in login_errors):
-                return Result.available(url=show_url)
+        login_options = login_data.get("loginOptions", {}) or {}
+        login_errors = login_data.get("errors", []) or []
 
-            pref = login_options.get("signInPreference", "")
+        # Check if errors indicates a non-existent email
+        if any(err.get("code") == "EMAIL_ID_INVALID" for err in login_errors):
+            return Result.available(url=show_url)
 
-            if pref in ["PASSWORD", "CHOICE"]:
-                if any(err.get("code") == "COMPROMISED" for err in login_errors):
-                    return Result.taken("Account flagged as compromised")
-                return Result.taken(url=show_url)
+        pref = login_options.get("signInPreference", "")
 
-            elif pref == "CREATE":
-                return Result.available(url=show_url)
+        if pref in ["PASSWORD", "CHOICE"]:
+            if any(err.get("code") == "COMPROMISED" for err in login_errors):
+                return Result.taken("Account flagged as compromised")
+            return Result.taken(url=show_url)
 
-            return Result.error("Unexpected response structure")
+        if pref == "CREATE":
+            return Result.available(url=show_url)
+
+        return Result.error("Unexpected response structure")
 
     except Exception as e:
         return Result.error(e)

--- a/user_scanner/email_scan/shopping/walmart.py
+++ b/user_scanner/email_scan/shopping/walmart.py
@@ -95,8 +95,11 @@ async def _check(email: str) -> Result:
         if response.status_code == 429:
             return Result.error("Rate limited")
 
+        # Walmart answers 412 with a PerimeterX block payload whenever it
+        # refuses the request — an unaccepted session, a flagged IP, a blocked
+        # region — so the status alone does not name which one.
         if response.status_code == 412:
-            return Result.error("Precondition Failed (412) - Walmart detected session mismatch")
+            return Result.error("Blocked by Walmart bot protection (412)")
 
         if response.status_code != 200:
             return Result.error(f"HTTP Error: {response.status_code}")


### PR DESCRIPTION
httpx is fingerprint-blocked and every address returned `412 Precondition Failed`. Two things beyond the transport swap were needed:

- **The hand-set `User-Agent` and client hints re-tripped the same 412.** They contradicted the impersonated TLS fingerprint, so they are dropped and the transport supplies a self-consistent set.
- **The warm-up cannot use the shared `warmup_url`.** That warms once per session key, but Walmart's login-page URL carries this call's PKCE challenge, so it has to be fetched per check.

```
registered address  -> signInPreference: PASSWORD                Registered
unknown address     -> errors: [{code: EMAIL_ID_INVALID}]        Not Registered
```

Both live-tested. The GraphQL query and verdict logic are unchanged.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
