### PR TITLE
fix(pypi): stop reporting a package's publisher as the account holder

### DIFF
--- a/user_scanner/user_scan/dev/pypi.py
+++ b/user_scanner/user_scan/dev/pypi.py
@@ -1,20 +1,30 @@
 import re
 import xmlrpc.client
+from email.utils import getaddresses
 from typing import Any
+
 import httpx
 
 from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import Result, make_request
+
+# Packages listed on the result, and the ones sampled for release metadata.
+PACKAGE_SAMPLE = 5
+
+# Release metadata names whoever published a package — a co-maintainer, a
+# company, a mailing list — not necessarily the account it hangs off. The keys
+# below keep that provenance, so nothing downstream reads an address here as
+# the account holder's own mailbox or a name here as the account holder's name.
+CONTACT_ROLES = ("author", "maintainer")
 
 
 def validate_pypi(user: str) -> Result:
     """
     Validates a PyPI username and extracts:
 
-    - display_name
-    - email
     - packages_count
     - packages
+    - author / author_email / maintainer / maintainer_email of those packages
     """
 
     if not re.match(r"^(?!_+$)[A-Za-z0-9._-]+$", user):
@@ -25,13 +35,6 @@ def validate_pypi(user: str) -> Result:
     profile_url = f"https://pypi.org/user/{user}"
     xmlrpc_url = "https://pypi.org/pypi"
     user_agent = get_random_user_agent()
-
-    extra: dict[str, Any] = {
-        "display_name": None,
-        "email": None,
-        "packages_count": 0,
-        "packages": [],
-    }
 
     #
     # XML-RPC lookup
@@ -78,71 +81,70 @@ def validate_pypi(user: str) -> Result:
         return Result.available(url=profile_url)
 
     package_names = sorted({package_name for _, package_name in packages})
+    sample = package_names[:PACKAGE_SAMPLE]
 
-    extra["packages_count"] = len(package_names)
-    if len(package_names) > 5:
-        extra["packages"] = package_names[:5]
-    else:
-        extra["packages"] = package_names
-
-    #
-    # Query package JSON API to extract author name & email as fallback
-    #
-    if package_names:
-        name_candidate = None
-        email_candidate = None
-        for pkg in package_names:
-            if name_candidate and email_candidate:
-                break
-            try:
-                pkg_url = f"https://pypi.org/pypi/{pkg}/json"
-                res = make_request(
-                    pkg_url,
-                    headers={"User-Agent": user_agent},
-                    http2=True,
-                )
-                if res.status_code == 200:
-                    info = res.json().get("info", {})
-                    author = info.get("author")
-                    author_email = info.get("author_email")
-                    maintainer = info.get("maintainer")
-                    maintainer_email = info.get("maintainer_email")
-
-                    for email_field in (author_email, maintainer_email):
-                        if email_field and "@" in email_field:
-                            if "<" in email_field and ">" in email_field:
-                                parts = email_field.split("<")
-                                name_part = parts[0].strip()
-                                email_part = parts[1].replace(">", "").strip()
-                                if not name_candidate and name_part:
-                                    name_candidate = name_part
-                                if not email_candidate and email_part:
-                                    email_candidate = email_part
-                            elif not email_candidate:
-                                email_candidate = email_field.strip()
-
-                    # Fallbacks for names
-                    if (
-                        author
-                        and author.strip().lower() != "none"
-                        and not name_candidate
-                    ):
-                        name_candidate = author.strip()
-                    if (
-                        maintainer
-                        and maintainer.strip().lower() != "none"
-                        and not name_candidate
-                    ):
-                        name_candidate = maintainer.strip()
-            except Exception:
-                pass
-
-        if name_candidate:
-            extra["display_name"] = name_candidate
-        if email_candidate:
-            extra["email"] = email_candidate
+    extra: dict[str, Any] = {
+        "packages_count": len(package_names),
+        "packages": sample,
+    }
+    extra.update(_release_metadata(sample, user_agent))
 
     return Result.taken(
         url=profile_url,
         extra=extra,
     )
