### PR TITLE
feat(email_scan): add 14 new email OSINT modules and introduce dating category

### DIFF
--- a/user_scanner/core/helpers.py
+++ b/user_scanner/core/helpers.py
@@ -52,6 +52,9 @@ LOUD_MODULES: Dict[str, List[str]] = {
         "fantasia",
         "couplejoy",
         "asafeer",
+        "weverse",
+        "cambly",
+        "superlive",
     ],
 }
 

--- a/user_scanner/email_scan/dating/lespark.py
+++ b/user_scanner/email_scan/dating/lespark.py
@@ -1,0 +1,77 @@
+import uuid
+import secrets
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api3.lespark.cn/login"
+    show_url = "https://www.lespark.cn"
+
+    req_id = str(uuid.uuid4())
+    device_id = secrets.token_hex(8)
+    gaid = str(uuid.uuid4())
+
+    headers = {
+        "User-Agent": "okhttp-okgo/jeasonlzy",
+        "Accept-Encoding": "gzip",
+        "accept-language": "en-US,en;q=0.8",
+        "lang": "en",
+        "lang-app": "en",
+        "device-os": "13",
+        "device_model": "Pixel 6",
+        "bundle-id": "com.redwolfama.peonylespark.gp",
+        "version": "9.7.38.1",
+        "version-code": "786",
+        "pkg": "com.redwolfama.peonylespark.gp",
+        "device-id": device_id,
+        "is-ipad": "0",
+        "locale": "US",
+        "is-cn": "0",
+        "channel": "google",
+        "request-id": req_id,
+        "gaid": gaid,
+    }
+
+    payload = {
+        "password": "d9bd8afc54ee5dc6c1ee6096e297ec31",
+        "verion": "1",
+        "email": email,
+        "luid": "",
+        "request-id": req_id,
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                msg = str(data.get("msg", "")).lower()
+
+                if "password is wrong" in msg:
+                    return Result.taken(url=show_url)
+
+                if "user does not exist" in msg:
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_lespark(email: str) -> Result:
+    """
+    LesPark dating app email validator.
+    Checks login endpoint with dummy password.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/dating/locanto.py
+++ b/user_scanner/email_scan/dating/locanto.py
@@ -1,0 +1,56 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://www.locanto.org/api/ajax/general"
+    show_url = "https://www.locanto.org"
+
+    payload = {
+        "action": "register_attempt",
+        "email": email,
+        "is_dol": "true",
+    }
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 13; Pixel 6 Build/TQ3A.230901.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/111.0.5563.116 Safari/537.36 YalwApp/eL.4.2.83",
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": "https://www.locanto.org",
+        "Referer": "https://www.locanto.org/g/dol/signup/?continue=https%3A%2F%2Fwww.locanto.org%2Fg%2Fdol%2Fdiscover%2F",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("success") is True:
+                    return Result.available(url=show_url)
+
+                text = str(data.get("text", "")).lower()
+                if data.get("email_exists") is True or "already exists" in text or "something went wrong" in text:
+                    return Result.taken(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_locanto(email: str) -> Result:
+    """
+    #Dating by Locanto email validator.
+    Checks register_attempt ajax endpoint for #Dating (Dating Only / DOL).
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/dating/okcupid.py
+++ b/user_scanner/email_scan/dating/okcupid.py
@@ -1,0 +1,116 @@
+import secrets
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    token_url = "https://e2p-okapi.api.okcupid.com/graphql/AnonAuthToken"
+    validate_url = "https://e2p-okapi.api.okcupid.com/graphql/ValidateEmail"
+    show_url = "https://okcupid.com"
+
+    device_id = secrets.token_hex(11)
+
+    headers = {
+        "User-Agent": "Android 115.1.0",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "x-apollo-operation": "AnonAuthToken",
+        "x-okcupid-device-id": f"Android; Pixel 6; 13; {device_id};",
+        "x-okcupid-app": "OkCupid Android App 115.1.0",
+        "x-okcupid-platform": "Android",
+        "x-okcupid-version": "115.1.0",
+        "x-okcupid-locale": "en-US",
+        "x-match-useragent": "OkCupid/115.1.0 REL/13",
+        "x-okcupid-auth-v": "1",
+        "x-okcupid-emulator": "false",
+        "x-emb-path": "/graphql/AnonAuthToken",
+    }
+
+    payload_token = {
+        "operationName": "AnonAuthToken",
+        "variables": {
+            "input": {
+                "deviceId": device_id,
+                "siteCode": 36,
+            }
+        },
+        "query": "mutation AnonAuthToken($input: AuthAnonymousInput!) { authAnonymous(input: $input) { token } }",
+        "extensions": {
+            "clientLibrary": {
+                "name": "apollo-kotlin",
+                "version": "4.4.3",
+            }
+        },
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            token_resp = await client.post(token_url, json=payload_token, headers=headers, timeout=6.0)
+
+            if token_resp.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if token_resp.status_code != 200:
+                return Result.error(
+                    f"Unexpected token status: {token_resp.status_code}, report it via GitHub issues",
+                    url=show_url,
+                )
+
+            token_data = token_resp.json()
+            token = token_data.get("data", {}).get("authAnonymous", {}).get("token")
+
+            if not token:
+                return Result.error("Could not obtain anonymous auth token", url=show_url)
+
+            headers_validate = headers.copy()
+            headers_validate["authorization"] = token
+            headers_validate["x-apollo-operation"] = "ValidateEmail"
+            headers_validate["x-emb-path"] = "/graphql/ValidateEmail"
+
+            payload_validate = {
+                "operationName": "ValidateEmail",
+                "variables": {
+                    "email": email
+                },
+                "query": "query ValidateEmail($email: String!) { auth { isEmailValid(email: $email) } }",
+                "extensions": {
+                    "clientLibrary": {
+                        "name": "apollo-kotlin",
+                        "version": "4.4.3",
+                    }
+                },
+            }
+
+            response = await client.post(validate_url, json=payload_validate, headers=headers_validate, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                auth_data = data.get("data", {}).get("auth", {})
+                if "isEmailValid" in auth_data:
+                    is_valid = auth_data["isEmailValid"]
+                    if is_valid is False:
+                        return Result.taken(url=show_url)
+                    elif is_valid is True:
+                        return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_okcupid(email: str) -> Result:
+    """
+    OkCupid dating app email validator.
+    Fetches an anonymous token and checks the ValidateEmail GraphQL query.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/dating/skout.py
+++ b/user_scanner/email_scan/dating/skout.py
@@ -1,0 +1,83 @@
+import secrets
+import uuid
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.skout.com/validations/Users_NewUserCheck"
+    show_url = "https://www.skout.com"
+
+    android_id = secrets.token_hex(8)
+    app_id = f"{uuid.uuid4()}?identifier=skout.prod"
+    gpsa_id = f"{uuid.uuid4()}?identifier=skout.prod"
+    appset_id = f"{uuid.uuid4()}?identifier=skout.prod"
+    firebase_id = secrets.token_hex(16)
+
+    params = {
+        "email": email,
+        "name": "notSet",
+        "brand": "skout",
+    }
+
+    headers = {
+        "User-Agent": "Skout/23201 Dalvik/2.1.0 (Linux; U; Android 13; Pixel 6 Build/TQ3A.230901.001) 4.12.0",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "kissapi-ad-id": "c66aefe62fa926b6e76dc1ebef756baf",
+        "kissapi-ad-name": "Organic",
+        "kissapi-ad-label": "",
+        "kissapi-app-version": "23201",
+        "kissapi-version": "1.36.0",
+        "kissapi-device-os": "33",
+        "kissapi-device-model": "Pixel 6",
+        "tz": "UTC",
+        "kissapi-device": "android",
+        "kissapi-app-package-id": "com.skout.android",
+        "kissapi-brand": "skout",
+        "kissapi-apptype": "google",
+        "kissapi-android-id": android_id,
+        "kissapi-app-id": app_id,
+        "kissapi-gpsa-id": gpsa_id,
+        "kissapi-gpsa-on": "true",
+        "kissapi-appset-id": appset_id,
+        "firebase-analytics-app-instance-id": firebase_id,
+        "accept-language": "en-US",
+        "wifi": "0",
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 409:
+                data = response.json()
+                msg = str(data.get("statusMessage", "")).lower()
+                if "email already exists" in msg:
+                    return Result.taken(url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("statusCode") == 200:
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_skout(email: str) -> Result:
+    """
+    Skout dating app email validator.
+    Checks Users_NewUserCheck endpoint.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/entertainment/dreame.py
+++ b/user_scanner/email_scan/entertainment/dreame.py
@@ -1,0 +1,66 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://wap-api.dreame.com/Login/loginWithEmail"
+    show_url = "https://www.dreame.com"
+
+    dummy_password = (
+        "jnW1Pjcoiyrg+dkxNw8SsMdrWC3Iho1qwaUEwXKeC5cXvvySR0iaYJLLYBNSceDB6KSQoNn9"
+        "BVk9ZzIpSr8iAkwnNp/Ou0HbXcPXZiLK6t+b/DvlWVxaadaOke15mibcYWgg82C8BBWSHMX6"
+        "NyWs2YkVitTlWVCZ22rNz1ahFaQ="
+    )
+
+    params = {
+        "systemFlag": "android",
+        "channel": "dreamepmian-173",
+        "product": "1",
+        "osType": "2",
+        "userKey": "",
+        "language": "en",
+        "user": email,
+        "password": dummy_password,
+    }
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Encoding": "gzip, deflate",
+        "origin": "https://www.dreame.com",
+        "referer": "https://www.dreame.com/",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, params=params, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                msg = str(data.get("msg", "")).lower()
+
+                if "account or password is incorrect" in msg:
+                    return Result.taken(url=show_url)
+                elif "has not been registered" in msg:
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_dreame(email: str) -> Result:
+    """
+    Dreame (Dreame Media / Ebooks) email validator.
+    Checks loginWithEmail endpoint with a dummy password.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/entertainment/weverse.py
+++ b/user_scanner/email_scan/entertainment/weverse.py
@@ -1,0 +1,66 @@
+import secrets
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://sdk.weverse.io/api/v1/auth/password-reset/otp-sessions"
+    show_url = "https://weverse.io"
+
+    payload = {
+        "email": email
+    }
+
+    device_id = secrets.token_hex(15)
+    trace_id = secrets.token_hex(16).upper()
+
+    headers = {
+        "User-Agent": "AppName/weverse AppVersion/4.5.0 BundleId/co.benx.weverse OS/Android SystemVersion/Android13 DeviceModel/Pixel 6",
+        "Accept-Encoding": "gzip",
+        "x-sdk-language": "en",
+        "x-clog-producer": "account-android",
+        "x-sdk-service-secret": "9d79660be5ca452ab8c93bcaee310bb7",
+        "x-clog-user-device-id": device_id,
+        "x-sdk-platform": "Android",
+        "x-sdk-device-model": "Pixel 6",
+        "x-sdk-app-version": "3.17.0",
+        "x-sdk-platform-version": "13",
+        "x-sdk-service-id": "weverse",
+        "x-sdk-trace-id": trace_id,
+        "x-sdk-version": "4.5.0",
+        "content-type": "application/json; charset=UTF-8",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if "otpSessionId" in data:
+                    return Result.taken(url=show_url)
+
+            if response.status_code == 404:
+                data = response.json()
+                msg = str(data.get("message", "")).lower()
+                if "account does not exist" in msg:
+                    return Result.available(url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_weverse(email: str) -> Result:
+    """
+    Weverse email validator. Checks password-reset/otp-sessions endpoint.
+    Loud module because creating an OTP session sends a reset code.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/fitness/evolveyou.py
+++ b/user_scanner/email_scan/fitness/evolveyou.py
@@ -1,0 +1,58 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://fitness.evolveyouapi.com/api/v1/auth"
+    show_url = "https://evolveyou.app"
+
+    payload = {
+        "username": email,
+        "password": "dummy_password_xyz123",
+    }
+
+    headers = {
+        "User-Agent": "okhttp/4.12.0",
+        "Accept": "application/json; text/plain; charset=utf-8",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "x-device-type": "unknown",
+        "x-consumer": "Tablet",
+        "x-app-version": "9.7.7",
+        "x-timezone-offset": "-480",
+        "os": "android",
+        "accept-language": "en-gb",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code in (400, 401):
+                data = response.json()
+                msg = str(data.get("message", "")).lower()
+
+                if "incorrect username or password" in msg:
+                    return Result.taken(url=show_url)
+
+                if "user not found" in msg:
+                    return Result.available(url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_evolveyou(email: str) -> Result:
+    """
+    EvolveYou fitness app email validator.
+    Checks auth endpoint with a dummy password.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/fitness/sweat.py
+++ b/user_scanner/email_scan/fitness/sweat.py
@@ -1,0 +1,59 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://login.sweat.com/oauth/token"
+    show_url = "https://sweat.com"
+
+    payload = {
+        "client_id": "ekN6uujzIgNGOxe8gu6XkmhSyhlnmt31",
+        "scope": "openid email offline_access profile",
+        "username": email,
+        "password": "dummy_password_xyz123",
+        "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+        "realm": "Username-Password-Authentication",
+    }
+
+    headers = {
+        "User-Agent": "okhttp/5.3.2",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 403:
+                data = response.json()
+                error_desc = str(data.get("error_description", "")).lower()
+
+                if "password is incorrect" in error_desc:
+                    return Result.taken(url=show_url)
+
+                if "couldn’t find an account" in error_desc or "couldn't find an account" in error_desc:
+                    return Result.available(
+                        reason="Target may have an OAuth-only registered account (Apple, Google, or Facebook)",
+                        url=show_url,
+                    )
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_sweat(email: str) -> Result:
+    """
+    Sweat fitness app email validator.
+    Checks Auth0 password-realm oauth token endpoint with a dummy password.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/cambly.py
+++ b/user_scanner/email_scan/learning/cambly.py
@@ -1,0 +1,61 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://www.cambly.com/forgotPassword"
+    show_url = "https://www.cambly.com"
+
+    payload = {
+        "email": email,
+    }
+
+    headers = {
+        "User-Agent": "Cambly/7.30.1 (com.cambly.cambly; Android 13)",
+        "Accept-Encoding": "gzip",
+        "Content-Type": "application/json; charset=UTF-8",
+        "Accept-Language": "en",
+        "x-cambly-interface-locale": "en_US",
+        "x-cambly-entity": "googlePlay",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                return Result.taken(url=show_url)
+
+            if response.status_code == 422:
+                data = response.json()
+                err = str(data.get("error", "")).lower()
+                err_text = str(data.get("error_text", "")).lower()
+                if "nocaptcha" in err or "captcha" in err_text:
+                    return Result.taken(url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                err = str(data.get("error", "")).lower()
+                err_text = str(data.get("error_text", "")).lower()
+                if "notfound" in err or "could not be found" in err_text:
+                    return Result.available(url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_cambly(email: str) -> Result:
+    """
+    Cambly learning app email validator.
+    Checks forgotPassword endpoint.
+    Loud module because password reset emails are sent for registered accounts.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/classdojo.py
+++ b/user_scanner/email_scan/learning/classdojo.py
@@ -1,0 +1,71 @@
+from urllib.parse import quote
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = f"https://api.classdojo.com/api/user/emailValidation/{quote(email)}"
+    show_url = "https://www.classdojo.com"
+
+    params = {
+        "skipDomainValidation": "false",
+    }
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 13; WayDroid x86_64 Device Build/TQ3A.230901.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/111.0.5563.116 Safari/537.36",
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "x-client-identifier": "Android",
+        "x-client-version": "8.80.0",
+        "x-sign-attachment-urls": "true",
+        "x-client-os-version": "33",
+        "x-device-id": "fb125fbaf088ff2d",
+        "x-client-language": "en-US",
+        "accept-language": "en",
+        "x-rn-request": "true",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.get(url, params=params, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                is_available = data.get("isAvailableForSignUp")
+
+                if is_available is False:
+                    extra = {}
+                    if "entityType" in data:
+                        extra["entity_type"] = data["entityType"]
+                    if "isPasswordless" in data:
+                        extra["is_passwordless"] = data["isPasswordless"]
+                    if "hasMandatorySSO" in data:
+                        extra["has_mandatory_sso"] = data["hasMandatorySSO"]
+                    if "oidcProviders" in data and data["oidcProviders"]:
+                        extra["oidc_providers"] = data["oidcProviders"]
+
+                    return Result.taken(extra=extra if extra else None, url=show_url)
+
+                elif is_available is True:
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_classdojo(email: str) -> Result:
+    """
+    ClassDojo learning app email validator.
+    Checks emailValidation endpoint and extracts metadata into extra.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/learning/quizlet.py
+++ b/user_scanner/email_scan/learning/quizlet.py
@@ -1,0 +1,62 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.quizlet.com/3.11/validate-email"
+    show_url = "https://quizlet.com"
+
+    params = {
+        "client_id": "XbSGGchEnA",
+    }
+
+    payload = {
+        "email": email,
+    }
+
+    headers = {
+        "User-Agent": "QuizletAndroid/10.47 Dalvik/2.1.0 (Linux; U; Android 13; Pixel 6 Build/TQ3A.230901.001)",
+        "Accept-Encoding": "gzip",
+        "accept-language": "en-US",
+        "content-type": "application/json; charset=UTF-8",
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, params=params, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                responses = data.get("responses", [])
+                if responses and isinstance(responses, list):
+                    validate_data = responses[0].get("data", {}).get("validateEmail", {})
+                    if "isValid" in validate_data:
+                        is_valid = validate_data["isValid"]
+                        if is_valid is False:
+                            extra = {}
+                            if validate_data.get("existingAccount"):
+                                extra["existing_account"] = validate_data["existingAccount"]
+                            return Result.taken(extra=extra if extra else None, url=show_url)
+                        elif is_valid is True:
+                            return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_quizlet(email: str) -> Result:
+    """
+    Quizlet learning app email validator.
+    Checks validate-email endpoint and returns verdict based on isValid.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/other/secondline.py
+++ b/user_scanner/email_scan/other/secondline.py
@@ -1,0 +1,63 @@
+import uuid
+
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://autobizline.com/secondline/user/has_user/"
+    show_url = "https://autobizline.com"
+
+    headers = {
+        "User-Agent": "okhttp/4.10.0",
+        "Accept-Encoding": "gzip",
+    }
+
+    payload = {
+        "api_token": "S(FNMSLDFKSD)FLKSlsdflkladf09asdfsafdasdf90123iksf=!@*#",
+        "from_channel": "android",
+        "device_id": str(uuid.uuid4()),
+        "user_number": email,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                result_status = data.get("result")
+
+                if result_status == "success":
+                    has_user = data.get("has_user")
+                    has_account = data.get("has_account")
+
+                    if has_user == "yes" or has_account == "yes":
+                        return Result.taken(url=show_url)
+
+                    if has_user == "no" and has_account == "no":
+                        return Result.available(url=show_url)
+
+                if result_status == "failed":
+                    return Result.error("API error / request failed", url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_secondline(email: str) -> Result:
+    """
+    SecondLine email validator.
+    Checks user/has_user API endpoint.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/social/superlive.py
+++ b/user_scanner/email_scan/social/superlive.py
@@ -1,0 +1,97 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://api.sskkjp1l6cx7.link/api/v1/user/signup/send_password_renewal_code"
+    show_url = "https://superlive.io"
+
+    headers = {
+        "User-Agent": "SuperLive/2.38.1 (Pixel 6; Android 13; Scale/mdpi)",
+        "Accept-Encoding": "gzip",
+        "device-id": "08f890cd6e0b9235cde1d50522f5f4ed",
+        "Content-Type": "application/json; charset=UTF-8",
+    }
+
+    payload = {
+        "email": email,
+        "force_new": True,
+        "client_params": {
+            "adid": "c66aefe62fa926b6e76dc1ebef756baf",
+            "adjust_attribution_data": {
+                "adgroup": "",
+                "adid": "c66aefe62fa926b6e76dc1ebef756baf",
+                "campaign": "",
+                "click_label": "",
+                "creative": "",
+                "network": "Organic",
+                "tracker_name": "Organic",
+                "tracker_token": "mii5ej6",
+            },
+            "android_id": "1db33b89299a9d90",
+            "app_language": "en",
+            "brand_name": "google",
+            "carrier": "",
+            "currency_code": "_",
+            "device_language": "en",
+            "device_preferred_languages": ["en"],
+            "initial_country": "US",
+            "display_density": "420 dpi",
+            "display_ratio": "16:9",
+            "display_resolution_height": 1920,
+            "display_resolution_width": 1080,
+            "display_size": "6.0 inch",
+            "firebase_analytics_id": "ec9377988825dec03f2335b01dc32179",
+            "ga_session_id": "1786979772",
+            "gps_adid": "0e1aa4df-0e53-4cb6-8a37-b73fff9a27de",
+            "installation_id": "5d27f697-91ec-407e-a5e3-cbf2e0e1e66b",
+            "mac": "None",
+            "marketing_name": "Pixel 6",
+            "model_name": "Pixel 6",
+            "network_type": "WIFI",
+            "os_hardware_model": "unknown",
+            "os_type": "android",
+        },
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 400:
+                data = response.json()
+                err = data.get("error", {})
+                msg = str(err.get("message", "")).lower()
+
+                if "no registered users with this email" in msg:
+                    return Result.available(url=show_url)
+
+                if "attempt limit reached" in msg or err.get("code") == 12:
+                    return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                if "password_renewal_id" in data:
+                    return Result.taken(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_superlive(email: str) -> Result:
+    """
+    SuperLive email validator.
+    Checks send_password_renewal_code endpoint.
+    Loud module because password renewal codes are sent to registered accounts.
+    """
+    return await _check(email)

--- a/user_scanner/email_scan/women_health/womanlog.py
+++ b/user_scanner/email_scan/women_health/womanlog.py
@@ -1,0 +1,53 @@
+import httpx
+from user_scanner.core.result import Result
+
+
+async def _check(email: str) -> Result:
+    url = "https://proactiveapp.com/account/login_native_v1"
+    show_url = "https://womanlog.com"
+
+    payload = {
+        "email": email,
+        "password": "dummy_password_xyz123",
+        "package": "com.womanlog",
+        "app_version": "7.3.5",
+        "os": "A",
+    }
+
+    headers = {
+        "User-Agent": "Dalvik/2.1.0 (Linux; U; Android 13; WayDroid x86_64 Device Build/TQ3A.230901.001)",
+        "Accept-Encoding": "gzip",
+    }
+
+    async with httpx.AsyncClient(http2=True) as client:
+        try:
+            response = await client.post(url, data=payload, headers=headers, timeout=6.0)
+
+            if response.status_code == 429:
+                return Result.error("Rate limited", url=show_url)
+
+            if response.status_code == 200:
+                data = response.json()
+                error_code = data.get("error_code")
+                if error_code == "INCORRECT_PASSWORD":
+                    return Result.taken(url=show_url)
+                elif error_code == "EMAIL_NOT_FOUND":
+                    return Result.available(url=show_url)
+
+                return Result.error("Unexpected response body, report it via GitHub issues", url=show_url)
+
+            return Result.error(
+                f"Unexpected response status: {response.status_code}, report it via GitHub issues",
+                url=show_url,
+            )
+
+        except Exception as e:
+            return Result.error(e, url=show_url)
+
+
+async def validate_womanlog(email: str) -> Result:
+    """
+    WomanLog (ProactiveApp) email validator.
+    Checks login_native_v1 endpoint with form data.
+    """
+    return await _check(email)


### PR DESCRIPTION
## Summary
Adds 14 new email OSINT scan modules across multiple categories, including introducing a brand new **`dating`** email category!

### New Category Introduced
- **`dating`** (`user_scanner/email_scan/dating/`):
  - **LesPark**: Checks lesbian social/dating platform API (`/login`).
  - **Locanto / #Dating**: Checks Locanto classifieds & #Dating registration API (`/api/ajax/general`).
  - **OkCupid**: Checks GraphQL registration API (`ValidateEmail`).
  - **Skout**: Checks Skout dating network registration API (`/validations/Users_NewUserCheck`).

### Modules by Category (14 Total)
- **`dating` (4)**: `lespark`, `locanto`, `okcupid`, `skout`
- **`learning` (3)**: `cambly`, `classdojo`, `quizlet`
- **`fitness` (2)**: `evolveyou`, `sweat`
- **`entertainment` (2)**: `dreame`, `weverse`
- **`social` (1)**: `superlive`
- **`women_health` (1)**: `womanlog`
- **`other` (1)**: `secondline`