### PR TITLE
fix(email_scan): handle Facebook rate-limiting response gracefully

### DIFF
--- a/user_scanner/email_scan/social/facebook.py
+++ b/user_scanner/email_scan/social/facebook.py
@@ -94,7 +94,9 @@ async def _check(email: str) -> Result:
             response = await client.post(url3, params=params3, data=payload3, headers=headers3)
             body = response.text
 
-            if "These accounts matched your search" in body or "redirectPageTo" in body:
+            if "error\":3252001" in body or "temporarily blocked" in body:
+                return Result.error("Rate limited by Facebook (IP blocked)")
+            elif "These accounts matched your search" in body or "redirectPageTo" in body:
                 return Result.taken(url=show_url)
             elif "No search results" in body or "Your search did not return any results." in body:
                 return Result.available(url=show_url)


### PR DESCRIPTION
- Detect Facebook action block / rate-limiting error payloads (`error: 3252001` and `temporarily blocked`)
- Return descriptive `Result.error("Rate limited by Facebook (IP blocked)")` instead of generic unexpected error