### PR TITLE
fix(pornhub): probe a sub-addressed alias to get a verdict again

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/adult/pornhub.py
+++ b/user_scanner/email_scan/adult/pornhub.py
@@ -1,71 +1,95 @@
-import httpx
 import re
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+BASE_URL = "https://www.pornhub.com"
+SHOW_URL = "https://pornhub.com"
+CHECK_API = f"{BASE_URL}/api/v1/user/create_account_check"
+
+# The token is only reachable through the create_account_check URL Pornhub
+# embeds (HTML-escaped) in the page's signup config.
+TOKEN_RE = re.compile(r"create_account_check\?token=([A-Za-z0-9_.\-]+)")
+
+# Pornhub no longer discloses registration for the address as typed: a
+# deliverable address always gets the same "if this email is already
+# registered" placeholder, and that path is what mails the account holder.
+# Probing a sub-addressed alias sidesteps both problems, because Pornhub
+# normalises the "+tag" away and then answers plainly.
+PROBE_TAG = "+phck"
+
+HEADERS = {
+    "x-requested-with": "XMLHttpRequest",
+    "origin": BASE_URL,
+    "referer": BASE_URL + "/",
+    "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+}
 
 
 async def _check(email: str) -> Result:
-    base_url = "https://www.pornhub.com"
-    show_url = "https://pornhub.com"
-    check_api = f"{base_url}/api/v1/user/create_account_check"
+    local, _, domain = email.rpartition("@")
+    if not local or not domain:
+        return Result.error("Not a valid email address")
 
-    headers = {
-        "user-agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
-        "x-requested-with": "XMLHttpRequest",
-        "origin": base_url,
-        "referer": base_url + "/",
-        "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
-    }
+    if "+" in local:
+        return Result.error(
+            "Address is already sub-addressed; Pornhub cannot be probed for it"
+        )
 
-    async with httpx.AsyncClient(http2=True, follow_redirects=True, timeout=15.0) as client:
-        try:
-            landing_resp = await client.get(base_url, headers=headers)
-            token_match = re.search(
-                r'var\s+token\s*=\s*"([^"]+)"', landing_resp.text)
+    try:
+        landing = await impersonate_request_async(BASE_URL + "/", allow_redirects=True)
+        token_match = TOKEN_RE.search(landing.text)
 
-            if not token_match:
-                return Result.error("Failed to extract dynamic token from HTML")
+        if not token_match:
+            return Result.error("Failed to extract dynamic token from HTML")
 
-            token = token_match.group(1)
+        response = await impersonate_request_async(
+            CHECK_API,
+            "POST",
+            params={"token": token_match.group(1)},
+            headers=HEADERS,
+            data={"check_what": "email", "email": f"{local}{PROBE_TAG}@{domain}"},
+        )
 
-            params = {"token": token}
-            payload = {
-                "check_what": "email",
-                "email": email
-            }
+        if response.status_code == 429:
+            return Result.error("Rate limited, wait for a few minutes")
 
-            response = await client.post(
-                check_api,
-                params=params,
-                headers=headers,
-                data=payload
+        if response.status_code != 200:
+            return Result.error(f"HTTP Error: {response.status_code}")
+
+        data = response.json()
+        status = data.get("email")
+        error_msg = data.get("error_message", "")
+
+        if status == "create_account_passed":
+            return Result.available(url=SHOW_URL)
+
+        if "has been taken" in error_msg:
+            return Result.taken(url=SHOW_URL)
+
+        if "delivery issues" in error_msg:
+            return Result.error(url=SHOW_URL, reason="The email is experiencing email delivery issues")
+
+        # Pornhub refuses to check some providers at all (proton.me, zoho.com),
+        # which is a rule about the domain rather than a verdict on the address.
+        if "is not allowed" in error_msg:
+            return Result.error(
+                url=SHOW_URL,
+                reason=f"Pornhub does not accept registrations from '{domain}'",
             )
 
-            if response.status_code == 429:
-                return Result.error("Rate limited, wait for a few minutes")
+        # Sub-addressing is only accepted for mailboxes that actually resolve,
+        # so an unusable alias says nothing about the address it derives from.
+        if "invalid or cannot be used" in error_msg:
+            return Result.error(
+                url=SHOW_URL,
+                reason=f"Domain '{domain}' does not support the sub-address probe",
+            )
 
-            if response.status_code != 200:
-                return Result.error(f"HTTP Error: {response.status_code}")
+        return Result.error(f"Unexpected API response: {status}: {error_msg}")
 
-            data = response.json()
-            status = data.get("email")
-            error_msg = data.get("error_message", "")
-            email_dom = email.split("@")[-1]
-
-            if status == "create_account_failed":
-                if "Email extension" in error_msg:
-                    return Result.available(url=show_url, reason=f"Domain '{email_dom}' is not allowed by PornHub")
-                if "delivery issues" in error_msg:
-                    return Result.error(url=show_url, reason="The email is experiencing email delivery issues")
-
-            if status == "create_account_passed" and error_msg == "":
-                return Result.available(url=show_url)
-            elif status == "create_account_failed" and "already registered" in error_msg:
-                return Result.taken(url=show_url)
-            else:
-                return Result.error(f"Unexpected API response: {status}: {error_msg}")
-
-        except Exception as e:
-            return Result.error(e)
+    except Exception as e:
+        return Result.error(e)
 
 
 async def validate_pornhub(email: str) -> Result:


### PR DESCRIPTION
## tl;dr

- **Three separate breakages**, only one of which is the token regex named in the title of the old behavior.
- **The check stopped disclosing registration for the address as typed** — the module now probes a sub-addressed alias, which is the fragile part of this change.
- Domains Pornhub refuses outright are reported as such instead of as an unexpected response.

## Three breakages

| Fault | Effect |
| --- | --- |
| Token moved out of `var token = "…"` into the embedded `create_account_check?token=…` URL | `Failed to extract dynamic token` |
| httpx now gets HTTP 410 on the homepage | Nothing to parse even with the right pattern |
| The check no longer answers plainly for the address as typed | No verdict available |

## The check no longer discloses registration, so the module probes an alias

For the address as typed the response is the same string whether or not an account exists — these two are certainly not registered:

```
support@github.com    -> "If this email is already registered, you'll receive a verification link."
postmaster@gmail.com  -> "If this email is already registered, you'll receive a verification link."
```

Pornhub strips `+tag` sub-addressing before the lookup and forgot to apply that placeholder on the stripped path, so the alias answers plainly:

```
<registered>+zz1@gmail.com    -> {"email":"create_account_failed","error_message":"Email has been taken."}
<unregistered>+zz1@gmail.com  -> {"email":"create_account_passed","error_message":""}
```

Nobody registered the tagged form, so "taken" can only be about the base address after normalisation.

**This is an undocumented inconsistency, not an API contract.** If Pornhub applies the placeholder uniformly the module returns `Unexpected API response` rather than a wrong verdict.

Verified across gmail, outlook, hotmail, yahoo, icloud, gmx, yandex and fastmail. The control that matters: a nonsense local part returns `create_account_passed` at every one of them, tagged or not, so the probe discriminates rather than blanket-reporting taken.

It also avoids the "you'll receive a verification link" path entirely — the only one that could plausibly mail the account holder.

## Where it declines to answer

The alias has to be deliverable, so a dead mailbox or a provider without sub-addressing yields `Email is invalid or cannot be used`, reported as an error rather than a guess. Addresses already containing `+` are rejected up front. proton.me and zoho.com are refused by Pornhub's own domain allowlist and now return a named error; previously a disallowed domain was reported as **available**, which was a false negative.

## Not verified

Corporate and self-hosted domains — only the major consumer providers were exercised, and sub-addressing support elsewhere varies.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
