### PR TITLE
fix(monkeytype): stop reporting real accounts as errors, and extract the profile

### DIFF
--- a/user_scanner/user_scan/gaming/monkeytype.py
+++ b/user_scanner/user_scan/gaming/monkeytype.py
@@ -1,13 +1,16 @@
+from datetime import datetime, timezone
 from urllib.parse import quote
 
 from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import generic_validate
 from user_scanner.core.result import Result
 
+API = "https://api.monkeytype.com"
+
 
 def validate_monkeytype(user: str) -> Result:
     safe_user = quote(user, safe="")
-    url = f"https://api.monkeytype.com/users/checkName/{safe_user}"
+    url = f"{API}/users/checkName/{safe_user}"
     show_url = f"https://monkeytype.com/profile/{safe_user}"
 
     headers = {
@@ -18,27 +21,110 @@ def validate_monkeytype(user: str) -> Result:
     }
 
     def process(response):
-        if response.status_code == 200:
+        data = {}
+        try:
             data = response.json()
+        except Exception:
+            pass
+
+        if response.status_code == 200:
             # Expected shape:
             # { "message": "string", "data": { "available": true/false } }
-            payload = data.get("data", {})
-            available = payload.get("available")
+            available = data.get("data", {}).get("available")
 
             if available is True:
                 return Result.available()
             elif available is False:
-                return Result.taken()
+                profile = _fetch_profile(safe_user, show_url, headers)
+                return profile if profile.is_found() else Result.taken()
 
         # Surface Monkeytype validation errors (e.g. special characters)
-        try:
-            data = response.json()
-            errors = data.get("validationErrors")
-            if errors:
-                return Result.error("; ".join(errors))
-        except Exception:
-            pass
+        errors = data.get("validationErrors")
+        if errors:
+            # The name filter also rejects names that predate it, so a rejected
+            # name can still belong to an account the profile endpoint serves.
+            profile = _fetch_profile(safe_user, show_url, headers)
+            return profile if profile.is_found() else Result.error("; ".join(errors))
 
         return Result.error("Invalid status code")
 
     return generic_validate(url, process, show_url=show_url, headers=headers)
+
+
+def _fetch_profile(safe_user: str, show_url: str, headers: dict) -> Result:
+    """Public profile metadata as a taken Result, or an error Result when the
+    name serves no profile. Resolves names case-insensitively."""
+    url = f"{API}/users/{safe_user}/profile?isUid=false"
+
+    def process(response):
+        if response.status_code != 200:
+            return Result.error(f"Unexpected status code: {response.status_code}")
+
+        data = response.json().get("data", {})
+        name = data.get("name")
+        if not name:
+            return Result.error("Profile response carried no account")
+
+        media = {}
+        # Monkeytype renders the linked Discord avatar as the profile picture.
+        discord_id, avatar = data.get("discordId"), data.get("discordAvatar")
+        if discord_id and avatar:
+            media["avatar"] = f"https://cdn.discordapp.com/avatars/{discord_id}/{avatar}.png"
+
+        return Result.taken(extra=_profile_extra(data, name), media=media)
+
+    return generic_validate(url, process, show_url=show_url, headers=headers)
+
+
+def _profile_extra(data: dict, name: str) -> dict:
+    extra = {"username": name}
+
+    if data.get("banned"): extra["banned"] = "Yes"
+    if data.get("isPremium"): extra["premium"] = "Yes"
+    if uid := data.get("uid"): extra["uid"] = uid
+    if added_at := data.get("addedAt"): extra["joined"] = _to_date(added_at)
+
+    details = data.get("details") or {}
+    if bio := details.get("bio"): extra["bio"] = bio
+    if keyboard := details.get("keyboard"): extra["keyboard"] = keyboard
+
+    socials = details.get("socialProfiles") or {}
+    for field in ("github", "twitter", "website"):
+        if handle := socials.get(field): extra[field] = handle
+
+    # Discord's numeric snowflake, which no public lookup resolves to a handle.
+    if discord_id := data.get("discordId"): extra["discord_id"] = discord_id
+
+    stats = data.get("typingStats") or {}
+    if completed := stats.get("completedTests"): extra["tests_completed"] = str(completed)
+    if seconds := stats.get("timeTyping"): extra["time_typing"] = _to_duration(seconds)
+    if best_wpm := _best_wpm(data.get("personalBests")): extra["best_wpm"] = f"{best_wpm:g}"
+    if xp := data.get("xp"): extra["xp"] = str(int(xp))
+    if streak := data.get("maxStreak"): extra["max_streak"] = f"{streak} days"
+
+    return extra
+
+
+def _to_date(epoch_ms: int) -> str:
+    return datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def _to_duration(seconds: float) -> str:
+    if seconds < 3600:
+        return f"{seconds / 60:.0f} minutes"
+    return f"{seconds / 3600:.1f} hours"
+
+
+def _best_wpm(personal_bests) -> float:
+    if not isinstance(personal_bests, dict):
+        return 0.0
+
+    scores = [
+        entry.get("wpm") or 0
+        for mode in personal_bests.values()
+        if isinstance(mode, dict)
+        for entries in mode.values()
+        for entry in entries
+        if isinstance(entry, dict)
+    ]
+    return max(scores, default=0.0)


