### PR TITLE
feat(ifttt): extract the profile instead of discarding the response

### DIFF
--- a/user_scanner/user_scan/social/ifttt.py
+++ b/user_scanner/user_scan/social/ifttt.py
@@ -1,6 +1,26 @@
+import html
+import re
+
 from user_scanner.core.orchestrator import generic_validate, Result
 
-def validate_ifttt(user):
+# The profile header block, from the avatar to the close of its section. Only
+# this span belongs to the user: the page footer carries IFTTT's own corporate
+# accounts (twitter.com/IFTTT, facebook.com/ifttt, instagram.com/iftttapp),
+# which a document-wide sweep would report as the user's.
+_BLOCK_START = '<div class="platform-avatar-container">'
+_BLOCK_END = "</section>"
+
+_AVATAR_RE = re.compile(r'<img[^>]*class="maker-avatar"[^>]*src="([^"]+)"')
+_PARAGRAPH_RE = re.compile(r"<p>(.*?)</p>", re.S)
+_ANCHOR_RE = re.compile(r"<a\b[^>]*>.*?</a>", re.S)
+_LINK_RE = re.compile(r'<a\b[^>]*href="(https?://[^"]+)"', re.I)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_OWN_HOSTS = ("ifttt.com", "ift.tt")
+
+
+def validate_ifttt(user: str) -> Result:
     if "." in user:
         return Result.available("Username cannot contain periods")
 
@@ -10,9 +30,60 @@ def validate_ifttt(user):
         if response.status_code == 404:
             return Result.available()
         elif response.status_code == 200:
-            return Result.taken()
+            extra, media = _parse_profile(response.text)
+            return Result.taken(extra=extra, media=media)
 
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"User-Agent": "Mozilla/5.0"}
     return generic_validate(url, process, show_url=url, headers=headers)
+
+
+def _parse_profile(page: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Read the profile fields out of the header block.
+
+    A connected account is one IFTTT signed the user in through, so the far side
+    proved ownership. Facebook's is an app-scoped id that resolves to no public
+    profile; other providers hand back a real handle.
+    """
+    start = page.find(_BLOCK_START)
+    if start < 0:
+        return {}, {}
+
+    end = page.find(_BLOCK_END, start)
+    if end < 0:
+        return {}, {}
+
+    block = page[start:end]
+
+    bio = ""
+    joined = ""
+    for paragraph in _PARAGRAPH_RE.findall(block):
+        text = _text_of(_ANCHOR_RE.sub(" ", paragraph))
+        if not joined and text.startswith("Joined "):
+            joined = text.removeprefix("Joined ")
+        elif text and not bio:
+            bio = text
+
+    links = [link for link in _LINK_RE.findall(block) if not _is_own_link(link)]
+    extra = {"joined": joined, "bio": bio, "connected_accounts": ", ".join(links)}
+
+    media = {}
+    avatar = _AVATAR_RE.search(block)
+    if avatar:
+        media["avatar"] = _absolute(avatar.group(1))
+
+    return extra, media
+
+
+def _text_of(markup: str) -> str:
+    return _WHITESPACE_RE.sub(" ", html.unescape(_TAG_RE.sub(" ", markup))).strip()
+
+
+def _is_own_link(link: str) -> bool:
+    host = link.split("/")[2].lower().removeprefix("www.")
+    return host in _OWN_HOSTS
+
+
+def _absolute(src: str) -> str:
+    return f"https:{src}" if src.startswith("//") else src


### PR DESCRIPTION
`validate_ifttt` downloaded the full profile page and then threw it away:

```python
elif response.status_code == 200:
    return Result.taken()          # body discarded
```

Every hit returned `extra: {}`. It now emits `joined`, `bio` and `connected_accounts` from the response it already had. The verdict logic is byte-identical — 404 → available, 200 → taken, anything else → error — and there is no additional request.

```
linden  ->  joined: August 2010    bio: "CEO @ IFTTT. Every thing (and everyone)…"
            connected_accounts: https://twitter.com/ltibbets
kevin   ->  joined: February 2011  connected_accounts: https://twitter.com/kvn
anna    ->  joined: June 2011      (no bio, no linked account — keys absent)
```

## `connected_accounts` is an OAuth link, so it is named as one

IFTTT obtains these through a sign-in handshake with the far side, not from a text field the owner filled in, so the key is `connected_accounts` rather than a generic link field.

The provider is not fixed. It is Twitter for the accounts above and Facebook for others, so the field is emitted generically rather than hardcoded to one platform — restricting it to Facebook would have silently dropped every Twitter link.

## The page also carries IFTTT's own corporate accounts

`twitter.com/IFTTT`, `facebook.com/ifttt`, `instagram.com/iftttapp` and `linkedin.com/company/ifttt` appear on **every** profile. A document-wide link sweep would attribute them to whoever was scanned, so extraction is bounded to the profile block.

The sharpest control for this is `linden` — he is IFTTT's CEO and his bio literally reads "CEO @ IFTTT", yet the module returns his personal `ltibbets`, not the corporate handle.

## A Facebook-linked account yields no usable target

Where the connected account is Facebook, the URL is an app-scoped user id (`facebook.com/app_scoped_user_id/<digits>`). Facebook no longer resolves those to public profiles, so such a value is a true statement about the account but can never become a scannable handle. It is still emitted, because "this account has Facebook linked" is real information — but it should not be mistaken for a cross-platform lead.

## Testing

Verified live against accounts with a Twitter link, with a Facebook link, with a bio but no link, and with neither; plus a nonexistent handle (unchanged `available`). Profiles in the "hasn't made any Applets yet" state parse correctly, as does a 162 KB profile with many applets.

## Not verified

Only English pages were seen. `joined` is parsed off the literal `Joined ` prefix, so a translated page would drop that key rather than mis-parse it. No profile with two connected accounts was found, so the multi-link join path is untested.
