### PR TITLE
fix(yaga): name the CloudFront country block instead of a bare 403

### DIFF
--- a/user_scanner/user_scan/shopping/yaga_co_za.py
+++ b/user_scanner/user_scan/shopping/yaga_co_za.py
@@ -8,6 +8,9 @@ from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
 
+GEO_BLOCK_MARKER = "configured to block access from your country"
+
+
 def validate_yaga_co_za(user: str) -> Result:
     user = user.lower()
     url = f"https://www.yaga.co.za/{quote(user, safe='')}"
@@ -23,6 +26,11 @@ def validate_yaga_co_za(user: str) -> Result:
             return Result.available()
 
         if response.status_code != 200:
+            # CloudFront fronts this shop and refuses whole countries outright;
+            # that 403 says nothing about the handle.
+            if response.status_code == 403 and GEO_BLOCK_MARKER in response.text:
+                return Result.error("CloudFront blocks this country, the site is unreachable from here")
+
             return Result.error(
                 f"Unexpected response status: {response.status_code}",
             )

--- a/user_scanner/user_scan/shopping/yaga_ee.py
+++ b/user_scanner/user_scan/shopping/yaga_ee.py
@@ -8,6 +8,9 @@ from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
 
+GEO_BLOCK_MARKER = "configured to block access from your country"
+
+
 def validate_yaga_ee(user: str) -> Result:
     user = user.lower()
     url = f"https://www.yaga.ee/{quote(user, safe='')}"
@@ -23,6 +26,11 @@ def validate_yaga_ee(user: str) -> Result:
             return Result.available()
 
         if response.status_code != 200:
+            # CloudFront fronts this shop and refuses whole countries outright;
+            # that 403 says nothing about the handle.
+            if response.status_code == 403 and GEO_BLOCK_MARKER in response.text:
+                return Result.error("CloudFront blocks this country, the site is unreachable from here")
+
             return Result.error(
                 f"Unexpected response status: {response.status_code}",
             )


### PR DESCRIPTION
## tl;dr

- **Both branches are now live-verified from a region CloudFront serves** — the earlier revision of this PR could not exercise them at all.
- `yaga.co.za` answers a CloudFront country block, which surfaced as an unexplained 403; it is now named.
- The verdict logic needed no change: it already gates on the Next.js shop object rather than a bare 200.

## The block

```
Unexpected response status: 403   ->   "configured to block access from your country"
```

That is a network wall, not a verdict, and is now reported as one.

## Verified from a serving region

```
chantell-baker        -> Found
hero-thrift           -> Found
bargain-cat           -> Found
zzznotarealuser99xzq  -> Not Found
qqzzxxnothandle7788   -> Not Found
```

No soft-200 exposure: the module keys on `initialShop` inside `__NEXT_DATA__` and rejects a mismatched `activeSlug`, so the site's own pages come back clean rather than as hits.

```
about, help, search, login, terms   -> Not Found
```

Metadata was checked against the live shop rather than assumed — every field belongs to the requested handle:

```
chantell-baker -> {'id': 102149401, 'name': 'chantell-baker',
                   'description': 'Gaming and technology',
                   'owner_first_name': 'Chantell', 'owner_last_name': 'Baker'}
```

## Why both siblings are in one PR

`yaga_ee.py` is **not defective** — re-confirmed working here. It gets the same geo-block detection purely so the pair stays identical; splitting them would leave two near-identical files diverging for no reason, and a standalone `yaga_ee` PR would have no justification beyond "match the other one". This is the only place in the split where two modules share a PR; say the word and I'll separate them.
