### PR TITLE
feat(devto): extract the linked github and twitter handles

### DIFF
--- a/user_scanner/user_scan/creator/devto.py
+++ b/user_scanner/user_scan/creator/devto.py
@@ -20,7 +20,11 @@ def validate_devto(user):
                 extra["joined_at"] = joined_at
             if website := data.get("website_url"):
                 extra["website"] = website
-                
+            if github := data.get("github_username"):
+                extra["github"] = github
+            if twitter := data.get("twitter_username"):
+                extra["twitter"] = twitter
+
             return Result.taken(extra=extra, url=show_url)
         elif response.status_code == 404:
             return Result.available(url=show_url)


### PR DESCRIPTION
dev.to's public API returns the account's GitHub and Twitter handles as first-class fields, but `validate_devto` read neither. Both are now emitted.

```python
if github := data.get("github_username"):
    extra["github"] = github
if twitter := data.get("twitter_username"):
    extra["twitter"] = twitter
```

These are worth having because each names an account on a *different* platform, which is what makes a username hit useful beyond "this handle exists here". The response is already parsed by the module, so there is no extra request.

## Unset fields are `null`, so the guard matters

Both fields are optional and the API sends JSON `null` when unset. The truthy guard keeps the key absent rather than leaking a `None` into `extra` and the exports:

```
ben               ->  Found      github: benhalpern   twitter: bendhalpern
thepracticaldev   ->  Found      github: (absent)     twitter: ThePracticalDev
nazar-boyko       ->  Found      github: (absent)     twitter: (absent)
zzznotarealuser99xzq -> Not Found  unchanged
```

Each emitted value was cross-checked against the raw API response. `thepracticaldev` is the one-sided case — it has a Twitter handle but no GitHub one — and `nazar-boyko` is a real account with neither, found by sampling article authors rather than by inventing a synthetic case.

## Handles are stored bare, not as URLs

The values are emitted exactly as the API gives them (`benhalpern`, not `https://github.com/benhalpern`). This matches how `kick.py` and `px500.py` already store theirs, and avoids guessing a URL shape per platform.

## These are deliberately not marked as verified links

dev.to accounts are created by signing in with GitHub or Twitter, so it is tempting to treat these as platform-verified. The API exposes no flag distinguishing an OAuth-sourced handle from one edited into the profile afterwards, and the fields are user-editable — so labelling them verified would assert more than the response supports.

## Not verified

Only `dev.to` itself was tested. Forem instances running the same software elsewhere are not covered by this module.
