### PR TITLE
fix(riot-id): require a boolean verdict from the lookup API

### DIFF
--- a/user_scanner/user_scan/gaming/riot_id.py
+++ b/user_scanner/user_scan/gaming/riot_id.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
@@ -17,15 +19,20 @@ def validate_riot_id(user: str) -> Result:
     if not (3 <= len(tag) <= 5):
         return Result.error("Tag must be 3-5 characters")
 
-    encoded = user.replace("#", "%23")
-    url = f"https://www.riotid-lookup.com/api/lookup?riotId={encoded}"
+    url = f"https://www.riotid-lookup.com/api/lookup?riotId={quote(user, safe='')}"
 
     def process(response):
         if response.status_code == 200:
-            data = response.json()
-            if data.get("isTaken"):
-                return Result.taken()
-            return Result.available()
+            try:
+                data = response.json()
+            except ValueError:
+                return Result.error("Unexpected response body from the lookup API")
+
+            taken = data.get("isTaken") if isinstance(data, dict) else None
+            if not isinstance(taken, bool):
+                return Result.error("Lookup API did not report a verdict")
+
+            return Result.taken() if taken else Result.available()
 
         if response.status_code == 400:
             return Result.error("Invalid Riot ID format")


### PR DESCRIPTION
Any 200 response without a truthy `isTaken` was read as available, so a shape change or an error object from the third-party lookup API would report **every** Riot ID as free. A boolean `isTaken` is now required, and anything else returns an error.

Also encodes the whole ID rather than escaping `#` by hand, so an `&` in the name can no longer split the query string.


---

Split out of #523; the file here is byte-identical to what was tested there, and `ruff`/`mypy` pass on this branch.
