### PR TITLE
fix(annaabi): name the Cloudflare challenge instead of emitting a bare 403

### DIFF
--- a/user_scanner/core/impersonate.py
+++ b/user_scanner/core/impersonate.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import Callable, Literal, Optional
 
@@ -55,6 +56,27 @@ def impersonate_request(
     kwargs.setdefault("timeout", _timeout())
     kwargs.setdefault("allow_redirects", False)
     return session.request(method, url, **kwargs)
+
+
+async def impersonate_request_async(
+    url: str,
+    method: Literal["GET", "POST"] = "GET",
+    warmup_url: Optional[str] = None,
+    impersonate: str = DEFAULT_IMPERSONATE,
+    **kwargs,
+) -> cffi.Response:
+    """``impersonate_request`` for the async email modules. curl_cffi's session
+    API is blocking, so it runs in a worker thread; the session cache is shared
+    with the synchronous username modules, so cookies carry over either way.
+    """
+    return await asyncio.to_thread(
+        impersonate_request,
+        url,
+        method,
+        warmup_url=warmup_url,
+        impersonate=impersonate,
+        **kwargs,
+    )
 
 
 def _get_warm_session(

--- a/user_scanner/email_scan/learning/annaabi.py
+++ b/user_scanner/email_scan/learning/annaabi.py
@@ -1,5 +1,4 @@
-import httpx
-
+from user_scanner.core.impersonate import impersonate_request_async
 from user_scanner.core.result import Result
 
 
@@ -7,16 +6,19 @@ async def validate_annaabi(email: str) -> Result:
     show_url = "https://annaabi.ee"
 
     try:
-        async with httpx.AsyncClient(
-            headers={
-                "User-Agent": "Mozilla/5.0",
-                "Referer": f"{show_url}/register.php",
-            },
-            timeout=15.0,
-        ) as client:
-            response = await client.get(
-                f"{show_url}/register.php",
-                params={"go": "1", "emailcheck": email},
+        response = await impersonate_request_async(
+            f"{show_url}/register.php",
+            params={"go": "1", "emailcheck": email},
+            headers={"Referer": f"{show_url}/register.php"},
+            allow_redirects=True,
+        )
+
+        # Cloudflare serves a managed challenge to some clients; no HTTP client
+        # can clear it, so never turn it into a verdict.
+        if response.headers.get("cf-mitigated") == "challenge":
+            return Result.error(
+                "Cloudflare challenge, cannot be solved without a browser",
+                url=show_url,
             )
 
         if response.status_code != 200:
@@ -40,5 +42,5 @@ async def validate_annaabi(email: str) -> Result:
                 else Result.available(url=show_url)
             )
         return Result.error("Unexpected response body", url=show_url)
-    except httpx.HTTPError as exc:
+    except Exception as exc:
         return Result.error(exc, url=show_url)


### PR DESCRIPTION
The module reported a bare `Unexpected response status: 403` for every address, which reads like a module bug. It is a Cloudflare managed challenge — `cf-mitigated: challenge` on every request, confirmed from two different countries and across httpx, curl_cffi and urllib.

Two changes: the module moves to the impersonating transport, which may be all it needs where the site is reachable, and the challenge is named when it is not.

## The verdict logic is verified, not assumed

The challenge was cleared by hand in a real browser and both markers still match exactly:

```
test@gmail.com              -> "Sellise emailiga kasutaja on juba registreerinud"   taken
admin@annaabi.ee            -> "See email on vaba"                                  free
info@annaabi.ee             -> "See email on vaba"                                  free
xkqpzrmvn4471zzq@gmail.com  -> "See email on vaba"                                  free
```

So this is a network wall rather than rotted parsing, and the module should work unchanged wherever the site talks to an HTTP client.

## Not verified

It has not run end-to-end from here — the challenge is served to every HTTP client regardless of region, so from my locations it returns the named error rather than a verdict. What is verified is the verdict logic, against real server responses captured once the challenge was cleared.

This mirrors #547, which does the same for the `user_scan` twin.

---

**Depends on #528**, whose commit is included here until it merges — review only the module file.