+
+
+def _release_metadata(packages: list[str], user_agent: str) -> dict[str, str]:
+    """Every distinct name and address the sampled packages credit.
+
+    All of them, rather than the first one an alphabetical walk reaches: which
+    co-publisher that lands on is an accident of package naming, and several
+    names on one account is the thing worth seeing.
+    """
+    found: dict[str, list[str]] = {}
+
+    for package in packages:
+        info = _package_info(package, user_agent)
+        for role in CONTACT_ROLES:
+            _add(found, role, info.get(role))
+            for name, address in _contacts(info.get(f"{role}_email")):
+                _add(found, role, name)
+                if "@" in address:
+                    _add(found, f"{role}_email", address)
+
+    return {key: ", ".join(values) for key, values in found.items()}
+
+
+def _package_info(package: str, user_agent: str) -> dict[str, Any]:
+    try:
+        response = make_request(
+            f"https://pypi.org/pypi/{package}/json",
+            headers={"User-Agent": user_agent},
+            http2=True,
+        )
+        if response.status_code != 200:
+            return {}
+        return response.json().get("info") or {}
+    except Exception:
+        return {}
+
+
+def _contacts(value: object) -> list[tuple[str, str]]:
+    """The ``Name <addr>`` pairs in a core metadata contact field, which may
+    credit several people in one comma-separated string."""
+    return [
+        (name.strip(), address.strip())
+        for name, address in getaddresses([str(value or "")])
+    ]
+
+
+def _add(found: dict[str, list[str]], key: str, value: object) -> None:
+    """Record a value under ``key``, unless it is empty, a duplicate, or the
+    literal ``None`` some releases ship where the field was left unset."""
+    text = str(value or "").strip()
+    if not text or text.lower() == "none":
+        return
+    values = found.setdefault(key, [])
+    if text not in values:
+        values.append(text)


### PR DESCRIPTION
## tl;dr

- **PyPI reported a package's publisher as the account holder.** `author_email` was emitted as `email` and `author` as `display_name`, so scanning `hugovk` published a defunct company's address and name as that account's own.
- **It now credits every publisher its packages name, under keys that say where they came from** — `author`, `author_email`, `maintainer`, `maintainer_email`.

## Package metadata is not the account holder's

Before. Both values come from `PIL` — first package alphabetically, published by
Secret Labs AB in the 1990s — and the account owner appears nowhere:

```
  [✔] Pypi (hugovk): Found
      ├── display_name: Secret Labs AB (PythonWare)
      ├── email: info@pythonware.com
      ├── packages_count: 24
      └── packages: ['PIL', 'blurb', 'em-keyboard', 'fino', 'flake8-implicit-str-concat']
```

After:

```
  [✔] Pypi (hugovk): Found
      ├── packages_count: 24
      ├── packages: ['PIL', 'blurb', 'em-keyboard', 'fino', 'flake8-implicit-str-concat']
      ├── author: Secret Labs AB (PythonWare), Larry Hastings, Kenneth Reitz, Hugo van Kemenade, Dylan Turner
      ├── author_email: info@pythonware.com, larry@…, me@…, 58230987+…@users.noreply.github.com
      ├── maintainer: Python Core Developers, Hugo van Kemenade
      └── maintainer_email: core-workflow@mail.python.org
```

Three changes produce that:

| Change | Effect |
| --- | --- |
| `email` → `author_email` / `maintainer_email`, `display_name` → `author` / `maintainer` | The key names its source, so no consumer reads it as the account's own address or name |
| Every sampled package is read, not just up to the first hit | Five publishers surface instead of whichever one sorts first; the account owner is now among them |
| Contacts parsed with `email.utils.getaddresses` | `"A <a@x>, B <b@y>"` and `"Thomas Kluyver & contributors <thomas@…>"` no longer mangle |

Cost: `min(5, packages)` requests every time, where a lucky first package used to
cost 1. That is the ceiling the old loop already hit whenever it found nothing.

## Keys changed

| Removed | Added |
| --- | --- |
| `email`, `display_name` | `author`, `author_email`, `maintainer`, `maintainer_email` |

Neither removed key has another reader in the repo — the `display_name` hits in
`core/orchestrator.py` and `core/email_orchestrator.py` are a local variable
holding a category label. Consumers of the exported JSON/CSV/PDF that key off
the old names need updating.

## Testing

| Handle | Case | Result |
| --- | --- | --- |
| `hugovk` | packages with several publishers | Found; 4 addresses, 5 authors, 2 maintainers |
| `<pypi-user-c>` | package with an `author`, no email | Found; `author` only |
| `<pypi-user-b>` | package with no author, no email | Found; `packages_count` + `packages` only |
| `zzznotarealuser99xzq` | nonexistent | Not Found |

Not covered: `_package_info`'s request-failure path, a package crediting two
distinct `maintainer_email`s, and the PDF exporter — the key rename was checked
by `grep`, not by rendering every format.
