### PR TITLE
fix(reddit): stop naming a boolean flag after an email field

### DIFF
--- a/user_scanner/user_scan/social/reddit.py
+++ b/user_scanner/user_scan/social/reddit.py
@@ -35,7 +35,9 @@ BOOLEAN_FLAGS = {
     "is_employee": "employee",
     "is_mod": "moderator",
     "is_gold": "premium",
-    "has_verified_email": "verified_email",
+    # Keeps Reddit's own name: the value is a flag, and `verified_email` reads
+    # as a key holding the verified address.
+    "has_verified_email": "has_verified_email",
 }
 KARMA_FIELDS = {
     "total_karma": "karma_total",


### PR DESCRIPTION
## tl;dr

- **Reddit emitted a boolean under a key that names an address field.** The API's `has_verified_email` was reported as `verified_email`, so the export read as though Reddit had published the account's address when the value is only ever `True`.
- **The key now matches the API field.** No other behaviour changes.

## The key claims a mailbox the module never has

`about.json` exposes `has_verified_email`, a flag saying the account confirmed
*some* address. Reddit never discloses which one. `verified_email` names the
address itself, so any consumer keying on it reads a mailbox out of `True`.

```python
 BOOLEAN_FLAGS = {
     "is_employee": "employee",
     "is_mod": "moderator",
     "is_gold": "premium",
-    "has_verified_email": "verified_email",
+    "has_verified_email": "has_verified_email",
 }
```

| | Before | After |
| --- | --- | --- |
| `spez` | `verified_email: true` | `has_verified_email: true` |
| `<redditor-b>` (no verified email) | key absent | key absent |

The flag is only emitted when true, so an account without a verified email is
unaffected. `verified_email` has no other reader in the repo; consumers of the
exported JSON/CSV/PDF that key off the old name need updating.

## Testing

| Handle | Case | Result |
| --- | --- | --- |
| `spez` | verified email | Found; `has_verified_email: true` |
| `<redditor-b>` | no verified email | Found; key absent |
| `zzznotarealuser99xzq` | nonexistent | Not Found |

Not covered: suspended and deleted accounts, which return before the flag block
is reached, so the renamed key cannot appear on them; and the PDF exporter — the
rename was checked by `grep`, not by rendering every format.
