### PR TITLE
fix(donatello): confirm a creator page instead of returning taken on any 200

### DIFF
--- a/user_scanner/user_scan/donation/donatello.py
+++ b/user_scanner/user_scan/donation/donatello.py
@@ -5,14 +5,23 @@ from user_scanner.core.result import Result
 
 CLOUDFLARE_BLOCK_MARKER = "Attention Required! | Cloudflare"
 
+# Only a creator page carries its own handle in og:url; the site's own pages
+# (/about, /login, /terms) answer 200 with the bare domain there instead.
+OG_HANDLE_RE = re.compile(r'<meta property="og:url" content="https://donatello\.to/([^"/?]+)"')
+AUTHOR_RE = re.compile(r'<meta name="author" content="([^"]+)">')
+
 
 def validate_donatello(user):
     url = f"https://donatello.to/{user}"
 
     def process(response):
         if response.status_code == 200:
+            handle_match = OG_HANDLE_RE.search(response.text)
+            if not handle_match:
+                return Result.error("200 without a creator page, cannot confirm the handle")
+
             extra = {}
-            author_match = re.search(r'<meta name="author" content="([^"]+)">', response.text)
+            author_match = AUTHOR_RE.search(response.text)
             if author_match:
                 name = author_match.group(1).strip()
                 if name.lower() != user.lower():

--- a/user_scanner/user_scan/donation/donatello.py
+++ b/user_scanner/user_scan/donation/donatello.py
@@ -1,9 +1,13 @@
-from user_scanner.core.orchestrator import generic_validate, Result
 import re
+
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+CLOUDFLARE_BLOCK_MARKER = "Attention Required! | Cloudflare"
+
 
 def validate_donatello(user):
     url = f"https://donatello.to/{user}"
-    show_url = f"https://donatello.to/{user}"
 
     def process(response):
         if response.status_code == 200:
@@ -14,8 +18,14 @@ def validate_donatello(user):
                 if name.lower() != user.lower():
                     extra["name"] = name
             return Result.taken(extra=extra)
-        elif response.status_code == 404:
+
+        if response.status_code == 404:
             return Result.available()
+
+        # Cloudflare blocks whole regions from this domain; that is not a verdict.
+        if response.status_code == 403 and CLOUDFLARE_BLOCK_MARKER in response.text:
+            return Result.error("Blocked by Cloudflare, the site is unreachable from here")
+
         return Result.error(f"Unexpected status {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, show_url=url)


### PR DESCRIPTION
## tl;dr

- **Reaching the site from a permitted region exposed a false positive**: `/about`, `/login` and `/terms` answer 200 and were reported as **taken handles**.
- **A hit is now confirmed on the creator page's own `og:url`.**
- The Cloudflare regional block is still named rather than surfaced as a bare 403.
- Misses genuinely 404, so the availability branch was already correct.

## The false positive

The module returned `Result.taken()` on any 200. Donatello's own pages answer 200:

```
/about   200   og:url = https://donatello.to        <- site page, was reported TAKEN
/login   200   og:url = https://donatello.to        <- site page, was reported TAKEN
/terms   200   og:url = https://donatello.to        <- site page, was reported TAKEN
```

## A hit is now confirmed on og:url

Only a creator page carries its own handle there:

```
/sternenko  200  og:url = https://donatello.to/sternenko   -> Found
/help       200  og:url = https://donatello.to/help        -> Found   (a real user named "help")
/about      200  og:url = https://donatello.to             -> error
/zzznotarealuser99xzq  404                                 -> Not Found
```

A 200 without it returns an error rather than a verdict.

Live through the module:

```
sternenko             -> Found
about                 -> Error (200 without a creator page, cannot confirm the handle)
zzznotarealuser99xzq  -> Not Found
```

## The regional block

Cloudflare serves "Attention Required" to whole regions; that is a network wall, not a verdict, and is still reported as such. The module also moves to the impersonating transport. Both branches are now live-verified from a region the site serves — the earlier revision of this PR could not exercise them at all.
