### PR TITLE
fix(producthunt): confirm a hit on the profile title instead of a bare 200

### DIFF
--- a/user_scanner/user_scan/creator/producthunt.py
+++ b/user_scanner/user_scan/creator/producthunt.py
@@ -4,6 +4,8 @@ import re
 from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
+PROFILE_TITLE_RE = re.compile(r"<title>([^<]+?)(?:&#x27;s|&#39;s|'s) profile")
+
 
 def validate_producthunt(user: str) -> Result:
     if not (2 <= len(user) <= 32):
@@ -26,6 +28,12 @@ def validate_producthunt(user: str) -> Result:
 
         if response.status_code != 200:
             return Result.error(f"Unexpected status: {response.status_code}")
+
+        # A profile page is confirmed by the possessive title Product Hunt
+        # renders server-side; nothing else under /@ carries it, so a 200
+        # without it is an interstitial rather than a hit.
+        if not PROFILE_TITLE_RE.search(response.text):
+            return Result.error("200 without a profile title, cannot confirm the handle")
 
         return Result.taken(extra=_extract(response.text))
 
@@ -51,7 +59,7 @@ def _extract(body: str) -> dict:
     if "name" in extra:
         return extra
 
-    title = re.search(r"<title>([^<]+?)(?:&#x27;s|'s) profile", body)
+    title = PROFILE_TITLE_RE.search(body)
     if title:
         extra["name"] = title.group(1).strip()
         return extra

--- a/user_scanner/user_scan/creator/producthunt.py
+++ b/user_scanner/user_scan/creator/producthunt.py
@@ -1,6 +1,8 @@
-import re
 import json
-from user_scanner.core.orchestrator import Result, make_request
+import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
 
 
 def validate_producthunt(user: str) -> Result:
@@ -12,45 +14,50 @@ def validate_producthunt(user: str) -> Result:
         return Result.error("Only use letters, numbers, and underscores.")
 
     url = f"https://www.producthunt.com/@{user}"
-    show_url = f"https://www.producthunt.com/@{user}"
 
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Cache-Control": "max-age=0",
-        "Upgrade-Insecure-Requests": "1",
-    }
+    def process(response):
+        # Cloudflare serves a managed challenge on every path of this domain in
+        # some regions; no HTTP client can clear it, so never call it a verdict.
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error("Cloudflare challenge, cannot be solved without a browser")
 
-    try:
-        response = make_request(url, headers=headers, follow_redirects=True)
-        if response.status_code == 200:
-            html = response.text
-            extra = {}
-            
-            ld = re.search(r'<script type=\"application/ld\+json\">(.*?)</script>', html, re.DOTALL)
-            if ld:
-                try:
-                    data = json.loads(ld.group(1))
-                    if isinstance(data, list): data = data[0]
-                    if name := data.get("name"): extra["name"] = name
-                    if curl := data.get("url"): extra["url"] = curl
-                except Exception:
-                    pass
-                    
-            if "name" not in extra:
-                title_match = re.search(r'<title>([^<]+?)(?:&#x27;s|\'s) profile', html)
-                if title_match:
-                    extra["name"] = title_match.group(1).strip()
-                else:
-                    meta = re.search(r'See what kind of products\s+([^\(]+)', html)
-                    if meta:
-                        extra["name"] = meta.group(1).strip()
-                        
-            return Result.taken(extra=extra, url=show_url)
-        elif response.status_code == 404:
-            return Result.available(url=show_url)
-        else:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
-    except Exception as e:
-        return Result.error(e, url=show_url)
+        if response.status_code == 404:
+            return Result.available()
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status: {response.status_code}")
+
+        return Result.taken(extra=_extract(response.text))
+
+    return impersonate_validate(url, process, show_url=url, allow_redirects=True)
+
+
+def _extract(body: str) -> dict:
+    extra = {}
+
+    ld = re.search(r'<script type="application/ld\+json">(.*?)</script>', body, re.DOTALL)
+    if ld:
+        try:
+            data = json.loads(ld.group(1))
+            if isinstance(data, list):
+                data = data[0]
+            if name := data.get("name"):
+                extra["name"] = name
+            if profile_url := data.get("url"):
+                extra["url"] = profile_url
+        except (json.JSONDecodeError, AttributeError, IndexError, KeyError):
+            pass
+
+    if "name" in extra:
+        return extra
+
+    title = re.search(r"<title>([^<]+?)(?:&#x27;s|'s) profile", body)
+    if title:
+        extra["name"] = title.group(1).strip()
+        return extra
+
+    meta = re.search(r"See what kind of products\s+([^\(]+)", body)
+    if meta:
+        extra["name"] = meta.group(1).strip()
+
+    return extra


### PR DESCRIPTION
## tl;dr

- **The Cloudflare challenge was cleared manually in a real browser, so this module's verdict logic is now verified** — it was the one thing the earlier revision could not observe at all.
- **The soft-200 risk flagged previously is not real.** Misses genuinely 404.
- **A hit is now confirmed on a marker anyway**, rather than on a bare 200.
- The module still moves to the impersonating transport and names the challenge where the site is unreachable.

## Verified: misses genuinely 404

Every invented handle and every reserved-looking path answers 404 with the generic site title:

```
@rrhoover              -> 200  "Ryan Hoover's profile on Product Hunt"
@zzznotarealuser99xzq  -> 404  "Product Hunt – The best new products in tech."
@settings @about @posts-> 404  "Product Hunt – The best new products in tech."
```

Worth noting for anyone reading the old caveat: `@me`, `@admin`, `@null` and `@new` all return 200 — but each is a **real user account**, not a reserved page. So no non-profile page under `/@` was found returning 200.

## A hit is now confirmed on a marker anyway

Even with misses 404ing cleanly, `Result.taken()` on any 200 violates the project's no-false-positives rule — an interstitial answering 200 would become a hit. Product Hunt renders a possessive profile title **server-side**, so it is present in the raw response rather than only after hydration:

```
<title>Ryan Hoover&#x27;s profile on Product Hunt | Product Hunt</title>
```

Confirmed present in the raw HTML of every hit and absent from every 404 body. A 200 without it now returns an error instead of a verdict.

The name extraction reuses that same pattern, which also covers the `&#39;` apostrophe encoding the old copy missed. Verified against real titles including non-Latin names (`Кирилл Петренко`, `罗魏赵`). The JSON-LD path is kept as the preferred source but does not currently fire on profile pages.

## What is still not verified

The module has **not** been run end-to-end from this location — Cloudflare still challenges every HTTP client here, so it returns the named challenge error rather than a verdict. What is verified is the verdict logic itself, against real server responses captured once the challenge was cleared by hand in a browser. Where the site is reachable, the module should now work; that has not been observed directly.
