### PR TITLE
fix(livejournal): resolve journals, and split purged from suspended

### DIFF
--- a/user_scanner/user_scan/social/livejournal.py
+++ b/user_scanner/user_scan/social/livejournal.py
@@ -1,38 +1,97 @@
-import re
 import json
-from user_scanner.core.helpers import get_random_user_agent
-from user_scanner.core.orchestrator import Result, make_request
+import re
 
-def validate_livejournal(user):
-    url = f"https://{user}.livejournal.com"
-    show_url = url
-    headers = {"User-Agent": get_random_user_agent()}
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
+# The journal subdomain answers a ~750 KB page and stalls Python's TLS stack;
+# the profile page carries the same Site.journal payload and always resolves.
+PROFILE_URL = "https://www.livejournal.com/profile/"
+JOURNAL_RE = re.compile(r"Site\.journal\s*=\s*(\{.+?\});")
+NOT_FOUND_MARKER = "The page was not found!"
+
+# A purged journal frees its username for re-registration ("You can rename your
+# account with this username"); a suspended one keeps it.
+PURGED_MARKER = "This journal has been deleted and purged"
+SUSPENDED_MARKER = "This journal has been suspended"
+
+
+def validate_livejournal(user: str) -> Result:
+    show_url = f"https://{user}.livejournal.com"
+
+    def process(response):
+        if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
+            return Result.available()
+
+        if response.status_code == 410 and PURGED_MARKER in response.text:
+            return Result.available()
+
+        if response.status_code == 403 and SUSPENDED_MARKER in response.text:
+            return Result.taken(extra={"status": "suspended"})
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        journal = _journal(response.text)
+        if not journal:
+            return Result.error("200 response with no journal data")
+
+        # Guard against the generic profile shell: only the requested journal's
+        # own page echoes its username back.
+        if _canonical(journal.get("display_username", "")) != _canonical(user):
+            return Result.error("200 response for a different journal")
+
+        return Result.taken(extra=_extract(journal), media=_media(journal))
+
+    return impersonate_validate(
+        PROFILE_URL, process, params={"user": user}, show_url=show_url
+    )
+
+
+def _canonical(username) -> str:
+    # LiveJournal usernames are case-insensitive and treat "-" and "_" as the
+    # same character, so james-nicoll and JAMES_NICOLL are one journal.
+    return str(username).lower().replace("-", "_")
+
+
+def _journal(body: str) -> dict:
+    match = JOURNAL_RE.search(body)
+    if not match:
+        return {}
     try:
-        response = make_request(url, headers=headers)
-        if response.status_code == 200:
-            extra = {}
-            match = re.search(r'Site\.journal\s*=\s*({.+?});', response.text)
-            if match:
-                try:
-                    data = json.loads(match.group(1))
-                    if 'id' in data: extra['uid'] = data['id']
-                    if 'display_username' in data: extra['name'] = data['display_username']
-                    if 'is_paid' in data: extra['is_paid'] = data['is_paid']
-                    if 'is_community' in data: extra['is_community'] = data['is_community']
-                except Exception:
-                    pass
-            return Result.taken(extra=extra, url=show_url)
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        elif response.status_code in [403, 410, 302, 301]:
-            # Non-existent user might redirect or give 404
-            # If 403, usually suspended (which means taken)
-            if response.status_code == 403:
-                return Result.taken(extra={"status": "suspended or forbidden"}, url=show_url)
-            # Fallback for others
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        data = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _extract(journal: dict) -> dict:
+    extra: dict = {}
+
+    if uid := journal.get("id"):
+        extra["uid"] = uid
+    if name := journal.get("display_username"):
+        extra["name"] = name
+    if subtitle := journal.get("journal_subtitle"):
+        extra["subtitle"] = subtitle
+    if url := journal.get("journal_url"):
+        extra["journal_url"] = url
+
+    extra["type"] = _account_type(journal)
+    if journal.get("is_paid"):
+        extra["is_paid"] = True
+
+    return extra
+
+
+def _account_type(journal: dict) -> str:
+    if journal.get("is_syndicated"):
+        return "syndicated feed"
+    if journal.get("is_news"):
+        return "news"
+    return "personal" if journal.get("is_personal") else "community"
+
+
+def _media(journal: dict) -> dict:
+    userhead = journal.get("userhead_url")
+    return {"userhead": userhead} if userhead else {}


### PR DESCRIPTION
## tl;dr

- **Every handle timed out** — the journal subdomain stalls Python's TLS stack.
- **Purged and suspended accounts deserve opposite verdicts, and both used to error.**
- **`-` and `_` are the same character** in a LiveJournal username.
- **A redirect used to mean "this name is free."**

## Every handle timed out

The journal subdomain serves ~750 KB and stalls Python's TLS stack. `www.livejournal.com/profile/?user=` carries the same `Site.journal` payload at a fraction of the size.

```
ohnotheydidnt, james_nicoll -> Found
invented handle             -> Not Found
ohnotheydidnt -> {'uid': 3616053, 'type': 'community', 'is_paid': True, ...}
```

## Purged and suspended accounts get opposite verdicts

```
deleted -> 410 "Purged Account"     "...deleted and purged. You can rename
                                     your account with this username."   -> AVAILABLE
abc     -> 403 "Suspended Journal"  "This journal has been suspended."    -> TAKEN
```

Both fell through to `Unexpected status` before. The distinction isn't cosmetic — a purged username is genuinely re-registrable, so reporting it taken would be wrong in the other direction. The pre-existing `403 → taken` branch was right for this site and is kept, but gated on the explicit marker rather than the bare status.

## `-` and `_` are the same character

```
james-nicoll -> TAKEN (uid 86776258)   # same journal
james_nicoll -> TAKEN (uid 86776258)
JAMES_NICOLL -> TAKEN (uid 86776258)
```

The rewrite guards against the generic profile shell by comparing the echoed `display_username`, so that comparison normalises case and `-`/`_` on both sides — otherwise `james-nicoll` would error while `james_nicoll` resolves.

## A redirect used to mean "this name is free"

The old `302/301 → available` branch reported every redirect as an unregistered name. Removed.

## Not verified

- **Connectivity here is intermittent** — 4 connection timeouts in 30 consecutive requests. Those surface as `Result.error`, never a verdict.
- **Deleted-but-not-yet-purged journals.** Purged (410) and suspended (403) are covered by real handles; the window between deletion and purge was not observed and may behave differently.


---

Live-tested on the combined branch this was split out of (#526); the file here is byte-identical to what was tested.