### PR DESCRIPTION
## tl;dr

- **Real accounts were being reported as errors.** Monkeytype's `checkName` endpoint rejects names its word filter dislikes, including accounts registered before that filter existed — `Miodec`, a real account, returned `Result.error`. A rejected name now falls back to the profile endpoint and returns Found when an account actually exists.
- **This PR changes the availability path**, not just metadata extraction. That is the part worth reviewing hardest.
- **The module previously emitted nothing.** It now returns 14 fields for a populated profile, including `github` and `twitter` handles.
- **The not-found path still costs one request.** The profile fetch fires only when the name is confirmed taken, or when `checkName` rejects it.

## Real accounts were being reported as errors

```
checkName/Miodec  ->  422  "Disallowed word detected. Please remove it (Miodec)"
```

`Miodec` is a real, active account. The word filter post-dates it, so `checkName` refuses the name and the old module surfaced that as an error — a false negative on a genuine hit.

A rejected name now falls back to `GET /users/<user>/profile`. If a profile exists the verdict is Found; if not, the original validation error is surfaced exactly as before, so a genuinely invalid name still reports as invalid rather than being laundered into a verdict.

```
Miodec                ->  Found      (was: Error)
MIODEC                ->  Found      canonical casing recovered
ab                    ->  Found
brunolm7              ->  Not Found  1 request
zzznotarealuser99xzq  ->  Error      "String must contain at most 16 characters"
has space             ->  Error      "Only letters, numbers, underscores…"
fuck                  ->  Error      disallowed and no profile exists
```

The last case is the one that shows the fallback is not a rubber stamp: a genuinely disallowed name with no account behind it still errors.

## The enrichment can never downgrade a verdict

A failed or 404 profile fetch after `available: false` still returns a bare `Result.taken()`. Metadata is best-effort; the verdict is decided before it runs.

## Metadata

`github`, `twitter` and `website` come from `details.socialProfiles`; the rest are typing stats, join date, bio and keyboard. Handles are stored bare, as the API returns them, rather than expanded into guessed URLs.

`media["avatar"]` is built as `cdn.discordapp.com/avatars/{discordId}/{discordAvatar}.png` — the same URL monkeytype's own frontend constructs.

## `discord_id` is named so that it cannot be mistaken for a handle

The value is Discord's numeric snowflake. Discord exposes no public username→user lookup, and the Discord module checks usernames, so an id can never become a scannable target. The key is `discord_id` rather than `discord` precisely so it reads as an identifier and not as a linked account.

## Testing

Verified live against a populated profile, a profile with no socials set (keys absent, not empty strings), both casings of the same handle, a nonexistent handle, and three classes of invalid name.

## Not verified

- **Banned accounts.** Upstream returns 200 with `message: "Profile retrived: banned user"` and a stripped payload. The code keys Found on `data.name`, which that payload includes, and emits `banned: Yes` — but no banned handle was available to test against.
- **Premium accounts.** `isPremium` was false on every account sampled, so the `premium` field is untested.
