### PR TITLE
fix(stackoverflow): verify the fragment before returning a verdict

### DIFF
--- a/user_scanner/user_scan/community/stackoverflow.py
+++ b/user_scanner/user_scan/community/stackoverflow.py
@@ -1,16 +1,21 @@
 import re
-from user_scanner.core.orchestrator import generic_validate
+from html import unescape
+from urllib.parse import quote
+
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
 
 
 def validate_stackoverflow(user: str) -> Result:
-    url = f"https://stackoverflow.com/users/filter?search={user}"
+    url = f"https://stackoverflow.com/users/filter?search={quote(user)}"
     show_url = url
 
     def process(response):
-        if response.status_code == 200:
-            text = response.text
+        text = response.text
 
+        # The endpoint answers with an HTML fragment; without this anchor the
+        # body is a challenge or error page and carries no verdict.
+        if response.status_code == 200 and 'id="user-browser"' in text:
             if "No users matched your search." in text:
                 return Result.available()
 
@@ -35,20 +40,20 @@ def validate_stackoverflow(user: str) -> Result:
                     img_match = re.search(r'<img src="([^"]+)"', found_card)
 
                     if loc_match and loc_match.group(1).strip():
-                        extra["location"] = loc_match.group(1).strip()
+                        extra["location"] = unescape(loc_match.group(1).strip())
                     if rep_match:
-                        extra["reputation"] = rep_match.group(1).strip()
+                        extra["reputation"] = unescape(rep_match.group(1).strip())
                     if img_match:
-                        avatar_url = img_match.group(1).strip()
+                        avatar_url = unescape(img_match.group(1).strip())
                         if avatar_url.startswith("//"):
                             avatar_url = "https:" + avatar_url
-                        media["avatar"] = avatar_url.replace("&amp;", "&")
+                        media["avatar"] = avatar_url
                 except Exception:
                     pass
                 return Result.taken(extra=extra, media=media)
 
             return Result.available()
 
-        return Result.error("Unexpected status code from Stack Overflow")
+        return Result.error(f"Unexpected response body (HTTP {response.status_code})")
 
-    return generic_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, show_url=show_url)


### PR DESCRIPTION
Cloudflare answers httpx with a 403, so no handle reached a verdict. Routed through the impersonating transport.

The endpoint returns an HTML fragment, and the module now requires its user-browser anchor before deciding. That matters specifically because **Stack Overflow sheds requests under load** — a challenge or rate-limit page must stay an error rather than becoming a verdict.

Also: the search term is encoded, HTML entities in extracted values are unescaped, and the avatar moves to `media`.


---

Split out of #523; the file here is byte-identical to what was tested there, and `ruff`/`mypy` pass on this branch.
