### PR TITLE
fix(github): find accounts via the search API when signup is challenged

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/dev/github.py
+++ b/user_scanner/email_scan/dev/github.py
@@ -1,74 +1,101 @@
-import httpx
 import re
+from urllib.parse import quote
+
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
+
+SHOW_URL = "https://github.com"
+SEARCH_API = "https://api.github.com/search/users"
+SIGNUP_URL = "https://github.com/signup"
+VALIDITY_URL = "https://github.com/email_validity_checks"
+
+# The signup form carries one CSRF token per auto-check endpoint and emits the
+# value before the data-csrf marker, so the token has to be taken from inside
+# the email_validity_checks block rather than from the first match on the page.
+CSRF_RE = re.compile(
+    r'<auto-check[^>]*src="/email_validity_checks"'
+    r'[\s\S]*?<input[^>]*value="([^"]+)"[^>]*data-csrf="true"'
+)
 
 
 async def _check(email: str) -> Result:
-    show_url = "https://github.com"
-    async with httpx.AsyncClient(timeout=15.0, http2=True, follow_redirects=True) as client:
-        try:
-            url1 = "https://github.com/signup"
-            headers1 = {
-                'host': 'github.com',
-                'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"',
-                'sec-ch-ua-mobile': '?0',
-                'sec-ch-ua-platform': '"Linux"',
-                'upgrade-insecure-requests': '1',
-                'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36',
-                'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-                'sec-fetch-site': 'cross-site',
-                'sec-fetch-mode': 'navigate',
-                'sec-fetch-user': '?1',
-                'sec-fetch-dest': 'document',
-                'referer': 'https://www.google.com/',
-                'accept-encoding': 'gzip, deflate, br, zstd',
-                'accept-language': 'en-US,en;q=0.9',
-                'priority': 'u=0, i'
-            }
+    # The search API confirms a hit outright and costs one request, so it runs
+    # before the signup probe. It only sees accounts that publish the address
+    # on their profile, so a miss still has to fall through.
+    found = await _search_public_profiles(email)
+    if found is not None:
+        return found
 
-            res1 = await client.get(url1, headers=headers1)
-            html = res1.text
+    return await _check_signup_availability(email)
 
-            csrf_match = re.search(r'data-csrf="true"\s+value="([^"]+)"', html)
 
-            if not csrf_match:
-                return Result.error("Failed to extract GitHub authenticity_token")
+async def _search_public_profiles(email: str) -> Result | None:
+    try:
+        response = await impersonate_request_async(
+            f"{SEARCH_API}?q={quote(email)}+in:email",
+            headers={"accept": "application/vnd.github+json"},
+        )
+    except Exception:
+        return None
 
-            csrf_token = csrf_match.group(1)
+    if response.status_code != 200:
+        return None
 
-            url2 = "https://github.com/email_validity_checks"
-            payload = {
-                'authenticity_token': csrf_token,
-                'value': email
-            }
+    items = response.json().get("items") or []
+    if not items:
+        return None
 
-            headers2 = {
-                'User-Agent': "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
-                'Accept-Encoding': "gzip, deflate, br, zstd",
-                'sec-ch-ua-platform': '"Linux"',
-                'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"',
-                'sec-ch-ua-mobile': "?0",
-                'origin': "https://github.com",
-                'sec-fetch-site': "same-origin",
-                'sec-fetch-mode': "cors",
-                'sec-fetch-dest': "empty",
-                'referer': "https://github.com/signup",
-                'accept-language': "en-US,en;q=0.9",
-                'priority': "u=1, i"
-            }
+    user = items[0]
+    return Result.taken(
+        url=SHOW_URL,
+        extra={
+            "login": user.get("login"),
+            "user_id": user.get("id"),
+            "profile": user.get("html_url"),
+            "account_type": user.get("type"),
+            "matched_by": "public profile email",
+        },
+        media={"avatar": user.get("avatar_url")},
+    )
 
-            response = await client.post(url2, data=payload, headers=headers2)
-            body = response.text
 
-            if "already associated with an account" in body:
-                return Result.taken(url=show_url)
-            elif response.status_code == 200 and "Email is available" in body:
-                return Result.available(url=show_url)
-            else:
-                return Result.error(f"Unexpected status code: {response.status_code}, report this via GitHub issues")
+async def _check_signup_availability(email: str) -> Result:
+    try:
+        signup = await impersonate_request_async(SIGNUP_URL, allow_redirects=True)
+        csrf_match = CSRF_RE.search(signup.text)
 
-        except Exception as e:
-            return Result.error(f"unexpected exception: {e}")
+        if not csrf_match:
+            # GitHub fronts /signup with DataDome, whose interstitial no HTTP
+            # client can clear; the address may still be registered privately.
+            return Result.error(
+                "GitHub's signup form is behind a bot challenge, and the address "
+                "is not on any public profile"
+            )
+
+        response = await impersonate_request_async(
+            VALIDITY_URL,
+            "POST",
+            data={"authenticity_token": csrf_match.group(1), "value": email},
+            headers={
+                "origin": SHOW_URL,
+                "referer": SIGNUP_URL,
+                "accept": "*/*",
+            },
+        )
+        body = response.text
+
+        if "already associated with an account" in body:
+            return Result.taken(url=SHOW_URL)
+
+        if response.status_code == 200 and "Email is available" in body:
+            return Result.available(url=SHOW_URL)
+
+        return Result.error(
+            f"Unexpected status code: {response.status_code}, report this via GitHub issues"
+        )
+
+    except Exception as e:
+        return Result.error(f"unexpected exception: {e}")
 
 
 async def validate_github(email: str) -> Result:


### PR DESCRIPTION
## tl;dr

- **`/signup` is behind a DataDome interstitial**, so the authenticity_token was unreachable and every address errored.
- **The search API now leads** and confirms a hit outright, with profile metadata.
- **A miss is not proof of availability** — the module says so rather than returning Not Registered.
- **The signup fallback's CSRF pattern was stale and would never have matched**, even with the challenge cleared.

## /signup is behind a DataDome interstitial

Reproduced on `chrome`, `chrome131`, `chrome136`, `firefox135`, `safari184` and `edge101`, with and without the client hints the response asks for. No HTTP client clears it.

## The search API now leads

```
GET https://api.github.com/search/users?q=<email>+in:email
```

A hit is definitive and carries `login`, `id`, `html_url`, `type` and the avatar. It costs one request and uses a **separate rate-limit bucket** from the core API, so it does not compete with `githubgist` for the 60/hr budget.

## A miss is not proof of availability

The API only sees addresses published on a public profile. On a miss the module falls through to the signup probe, and when that is challenged it returns an error naming both reasons instead of a verdict. Behind DataDome the module can therefore confirm Registered but will never return Not Registered — that is a deliberate refusal to guess, not a silent failure.

## The signup fallback's CSRF pattern was stale

GitHub emits `value="…"` **before** the `data-csrf` marker, so `data-csrf="true"\s+value="([^"]+)"` matched nothing — the fallback was dead code regardless of the challenge. The page also carries one token per auto-check endpoint, so a first-match grab risked the `password_validity_checks` token. The search is now anchored inside the `email_validity_checks` block.

Both markers were confirmed against the live endpoint from a browser session that cleared the challenge:

```
unregistered -> 200  "Email is available"
registered   -> 422  "already associated with an account"
```

## Not verified

The available branch has never executed **through the module** — only through a browser. The markers and the corrected pattern are confirmed against live responses, but whether the path runs at all depends on the user's IP.


---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
