### PR TITLE
feat: CodePen username module

### DIFF
--- a/user_scanner/user_scan/dev/codepen.py
+++ b/user_scanner/user_scan/dev/codepen.py
@@ -1,0 +1,111 @@
+import html
+import re
+from urllib.parse import quote
+
+from user_scanner.core.orchestrator import generic_validate, make_request
+from user_scanner.core.result import Result, Status
+
+
+PROFILE_QUERY = """
+query ProfileOwner($ownerUsername: String!, $ownerType: OwnerEnum!) {
+  ownerByUsername(ownerUsername: $ownerUsername, ownerType: $ownerType) {
+    id
+    title
+    avatar512
+    pro
+    urls
+    location
+    bio
+    verified
+    counts {
+      id
+      followers
+      following
+      pens
+      posts
+      collections
+    }
+  }
+}
+"""
+
+
+def _meta(document: str, name: str) -> str:
+    match = re.search(
+        rf'<meta[^>]+(?:name|property)=["\']{re.escape(name)}["\'][^>]+'
+        r'content=(["\'])(.*?)\1',
+        document,
+        re.IGNORECASE | re.DOTALL,
+    )
+    return html.unescape(match.group(2).strip()) if match else ""
+
+
+def _enrichment(
+    user: str, account_type: str, document: str, profile_url: str
+) -> tuple[dict[str, str | bool | int | list[str] | None], dict[str, str]]:
+    extra: dict[str, str | bool | int | list[str] | None] = {
+        "account_type": account_type
+    }
+    csrf_token = _meta(document, "csrf-token")
+    if not csrf_token:
+        return extra, {}
+
+    try:
+        response = make_request(
+            "https://codepen.io/graphql",
+            method="POST",
+            headers={"referer": profile_url, "x-csrf-token": csrf_token},
+            json={
+                "query": PROFILE_QUERY,
+                "variables": {
+                    "ownerType": account_type.title(),
+                    "ownerUsername": user,
+                },
+            },
+        )
+        profile = response.json()["data"]["ownerByUsername"]
+        if not isinstance(profile, dict):
+            return extra, {}
+    except Exception:
+        return extra, {}
+
+    counts = profile.get("counts") or {}
+    extra["hashid"] = profile.get("id")
+    extra[f"{account_type}_id"] = counts.get("id")
+    for field in ("followers", "following", "pens", "posts", "collections"):
+        extra[field] = counts.get(field)
+    for field in ("pro", "verified"):
+        extra[field] = profile.get(field)
+    if links := [url for url in profile.get("urls") or [] if url]:
+        extra["links"] = list(dict.fromkeys(links))
+    extra["location"] = str(profile.get("location") or "").strip()
+    extra["fullname"] = str(profile.get("title") or "").strip()
+    extra["bio"] = html.unescape(str(profile.get("bio") or "")).strip()
+    return extra, {"avatar": str(profile.get("avatar512") or "")}
+
+
+def validate_codepen(user: str) -> Result:
+    encoded = quote(user, safe="")
+
+    def check(url: str, account_type: str) -> Result:
+        def process(response):
+            document = response.text
+            if response.status_code == 404 and 'data-test-id="text-404"' in document:
+                return Result.available()
+
+            if response.status_code != 200:
+                return Result.error(f"Unexpected response status: {response.status_code}")
+
+            canonical = _meta(document, "og:url")
+            if canonical.rstrip("/").casefold() != url.casefold():
+                return Result.error("Profile response did not match the requested username")
+
+            extra, media = _enrichment(user, account_type, document, url)
+            return Result.taken(extra=extra, media=media)
+
+        return generic_validate(url, process, show_url=url, follow_redirects=True)
+
+    result = check(f"https://codepen.io/{encoded}", "user")
+    if result != Status.AVAILABLE:
+        return result
+    return check(f"https://codepen.io/team/{encoded}", "team")

--- a/user_scanner/user_scan/dev/codepenteams.py
+++ b/user_scanner/user_scan/dev/codepenteams.py
@@ -56,7 +56,7 @@ def _enrichment(
             json={
                 "query": PROFILE_QUERY,
                 "variables": {
-                    "ownerType": "User",
+                    "ownerType": "Team",
                     "ownerUsername": user,
                 },
             },
@@ -81,9 +81,9 @@ def _enrichment(
     return extra, {"avatar": str(profile.get("avatar512") or "")}
 
 
-def validate_codepen(user: str) -> Result:
+def validate_codepenteams(user: str) -> Result:
     encoded = quote(user, safe="")
-    url = f"https://codepen.io/{encoded}"
+    url = f"https://codepen.io/team/{encoded}"
 
     def process(response):
         document = response.text


### PR DESCRIPTION
CodePen username module, checking both individual users and teams. Performs a separate GraphQL request to fetch information about the user/team.

There is one known limitation to this implementation: CodePen allows individual users and teams to share names, for example:
- https://codepen.io/shopify
- https://codepen.io/team/shopify

In this case, the module prefers the individual user. Is this an issue at all? Do we need to support teams? Should we have separate modules for them? Any other suggestions?