### PR TITLE
feat(user_scan): add Faceit, LessWrong, Hex.pm, Spatial, and Tenor modules

### DIFF
--- a/user_scanner/user_scan/community/lesswrong.py
+++ b/user_scanner/user_scan/community/lesswrong.py
@@ -1,0 +1,70 @@
+import json
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_lesswrong(user: str) -> Result:
+    """Validate a user profile on LessWrong (lesswrong.com)."""
+    url = "https://www.lesswrong.com/graphql"
+    show_url = f"https://www.lesswrong.com/users/{user}"
+
+    query = (
+        '{ user(input: {selector: {slug: "'
+        + user
+        + '"}}) { result { _id displayName slug karma bio createdAt } } }'
+    )
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    def process(response):
+        # 1. Explicit verification of available / not-found state
+        if (
+            response.status_code == 404
+            or "app.missing_document" in response.text
+            or '"user":null' in response.text.replace(" ", "")
+        ):
+            return Result.available(url=show_url)
+
+        # 2. Explicit verification of taken state + data extraction
+        if response.status_code == 200 and '"user":' in response.text:
+            try:
+                data = json.loads(response.text)
+                user_res = data.get("data", {}).get("user", {}).get("result")
+                if user_res:
+                    extra = {}
+                    media = {}
+
+                    if display_name := user_res.get("displayName"):
+                        extra["name"] = str(display_name).strip()
+                    if slug := user_res.get("slug"):
+                        extra["username"] = str(slug).strip()
+                    if user_id := user_res.get("_id"):
+                        extra["user_id"] = str(user_id).strip()
+                    if karma := user_res.get("karma"):
+                        extra["karma"] = str(karma)
+                    if created_at := user_res.get("createdAt"):
+                        extra["created_at"] = str(created_at).strip()
+                    if bio := user_res.get("bio"):
+                        clean_bio = str(bio).strip()
+                        if clean_bio:
+                            extra["bio"] = clean_bio
+
+                    return Result.taken(extra=extra, media=media, url=show_url)
+            except Exception:
+                return Result.error("Failed to parse LessWrong GraphQL response", url=show_url)
+
+        # 3. Graceful error for unexpected status codes (No bare else!)
+        return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+    return generic_validate(
+        url,
+        process,
+        method="POST",
+        json={"query": query},
+        headers=headers,
+        show_url=show_url,
+    )

--- a/user_scanner/user_scan/creative/spatial.py
+++ b/user_scanner/user_scan/creative/spatial.py
@@ -1,0 +1,53 @@
+import html
+import re
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_spatial(user: str) -> Result:
+    """Validate a 3D creator profile on Spatial (spatial.io)."""
+    url = f"https://www.spatial.io/@{user}"
+    show_url = f"https://www.spatial.io/@{user}"
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    }
+
+    def process(response):
+        title_match = re.search(r"<title>(.*?)</title>", response.text, re.IGNORECASE)
+        raw_title = title_match.group(1).strip() if title_match else ""
+        title = html.unescape(raw_title)
+
+        # 1. Explicit verification of available / not-found state
+        if (
+            response.status_code == 404
+            or "profile not found" in title.lower()
+            or "page not found" in title.lower()
+            or "not found" in response.text.lower()
+        ):
+            return Result.available(url=show_url)
+
+        # 2. Explicit verification of taken state + data extraction
+        if response.status_code == 200 and "spatial" in title.lower() and f"(@{user.lower()})" in title.lower():
+            extra = {"username": user}
+            media = {}
+
+            # Extract display name from "<Name> (@<user>) | Spatial"
+            name_match = re.search(r"^(.*?)\s+\(@", title)
+            if name_match:
+                extra["name"] = name_match.group(1).strip()
+
+            # Extract avatar from OpenGraph image (ReadyPlayerMe avatar PNG)
+            img_match = re.search(r'<meta property="og:image" content="(.*?)"', response.text, re.IGNORECASE)
+            if not img_match:
+                img_match = re.search(r'<meta content="(.*?)" property="og:image"', response.text, re.IGNORECASE)
+            if img_match:
+                img_url = img_match.group(1).strip()
+                if img_url and "og-image" not in img_url.lower() and "default" not in img_url.lower():
+                    media["avatar"] = img_url
+
+            return Result.taken(extra=extra, media=media, url=show_url)
+
+        # 3. Graceful error for unexpected status codes (No bare else!)
+        return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/dev/hex_pm.py
+++ b/user_scanner/user_scan/dev/hex_pm.py
@@ -1,0 +1,50 @@
+import json
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_hex_pm(user: str) -> Result:
+    """Validate a package author on Hex.pm (hex.pm)."""
+    url = f"https://hex.pm/api/users/{user}"
+    show_url = f"https://hex.pm/users/{user}"
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "application/json",
+    }
+
+    def process(response):
+        # 1. Explicit verification of available / not-found state
+        if response.status_code == 404 or "page not found" in response.text.lower():
+            return Result.available(url=show_url)
+
+        # 2. Explicit verification of 200 OK + Hex.pm user payload
+        if response.status_code == 200 and '"username":' in response.text:
+            try:
+                data = json.loads(response.text)
+                if (data.get("username") or "").lower() == user.lower():
+                    extra = {}
+                    media = {}
+
+                    if username := data.get("username"):
+                        extra["username"] = str(username).strip()
+                    if full_name := data.get("full_name"):
+                        extra["name"] = str(full_name).strip()
+                    if email := data.get("email"):
+                        extra["email"] = str(email).strip()
+                    if inserted_at := data.get("inserted_at"):
+                        extra["joined"] = str(inserted_at).strip()
+
+                    handles = data.get("handles", {})
+                    if github := handles.get("github"):
+                        extra["github"] = str(github).strip()
+                    if twitter := handles.get("twitter"):
+                        extra["twitter"] = str(twitter).strip()
+
+                    return Result.taken(extra=extra, media=media, url=show_url)
+            except Exception:
+                return Result.error("Failed to parse Hex.pm JSON response", url=show_url)
+
+        # 3. Graceful error for unexpected status codes (No bare else!)
+        return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)

