### PR TITLE
fix: ensure category headers print correctly with --all flag

### DIFF
--- a/user_scanner/core/email_orchestrator.py
+++ b/user_scanner/core/email_orchestrator.py
@@ -147,7 +147,7 @@ async def _run_batch(
         for coro in asyncio.as_completed(tasks):
             result = await coro
             actual_cat = result.category or "Unknown"
-            if not configs.show_all and result.is_visible(configs):
+            if configs.show_all or result.is_visible(configs):
                 if printed_cats is not None and actual_cat not in printed_cats:
                     print(
                         f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}"
@@ -264,7 +264,7 @@ async def _run_email_full_batch_async(email: str, configs: ScanConfig) -> List[R
                 
             for coro in asyncio.as_completed(tasks):
                 result = await coro
-                if not configs.show_all and result.is_visible(configs):
+                if configs.show_all or result.is_visible(configs):
                     display_name = result.category or "Unknown"
                     if display_name not in printed_cats:
                         print(

--- a/user_scanner/core/orchestrator.py
+++ b/user_scanner/core/orchestrator.py
@@ -117,7 +117,7 @@ async def _run_batch(
             
             actual_cat = result.category or "Unknown"
             # Handle specific logic where skipping needs to happen early
-            if not configs.show_all and result.is_visible(configs):
+            if configs.show_all or result.is_visible(configs):
                 if printed_cats is not None and actual_cat not in printed_cats:
                     print(f"\n{Fore.MAGENTA}== {actual_cat.upper()} SITES =={Style.RESET_ALL}")
                     printed_cats.add(actual_cat)
@@ -208,7 +208,7 @@ async def _run_user_full_async(username: str, configs: ScanConfig) -> List[Resul
             for coro in asyncio.as_completed(tasks):
                 result = await coro
                 
-                if not configs.show_all and result.is_visible(configs):
+                if configs.show_all or result.is_visible(configs):
                     display_name = result.category or "Unknown"
                     if display_name not in printed_cats:
                         print(f"\n{Fore.MAGENTA}== {display_name.upper()} SITES =={Style.RESET_ALL}")


### PR DESCRIPTION
Fixes a UI bug where passing the `--all` (`-a`) flag would completely silence the printing of `== CATEGORY ==` headers in the terminal because the check explicitly skipped printing them. Headers will now print cleanly for visible results even if `--all` is set.