### PR TITLE
fix(facebook): follow canonical-casing redirects and match both miss wordings

### DIFF
--- a/user_scanner/user_scan/social/facebook.py
+++ b/user_scanner/user_scan/social/facebook.py
@@ -1,34 +1,22 @@
+import html
 import re
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
-PROFILE_TITLE_RE = re.compile(r'<meta property="og:title" content="[^"]+"')
+PROFILE_TITLE_RE = re.compile(r'<meta property="og:title" content="([^"]+)"')
 PROFILE_URL_RE = re.compile(
-    r'<meta property="og:url" content="https://www\.facebook\.com/[^"]+"'
+    r'<meta property="og:url" content="(https://www\.facebook\.com/[^"]+)"'
 )
-UNAVAILABLE_MARKER = "This content isn't available at the moment"
-
-def _process_profile_response(status_code: int, html: str) -> Result:
-    if status_code == 429:
-        return Result.error("Rate limited by Facebook")
-
-    if status_code >= 500:
-        return Result.error(f"Facebook returned HTTP {status_code}")
-
-    has_profile_markers = bool(
-        PROFILE_TITLE_RE.search(html) and PROFILE_URL_RE.search(html)
-    )
-    has_unavailable_marker = UNAVAILABLE_MARKER in html
-
-    if has_profile_markers and not has_unavailable_marker:
-        return Result.taken()
-
-    if has_unavailable_marker and not has_profile_markers:
-        return Result.available()
-
-    return Result.error("Unexpected response body, report it via GitHub issues.")
+DESCRIPTION_RE = re.compile(r'<meta property="og:description" content="([^"]*)"')
+COUNTS_RE = re.compile(
+    r"^.*?\.\s*(?P<likes>[\d,.]+) likes"
+    r"(?:\s*&#xb7;\s*(?P<talking>[\d,.]+) talking about this)?\.\s*(?P<bio>.*)$",
+    re.DOTALL,
+)
+# Facebook ships this error in two wordings ("at the moment" / "right now"),
+# embedded in JSON where the apostrophe is backslash-escaped.
+UNAVAILABLE_RE = re.compile(r"This content isn\\?'t available")
 
 
 def validate_facebook(user: str) -> Result:
@@ -45,22 +33,55 @@ def validate_facebook(user: str) -> Result:
         return Result.error("Username cannot start or end with a period")
 
     show_url = f"https://www.facebook.com/{user}"
-    headers = {
-        "User-Agent": "Mozilla/5.0",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
 
-    request = Request(show_url, headers=headers)
+    def process(response):
+        return _process_profile_response(response.status_code, response.text)
 
-    try:
-        with urlopen(request, timeout=8.0) as response:
-            html = response.read().decode("utf-8", "ignore")
-            return _process_profile_response(response.status, html).update(url=show_url)
-    except HTTPError as exc:
-        html = exc.read().decode("utf-8", "ignore")
-        return _process_profile_response(exc.code, html).update(url=show_url)
-    except URLError as exc:
-        return Result.error(exc, url=show_url)
-    except Exception as exc:
-        return Result.error(exc, url=show_url)
+    # A handle in non-canonical casing 302s to its canonical form; a miss does not.
+    return impersonate_validate(show_url, process, show_url=show_url, allow_redirects=True)
+
+
+def _process_profile_response(status_code: int, body: str) -> Result:
+    if status_code == 429:
+        return Result.error("Rate limited by Facebook")
+
+    if status_code >= 500:
+        return Result.error(f"Facebook returned HTTP {status_code}")
+
+    title = PROFILE_TITLE_RE.search(body)
+    canonical = PROFILE_URL_RE.search(body)
+    has_unavailable_marker = bool(UNAVAILABLE_RE.search(body))
+
+    if title and canonical and not has_unavailable_marker:
+        return Result.taken(extra=_extract(title.group(1), canonical.group(1), body))
+
+    if has_unavailable_marker and not (title and canonical):
+        return Result.available()
+
+    return Result.error("Unexpected response body, report it via GitHub issues.")
+
+
+def _extract(title: str, canonical: str, body: str) -> dict:
+    extra = {"name": html.unescape(title).strip()}
+
+    # The canonical URL carries the handle's real casing, which the requested
+    # one does not — Facebook resolves handles case-insensitively.
+    handle = canonical.rsplit("/", 1)[-1]
+    if handle:
+        extra["handle"] = handle
+
+    description = DESCRIPTION_RE.search(body)
+    if not description:
+        return extra
+
+    counts = COUNTS_RE.match(description.group(1))
+    if not counts:
+        return extra
+
+    extra["likes"] = counts.group("likes")
+    if talking := counts.group("talking"):
+        extra["talking_about"] = talking
+    if bio := html.unescape(counts.group("bio")).strip():
+        extra["bio"] = bio
+
+    return extra


### PR DESCRIPTION
## tl;dr

- **Three faults, only one of which is the transport.** urllib received a body carrying neither marker, so no verdict was reachable.
- **Non-canonical casing was missed entirely** — the 302 to the canonical handle was never followed.
- **The not-found marker has a second wording** the exact-string check couldn't see.

## The transport

urllib got a page with neither the found nor the not-found marker, so every handle returned `Unexpected response body`. curl_cffi gets the real page.

## Two verdict bugs behind it

| Fault | Effect |
| --- | --- |
| 302 to canonical casing never followed | `bill.gates` (→ `BillGates`) missed entirely |
| Marker matched as one exact string | Facebook also ships "This content isn't available **right now**", apostrophe backslash-escaped inside JSON |

The marker is now a regex covering both wordings and the escaped form, and the canonical `og:url` supplies the handle's real casing.

```
zuck, cristiano, bill.gates -> Found
invented handle             -> Not Found
bill.gates                  -> {'name': 'Bill Gates', 'handle': 'BillGates', 'likes': '41,470,070', ...}
```

## Known behaviour, verified rather than assumed

- **Alias handles resolve to their canonical account.** `facebook.com/mark` redirects to Mark Zuckerberg's profile, so `mark` reports taken with `handle: zuck`. Accurate — the handle isn't free — but `extra` names a different string than the one scanned.
- **Profiles with no like count** come back without one rather than erroring: `jack` returns `{'name': 'Jack Lindamood', 'handle': 'jack'}` and nothing else.


---

Live-tested on the combined branch this was split out of (#526); the file here is byte-identical to what was tested.
