### PR TITLE
fix(gitlab): publish the account's public email

### DIFF
--- a/user_scanner/user_scan/dev/gitlab.py
+++ b/user_scanner/user_scan/dev/gitlab.py
@@ -32,6 +32,8 @@ def validate_gitlab(user):
                             extra["username"] = u_data.get("username").strip()
                         if u_data.get("state"):
                             extra["state"] = u_data.get("state")
+                        if public_email := u_data.get("public_email"):
+                            extra["email"] = public_email
 
                         avatar_url = u_data.get("avatar_url")
                         if avatar_url:


### PR DESCRIPTION
GitLab's public user API returns `public_email` for accounts that choose to publish an address, but `validate_gitlab` never read it. It is now emitted as `extra["email"]`.

This is worth the two lines because an address is the highest-value field a username module can produce: it is the only output that feeds the email side of the suite. Sweeping every `user_scan` module against two handles, exactly one produced a real address — Gravatar. This makes two.

```python
if public_email := u_data.get("public_email"):
    extra["email"] = public_email
```

The response is already parsed by the module, so there is no extra request and no new dependency.

## Most accounts leave it empty, so the guard matters

`public_email` is opt-in and defaults to `""`. The truthy guard keeps the key absent rather than emitting an empty string:

```
<account with an address published>  ->  Found      email: b•••••@gmail.com
stanhu                               ->  Found      no email key   (public_email: "")
dzaporozhets                         ->  Found      no email key
sytses                               ->  Found      no email key
ayufan                               ->  Found      no email key
zzznotarealuser99xzq                 ->  Not Found  unchanged
```

The address above is redacted; it belongs to the maintainer's own account, which is the only one I found with the field populated. Four GitLab staff accounts are shown as the empty-case control, and ten further accounts were sampled without finding another published address — so the populated path is real but uncommon.

## Not verified

Only `gitlab.com` was tested. Self-managed GitLab instances are not covered by this module at all, so the field's behaviour there is untested and unchanged.
