### PR TITLE
fix(bdsmlr): resolve blogs through the site API

### DIFF
--- a/user_scanner/user_scan/adult/bdsmlr.py
+++ b/user_scanner/user_scan/adult/bdsmlr.py
@@ -1,52 +1,72 @@
-import re
-from user_scanner.core.orchestrator import generic_validate, Result
+import json
+
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+# bdsmlr.com is a client-rendered SPA: every /blog/<name> URL serves the same
+# empty shell, so only this backend call distinguishes a real blog. It is
+# POST-only — a GET answers 404 regardless of the handle.
+API_URL = "https://api-prod.bdsmlr.com/v2/api/get-blog"
+
+EMPTY_DESCRIPTIONS = ("", "no description")
 
 
 def validate_bdsmlr(user):
-    user = user.replace(".", "")
-    url = f"https://{user}.bdsmlr.com"
-    show_url = f"https://{user}.bdsmlr.com"
+    show_url = f"https://bdsmlr.com/blog/{user}"
 
     def process(response):
-        if response.status_code == 200 and "login" in response.text:
-            extra = {}
-            media = {}
+        try:
+            data = response.json()
+        except ValueError:
+            return Result.error(f"Unexpected response body (HTTP {response.status_code})", url=show_url)
 
-            # Extract blog title
-            title_match = re.search(
-                r"<title>(.*?)</title>", response.text, re.IGNORECASE)
-            if title_match:
-                title_val = title_match.group(1).strip()
-                if title_val.lower() != "no title":
-                    extra["fullname"] = title_val
-                else:
-                    extra["fullname"] = user.capitalize()
+        error = data.get("error")
 
-            # Extract avatar image (if not default)
-            image_match = re.search(
-                r'<meta\s+property="og:image"\s+content="([^"]+)"', response.text, re.IGNORECASE)
-            if image_match and "default_avatar" not in image_match.group(1):
-                media["image"] = image_match.group(1).strip()
+        blog = data.get("blog")
+        if isinstance(blog, dict) and blog.get("name"):
+            return Result.taken(extra=_extra(blog), media=_media(blog), url=show_url)
 
-            # Extract description
-            desc_match = re.search(
-                r'<meta\s+property="og:description"\s+content="([^"]+)"', response.text, re.IGNORECASE)
-            if desc_match:
-                desc_val = desc_match.group(1).strip()
-                if desc_val.lower() != "no description":
-                    extra["bio"] = desc_val
-
-            # Extract blog ID
-            blog_id_match = re.search(
-                r'/followersblogs/(\d+)', response.text, re.IGNORECASE)
-            if blog_id_match:
-                extra["blog_id"] = blog_id_match.group(1)
-
-            return Result.taken(extra=extra, media=media, url=show_url)
-
-        if "This blog doesn't exist." in response.text or response.status_code == 404:
+        if error == "blog not found":
             return Result.available(url=show_url)
 
-        return Result.error(f"Unexpected response code/body: {response.status_code}", url=show_url)
+        # "blog gone" is a deleted blog: the name is neither free nor backed by
+        # a profile, so it must not become a verdict.
+        return Result.error(error or f"Unexpected response body (HTTP {response.status_code})", url=show_url)
 
-    return generic_validate(url, process, show_url=show_url)
+    return generic_validate(
+        API_URL,
+        process,
+        show_url=show_url,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        content=json.dumps({"blog_name": user}),
+    )
+
+
+def _extra(blog: dict) -> dict:
+    # A renamed blog still resolves under its old handle, so the canonical name
+    # is reported to make that visible rather than silently labelling the
+    # requested handle with another blog's metadata.
+    extra = {
+        "username": blog.get("name"),
+        "blog_id": blog.get("id"),
+        "owner_user_id": blog.get("ownerUserId"),
+        "fullname": blog.get("title"),
+        "posts": blog.get("postsCount"),
+        "followers": blog.get("followersCount"),
+    }
+
+    description = blog.get("description") or ""
+    if description.strip().lower() not in EMPTY_DESCRIPTIONS:
+        extra["bio"] = description
+
+    labels = (blog.get("personals") or {}).get("labels")
+    if labels:
+        extra["personals"] = ", ".join(sorted(labels))
+
+    return extra
+
+
+def _media(blog: dict) -> dict:
+    # Both URLs are signed and expire; they are reported as-is.
+    return {"avatar": blog.get("avatarUrl") or "", "cover": blog.get("coverUrl") or ""}


### PR DESCRIPTION
bdsmlr.com is now a client-rendered SPA, and no HTML marker can separate the cases:

```
{user}.bdsmlr.com   -> redirects for every handle
/blog/<anything>    -> byte-identical 2.3 KB shell for real, fake and deleted blogs
```

Resolved through the SPA's own unauthenticated `get-blog` endpoint instead, which returns a verdict plus full metadata in one request.

Three details behind that:

- **A deleted blog answers 410 "blog gone"** — neither free nor backed by a profile — so it returns an error rather than a verdict.
- **The canonical blog name is reported**, since a renamed blog still resolves under its old handle.
- **The `.` stripping is dropped**; it silently rewrote the requested handle into a different one.


---

Split out of #523; the file here is byte-identical to what was tested there, and `ruff`/`mypy` pass on this branch.
