### PR TITLE
feat(flickr): extract the profile's linked social accounts

### DIFF
--- a/user_scanner/user_scan/social/flickr.py
+++ b/user_scanner/user_scan/social/flickr.py
@@ -2,10 +2,15 @@ import json
 import re
 import urllib.parse
 
-from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
 from user_scanner.core.result import Result
 
 BASE_URL = "https://www.flickr.com"
+
+# Public-profile fields naming the owner's account on another platform. Flickr
+# stores the bare handle and derives the sibling `<field>Url` from it, so the
+# handle is what gets emitted.
+SOCIAL_FIELDS = ("facebook", "instagram", "pinterest", "tumblr", "twitter")
 
 
 def validate_flickr(user: str) -> Result:
@@ -28,22 +33,28 @@ def validate_flickr(user: str) -> Result:
             return Result.error("200 response with no matching photostream owner")
 
         extra, media = _extract(owner, profile, contacts)
+        if nsid := owner.get("id"):
+            extra.update(_public_profile(str(nsid)))
         return Result.taken(extra=extra, media=media)
 
     return impersonate_validate(url, process, allow_redirects=True)
 
 
-def _models(text: str) -> tuple[dict, dict, dict]:
+def _main_models(text: str) -> dict:
     match = re.search(r"modelExport:\s*(.*?),\s*auth", text)
     if not match:
-        return {}, {}, {}
+        return {}
 
     try:
         data = json.loads(urllib.parse.unquote(match.group(1)))
     except (json.JSONDecodeError, ValueError):
-        return {}, {}, {}
+        return {}
 
-    main = data.get("main") or {}
+    return data.get("main") or {}
+
+
+def _models(text: str) -> tuple[dict, dict, dict]:
+    main = _main_models(text)
 
     def first(key: str) -> dict:
         models = main.get(key) or [{}]
@@ -88,3 +99,32 @@ def _extract(owner: dict, profile: dict, contacts: dict) -> tuple[dict, dict]:
         media["avatar"] = f"https:{avatar}" if avatar.startswith("//") else avatar
 
     return extra, media
+
+
+def _public_profile(nsid: str) -> dict:
+    """The accounts the profile links elsewhere, which only the /people/ page
+    carries — the photostream omits them. Addressed by NSID so the lookup is
+    immune to the handle's casing. Best-effort: a failure just yields no extra."""
+    try:
+        response = impersonate_request(f"{BASE_URL}/people/{nsid}/", allow_redirects=True)
+        if response.status_code != 200:
+            return {}
+        profile = _public_profile_object(response.text, nsid)
+    except Exception:
+        return {}
+
+    extra = {field: profile[field] for field in SOCIAL_FIELDS if profile.get(field)}
+    if occupation := profile.get("occupation"):
+        extra["occupation"] = occupation
+    return extra
+
+
+def _public_profile_object(text: str, nsid: str) -> dict:
+    """The public-profile model belonging to the NSID asked for. The /people/
+    page embeds a person model per contact, so the object is matched on the
+    owner's id rather than taken by position."""
+    for entry in _main_models(text).get("person-public-profile-models") or []:
+        data = (entry or {}).get("data")
+        if isinstance(data, dict) and str(data.get("id") or "") == nsid:
+            return data
+    return {}


### PR DESCRIPTION
A Flickr profile carries dedicated fields for five other platforms — `facebook`, `instagram`, `twitter`, `tumblr`, `pinterest` — plus `occupation`. `validate_flickr` extracted none of them.

```
thomashawk    ->  facebook: thomashawk   instagram: thomashawk   twitter: thomashawk
                  tumblr: thomashawk     pinterest: thomashawk
kennethreitz  ->  occupation: Software Engineer   (only populated field)
```

Each value names an account on a *different* site, which is what turns a hit from "this handle exists here" into a lead.

## This needs a second request, contrary to what it looks like

The module fetches `/photos/{user}`. The social fields are not on that page at all — they live only in the `person-public-profile-models` block served by `/people/{nsid}/`. A page-wide search of `/photos/thomashawk` for `facebook` / `instagram` / `tumblr` returns only Flickr's own SDK config.

So the enrichment is a second, best-effort request made **only after** the account is already confirmed found, in the same shape as `stripchat._api_profile` and `camsoda._broadcaster_profile`. The verdict path is unchanged: a blocked or restructured `/people/` page costs metadata, never a verdict, and a miss never triggers the extra request.

## Extraction is anchored to the owner, because the page embeds 34 other people

`/people/51035555243@N01/` carries **35 person models** — the owner plus 34 contacts, with 25 distinct `realname` and 25 distinct `pathAlias` values belonging to other users. Taking the first match, or sweeping the document, would attribute a stranger's Instagram to the scanned account.

The lookup matches on the owner's NSID, taken from the already-verified photostream owner:

```python
for entry in _main_models(text).get("person-public-profile-models") or []:
    data = (entry or {}).get("data")
    if isinstance(data, dict) and str(data.get("id") or "") == nsid:
        return data
```

Running the same lookup with each of the 34 contact NSIDs returns `{}` in every case, and each emitted handle agrees with its `*Url` sibling in the matched object. Addressing the request by NSID also makes the whole thing casing-proof — `ThomasHawk` and `thomashawk` return identical output.

## Handles are stored bare, not as URLs

Flickr stores `"thomashawk"`, not `https://twitter.com/thomashawk`, and the values pass through unchanged rather than being expanded into a guessed URL shape per platform.

## Testing

Verified live against a profile with all five fields set, one with only `occupation`, one with none (keys absent, not empty strings), both casings of the same handle, the NSID form, and a nonexistent handle (unchanged `available`).

## Not verified

No profile was found whose social fields contain a full URL rather than a bare handle. If such an account exists the value passes through as-is, but there is no live example to confirm the shape.
