### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -129,6 +129,7 @@ def test_bulk_emails_skip_comments_blank_lines(tmp_path, run_main, capsys):
     assert exit_code == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod(0) does not make files unreadable on Windows")
 def test_email_file_unreadable(tmp_path, run_main):
     email_file = tmp_path / "test_emails.txt"
     email_file.write_text("user@example.com")
@@ -187,6 +188,7 @@ def test_bulk_usernames_skip_comments_blank_lines(tmp_path, run_main, capsys):
     assert exit_code == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod(0) does not make files unreadable on Windows")
 def test_username_file_unreadable(tmp_path, run_main):
     username_file = tmp_path / "test_usernames.txt"
     username_file.write_text("user")


### PR DESCRIPTION

### Summary

`tests/test_helpers.py` has two tests
(`test_email_file_unreadable`, `test_username_file_unreadable`) that use
`Path.chmod(0)` to simulate an unreadable input file and assert the CLI
exits with code 1.

On Windows, `chmod(0)` does **not** make a file unreadable (POSIX permission
bits are not enforced the same way), so the file stays readable, the CLI
exits 0, and the tests fail with `assert 0 == 1`.

The project's README explicitly claims **"Tested on Windows"** (badge +
PowerShell install instructions), but CI only runs on `ubuntu-latest`, so
this Windows failure has never surfaced.

Fix: skip the two tests on Windows (they still exercise the real
permission-denied path on POSIX, where `chmod` semantics are meaningful).

### Verification

- Before (Windows, Python 3.13): `pytest tests/` → **2 failed, 172 passed, 3 skipped**
- After: `pytest tests/` → **174 passed, 5 skipped, 0 failed**
  (the two tests now skip on win32; nothing else changed)

### Files changed

- `tests/test_helpers.py` (+2 `skipif` decorators; `sys`/`pytest` already imported)