### PR TITLE
fix: clean curl_cffi timeout errors and optimize apexlegends

### DIFF
--- a/user_scanner/core/result.py
+++ b/user_scanner/core/result.py
@@ -59,6 +59,9 @@ def humanize_exception(e: Exception) -> str:
     if "errno 101" in msg or "network is unreachable" in msg:
         return "Network unreachable (Is your internet on?)"
 
+    if "curl: (28)" in msg or "connection timed out" in msg:
+        return "Connection timed out (try a VPN if the site is blocked in your region)"
+
     return str(e)
 
 

--- a/user_scanner/user_scan/gaming/apexlegends.py
+++ b/user_scanner/user_scan/gaming/apexlegends.py
@@ -27,8 +27,7 @@ def validate_apexlegends(user: str) -> Result:
                 f"{API_URL}/{platform}/{user}", headers=HEADERS
             )
         except Exception as e:
-            errors.append(f"{platform}: {e}")
-            continue
+            return Result.error(e, url=show_url)
 
         if response.status_code == 404:
             continue


### PR DESCRIPTION
This PR updates the core error formatter to catch raw `curl_cffi` timeout logs and display a clean connection timeout message with VPN suggestions. It also refactors the apexlegends module to abort immediately on timeouts to prevent redundant hangs.