### PR TITLE
fix(bdsmsingles): stop reporting every handle as free

### DIFF
--- a/user_scanner/user_scan/adult/bdsmsingles.py
+++ b/user_scanner/user_scan/adult/bdsmsingles.py
@@ -4,7 +4,7 @@ from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_bdsmsingles(user):
     url = f"https://www.bdsmsingles.com/members/{user}/"
-    show_url = f"https://www.bdsmsingles.com/members/{user}/"
+    show_url = url
 
     def process(response):
         if response.status_code == 200 and "<title>Profile" in response.text:
@@ -62,9 +62,10 @@ def validate_bdsmsingles(user):
 
             return Result.taken(extra=extra, media=media, url=show_url)
 
-        if response.status_code == 302 or "BDSM Singles" in response.text:
-            return Result.available(url=show_url)
-
+        # No confirmed not-found marker exists: /members/ sits behind an active
+        # JS challenge, and the site name matches its own home page, its login
+        # redirect and the challenge page alike — keying a miss on any of them
+        # reports every handle as free.
         return Result.error("Unexpected response body, report it via GitHub issues.", url=show_url)
 
     return generic_validate(url, process, show_url=show_url)


### PR DESCRIPTION
The not-found branch fired on a 302 **or** on the string `BDSM Singles` — which is the site's own home page title. A login redirect, an interstitial or a challenge page therefore marked the handle available:

```python
if resp.status_code == 302 or "BDSM Singles" in resp.text:
    return Result.available(url=url)   # fires for the home page too
```

That branch is removed. Without a confirmed miss marker the module returns an error instead of guessing.

## Why no replacement marker

`/members/` sits behind an active JS challenge, so no confirmed marker can be established with an HTTP client. Reporting an error is the correct outcome here rather than a placeholder verdict — this PR trades a false "available" for an honest error, and does not restore a working check.


---

Split out of #523; the file here is byte-identical to what was tested there, and `ruff`/`mypy` pass on this branch.
