### PR TITLE
fix(annaabi): name the Cloudflare challenge instead of emitting a bare 403

### DIFF
--- a/user_scanner/user_scan/learning/annaabi.py
+++ b/user_scanner/user_scan/learning/annaabi.py
@@ -1,4 +1,4 @@
-from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
 
@@ -6,6 +6,11 @@ def validate_annaabi(user: str) -> Result:
     show_url = "https://annaabi.ee"
 
     def process(response):
+        # Cloudflare serves a managed challenge to some regions; no HTTP client
+        # can clear it, so never turn it into a verdict.
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error("Cloudflare challenge, cannot be solved without a browser")
+
         if response.status_code != 200:
             return Result.error(f"Unexpected response status: {response.status_code}")
 
@@ -22,7 +27,7 @@ def validate_annaabi(user: str) -> Result:
             return Result.taken() if taken else Result.available()
         return Result.error("Unexpected response body")
 
-    return generic_validate(
+    return impersonate_validate(
         f"{show_url}/register.php",
         process,
         params={"go": "1", "usernamecheck": user},


### PR DESCRIPTION
The module emitted a bare `Unexpected response status: 403`, which reads like a module bug. It is a Cloudflare managed challenge, which no HTTP client can clear.

Two changes: the module moves to the impersonating transport, which may be all it needs wherever the site is reachable, and an unclearable challenge is now named rather than surfaced as a status code.

**The verdict logic is verified, not assumed.** Through a real browser the check endpoint answers normally and both markers still match — `admin`, `test` and `marko` return the exact taken marker, invented handles the exact free marker. So this is a network wall at my location rather than rotted parsing, and the module should work unchanged from anywhere the site is reachable.


---

Live-tested on the combined branch this was split out of (#526); the file here is byte-identical to what was tested.