--- a/user_scanner/user_scan/gaming/faceit.py
+++ b/user_scanner/user_scan/gaming/faceit.py
@@ -1,0 +1,62 @@
+import json
+from user_scanner.core.impersonate import impersonate_validate
+from user_scanner.core.result import Result
+
+
+def validate_faceit(user: str) -> Result:
+    """Validate a player handle on Faceit (faceit.com)."""
+    url = f"https://www.faceit.com/api/users/v1/nicknames/{user}"
+    show_url = f"https://www.faceit.com/en/players/{user}"
+    headers = {
+        "Accept": "application/json",
+    }
+
+    def process(response):
+        # 1. Explicit verification of available / not-found state
+        if response.status_code == 404 or "user not found" in response.text.lower():
+            return Result.available(url=show_url)
+
+        # 2. Explicit verification of 200 OK + Faceit user payload
+        if response.status_code == 200 and '"result":"OK"' in response.text.replace(" ", ""):
+            try:
+                data = json.loads(response.text)
+                payload = data.get("payload", {})
+                if payload and (payload.get("nickname") or "").lower() == user.lower():
+                    extra = {}
+                    media = {}
+
+                    if nickname := payload.get("nickname"):
+                        extra["nickname"] = str(nickname).strip()
+                    if user_id := payload.get("id"):
+                        extra["user_id"] = str(user_id).strip()
+                    if country := payload.get("country"):
+                        extra["country"] = str(country).strip().upper()
+                    if created_at := payload.get("created_at"):
+                        extra["created_at"] = str(created_at).strip()
+                    if verified := payload.get("verified"):
+                        extra["verified"] = str(verified)
+
+                    # Extract linked platform accounts (Steam, Twitch)
+                    platforms = payload.get("platforms", {})
+                    if steam := platforms.get("steam", {}):
+                        if steam_id := steam.get("id64"):
+                            extra["steam_id64"] = str(steam_id)
+
+                    streaming = payload.get("streaming", {})
+                    if twitch_id := streaming.get("twitch_id"):
+                        extra["twitch_id"] = str(twitch_id)
+
+                    # Extract media
+                    if avatar := payload.get("avatar"):
+                        media["avatar"] = str(avatar).strip()
+                    if banner := payload.get("cover_image_url"):
+                        media["banner"] = str(banner).strip()
+
+                    return Result.taken(extra=extra, media=media, url=show_url)
+            except Exception:
+                return Result.error("Failed to parse Faceit JSON response", url=show_url)
+
+        # 3. Graceful error for unexpected status codes (No bare else!)
+        return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+    return impersonate_validate(url, process, headers=headers, show_url=show_url, impersonate="chrome")

--- a/user_scanner/user_scan/social/tenor.py
+++ b/user_scanner/user_scan/social/tenor.py
@@ -1,0 +1,52 @@
+import html
+import re
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+
+def validate_tenor(user: str) -> Result:
+    """Validate a creator profile on Tenor (tenor.com)."""
+    url = f"https://tenor.com/users/{user}"
+    show_url = f"https://tenor.com/users/{user}"
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    }
+
+    def process(response):
+        title_match = re.search(r"<title[^>]*>(.*?)</title>", response.text, re.IGNORECASE)
+        raw_title = title_match.group(1).strip() if title_match else ""
+        title = html.unescape(raw_title)
+        norm_title = title.replace("’", "'").lower()
+
+        # 1. Explicit verification of available / not-found state
+        if (
+            response.status_code == 404
+            or "404 error" in norm_title
+            or "page not found" in response.text.lower()
+        ):
+            return Result.available(url=show_url)
+
+        # 2. Explicit verification of taken state + data extraction
+        if (
+            response.status_code == 200
+            and "tenor" in norm_title
+            and (f"{user.lower()}'s gifs" in norm_title or f"{user.lower()}'s" in norm_title)
+        ):
+            extra = {"username": user}
+            media = {}
+
+            # Extract avatar or featured gif from OpenGraph
+            img_match = re.search(r'<meta content="(.*?)" property="og:image"', response.text, re.IGNORECASE)
+            if not img_match:
+                img_match = re.search(r'<meta property="og:image" content="(.*?)"', response.text, re.IGNORECASE)
+            if img_match:
+                img_url = img_match.group(1).strip()
+                if img_url and "tenor-logo" not in img_url.lower():
+                    media["avatar"] = img_url
+
+            return Result.taken(extra=extra, media=media, url=show_url)
+
+        # 3. Graceful error for unexpected status codes (No bare else!)
+        return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)


### PR DESCRIPTION
- Add 5 new username OSINT modules: Faceit (gaming), LessWrong (community), Hex.pm (dev), Spatial (creative), and Tenor (social)
- Extract rich profile metadata and cross-scan pivots (Steam ID and Twitch ID on Faceit; public email and GitHub/Twitter on Hex.pm)
- Isolate avatars and banners into media dictionary
- Implement explicit verdict markers for taken and available states with zero bare else blocks
- Verified live against active and nonexistent handles with all quality gates passing