### PR TITLE
fix: encode user-controlled input in request query strings (batch 2/#574)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,38 @@ For multi-step flows, use `impersonate_request` directly. It returns the raw `cu
 - **Purpose:** Simple helper for sites where availability can be determined purely from HTTP status codes (e.g., 404 = available, 200 = taken).
 - **Warning:** Use this *only* as a last resort if the site has absolutely no WAF and reliably returns strict HTTP codes without custom redirect/error pages. Modern sites heavily punish this approach.
 
+### 4. URL construction and user input
+
+Never interpolate user-controlled input (`user`, `email`, `target`, etc.) directly
+into a URL string:
+
+```python
+# ❌ Don't do this — special characters (&, #, %, +, whitespace, non-ASCII)
+# can corrupt the request or inject unintended query parameters
+url = f"https://example.com/api/users?username={user}"
+```
+
+Instead, build the URL without the value and pass it via `params`. This is
+supported by `generic_validate`, `make_request`, `status_validate`, and
+`impersonate_request`, and encodes correctly regardless of what the input
+contains:
+
+```python
+# ✅ Do this
+url = "https://example.com/api/users"
+return generic_validate(url, process, show_url=show_url, params={"username": user})
+```
+
+If a module needs a separate human-facing URL (e.g. to show the profile link
+in results), keep that as its own `show_url` built with an f-string — it's
+just for display and isn't sent as a request, so interpolation there is fine:
+
+```python
+url = "https://example.com/api/users"
+show_url = f"https://example.com/{user}"  # display only, not a request
+return generic_validate(url, process, show_url=show_url, params={"username": user})
+```
+
 ---
 
 ## Return values and error handling

--- a/user_scanner/user_scan/community/disqus.py
+++ b/user_scanner/user_scan/community/disqus.py
@@ -2,15 +2,21 @@ from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_disqus(user):
-    api_url = f"https://disqus.com/api/3.0/users/details?user=username%3A{user}&attach=userFlaggedUser&api_key=E8Uh5l5fHZ6gD8U3KycjAIAk46f68Zw7C6eW8WSjZvCLXebZ7p0r1yrYDrLilk2F"
+    api_url = "https://disqus.com/api/3.0/users/details"
     show_url = f"https://disqus.com/by/{user}/"
-    
+
+    params = {
+        "user": f"username:{user}",
+        "attach": "userFlaggedUser",
+        "api_key": "E8Uh5l5fHZ6gD8U3KycjAIAk46f68Zw7C6eW8WSjZvCLXebZ7p0r1yrYDrLilk2F",
+    }
+
     headers = {
         "User-Agent": get_random_user_agent(),
         "Accept": "application/json",
     }
-    
-    resp = make_request(api_url, headers=headers, http2=True)
+
+    resp = make_request(api_url, params=params, headers=headers, http2=True)
     if resp.status_code == 200:
         try:
             data = resp.json()

--- a/user_scanner/user_scan/creative/civitai.py
+++ b/user_scanner/user_scan/creative/civitai.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_civitai(user: str) -> Result:
     """Validate a creator on Civitai (civitai.com)."""
-    url = f"https://civitai.com/api/v1/creators?query={user}"
+    url = "https://civitai.com/api/v1/creators"
     show_url = f"https://civitai.com/user/{user}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -58,4 +58,7 @@ def validate_civitai(user: str) -> Result:
         # 3. Graceful error for unexpected status codes (No bare else!)
         return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
 
-    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)
+    return generic_validate(
+        url, process, headers=headers, show_url=show_url,
+        follow_redirects=True, params={"query": user},
+    )

--- a/user_scanner/user_scan/creative/px500.py
+++ b/user_scanner/user_scan/creative/px500.py
@@ -1,9 +1,22 @@
+import json
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_500px(user):
-    # Notice we pass the variables in URL encoded form, matching the query we inspected
-    url = f"https://api.500px.com/graphql?query=query%28%24username%3AString%21%29%7BuserByUsername%28username%3A%24username%29%7Bid%20legacyId%20username%20displayName%20firstName%20lastName%20registeredAt%20userProfile%7Bfirstname%20lastname%20about%20country%20city%20state%7DsocialMedia%7Bwebsite%20twitter%20facebook%20instagram%7D%7D%7D&variables=%7B%22username%22%3A%22{user}%22%7D"
+    url = "https://api.500px.com/graphql"
     show_url = f"https://500px.com/{user}"
+
+    graphql_query = (
+        "query($username:String!){"
+        "userByUsername(username:$username){"
+        "id legacyId username displayName firstName lastName registeredAt "
+        "userProfile{firstname lastname about country city state}"
+        "socialMedia{website twitter facebook instagram}"
+        "}}"
+    )
+    params = {
+        "query": graphql_query,
+        "variables": json.dumps({"username": user}),
+    }
 
     def process(response):
         if response.status_code == 200:
@@ -18,7 +31,7 @@ def validate_500px(user):
                         extra['displayName'] = user_data.get('displayName')
                     if user_data.get('registeredAt'):
                         extra['registeredAt'] = user_data.get('registeredAt')
-                    
+
                     profile = user_data.get('userProfile', {})
                     if profile.get('country'):
                         extra['country'] = profile.get('country')
@@ -26,7 +39,7 @@ def validate_500px(user):
                         extra['city'] = profile.get('city')
                     if profile.get('about'):
                         extra['about'] = profile.get('about')
-                        
+
                     social = user_data.get('socialMedia', {})
                     for net in ['website', 'twitter', 'facebook', 'instagram']:
                         if social.get(net):
@@ -39,8 +52,8 @@ def validate_500px(user):
                 pass
         elif response.status_code == 404:
             return Result.available()
-            
+
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(url, process, show_url=show_url, params=params, headers=headers)

--- a/user_scanner/user_scan/creator/devto.py
+++ b/user_scanner/user_scan/creator/devto.py
@@ -2,11 +2,11 @@ from user_scanner.core.orchestrator import Result, make_request
 
 
 def validate_devto(user):
-    url = f"https://dev.to/api/users/by_username?url={user}"
+    url = "https://dev.to/api/users/by_username"
     show_url = f"https://dev.to/{user}"
 
     try:
-        response = make_request(url, follow_redirects=True)
+        response = make_request(url, params={"url": user}, follow_redirects=True)
         if response.status_code == 200:
             data = response.json()
             extra = {}

--- a/user_scanner/user_scan/creator/fansly.py
+++ b/user_scanner/user_scan/creator/fansly.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_fansly(user):
-    url = f"https://apiv2.fansly.com/api/v1/account?usernames={user}"
+    url = "https://apiv2.fansly.com/api/v1/account"
     show_url = f"https://fansly.com/{user}"
 
     def process(response):
@@ -35,4 +35,6 @@ def validate_fansly(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"usernames": user}
+    )

--- a/user_scanner/user_scan/dev/atcoder.py
+++ b/user_scanner/user_scan/dev/atcoder.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_atcoder(user):
-    url = f"https://atcoder.jp/api/users/exists/?userScreenName={user}"
+    url = "https://atcoder.jp/api/users/exists/"
     show_url = f"https://atcoder.jp/users/{user}"
 
     def process(response):
@@ -13,4 +13,4 @@ def validate_atcoder(user):
 
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
-    return generic_validate(url, process, show_url=show_url)
+    return generic_validate(url, process, show_url=show_url, params={"userScreenName": user})

--- a/user_scanner/user_scan/dev/codeforces.py
+++ b/user_scanner/user_scan/dev/codeforces.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_codeforces(user):
-    url = f"https://codeforces.com/api/user.info?handles={user}"
+    url = "https://codeforces.com/api/user.info"
     show_url = f"https://codeforces.com/profile/{user}"
 
     def process(response):
@@ -41,4 +41,6 @@ def validate_codeforces(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"handles": user}
+    )

--- a/user_scanner/user_scan/dev/gitlab.py
+++ b/user_scanner/user_scan/dev/gitlab.py
@@ -4,7 +4,7 @@ from user_scanner.core.result import Result
 
 
 def validate_gitlab(user):
-    url = f"https://gitlab.com/api/v4/users?username={user}"
+    url = "https://gitlab.com/api/v4/users"
     show_url = f"https://gitlab.com/{user}"
 
     headers = {
@@ -50,4 +50,6 @@ def validate_gitlab(user):
                     return Result.taken(extra=extra, media=media)
         return Result.error(f"Unexpected status or response: {response.status_code}")
 
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"username": user}
+    )

--- a/user_scanner/user_scan/dev/googleplaystore.py
+++ b/user_scanner/user_scan/dev/googleplaystore.py
@@ -2,23 +2,25 @@ from user_scanner.core.helpers import get_random_user_agent
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_googleplaystore(user: str) -> Result:
-    url = f"https://play.google.com/store/apps/developer?id={user}"
-    
+    url = "https://play.google.com/store/apps/developer"
+    display_url = f"https://play.google.com/store/apps/developer?id={user}"
+
     headers = {
         "User-Agent": get_random_user_agent(),
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9",
         "Accept-Language": "en-US,en;q=0.9",
     }
-    
+
     try:
-        response = make_request(url, headers=headers, follow_redirects=True)
-        
+        response = make_request(
+            url, params={"id": user}, headers=headers, follow_redirects=True)
+
         if response.status_code == 200:
-            return Result.taken(url=url)
+            return Result.taken(url=display_url)
         elif response.status_code == 404:
-            return Result.available(url=url)
-            
-        return Result.error(f"Unexpected response status: {response.status_code}", url=url)
-        
+            return Result.available(url=display_url)
+
+        return Result.error(f"Unexpected response status: {response.status_code}", url=display_url)
+
     except Exception as e:
-        return Result.error(e, url=url)
+        return Result.error(e, url=display_url)

--- a/user_scanner/user_scan/dev/tryhackme.py
+++ b/user_scanner/user_scan/dev/tryhackme.py
@@ -26,7 +26,7 @@ def validate_tryhackme(user: str) -> Result:
     "Profile not found"}. An existing user returns 200 with
     {"status": "success", "data": {...profile fields...}}.
     """
-    url = f"https://tryhackme.com/api/v2/public-profile?username={user}"
+    url = "https://tryhackme.com/api/v2/public-profile"
     show_url = f"https://tryhackme.com/p/{user}"
 
     def process(response):
@@ -83,4 +83,5 @@ def validate_tryhackme(user: str) -> Result:
         impersonate="chrome",
         show_url=show_url,
         allow_redirects=True,
+        params={"username": user},
     )

--- a/user_scanner/user_scan/email/protonmail.py
+++ b/user_scanner/user_scan/email/protonmail.py
@@ -14,10 +14,8 @@ def validate_protonmail(user: str) -> Result:
     """
 
     # Use the same endpoint described in the issue; keep params explicit.
-    url = (
-        "https://account.proton.me/api/core/v4/users/available"
-        f"?Name={user}%40proton.me&ParseDomain=1"
-    )
+    url = "https://account.proton.me/api/core/v4/users/available"
+    params = {"Name": f"{user}@proton.me", "ParseDomain": "1"}
     show_url = "https://account.proton.me"
 
     headers = {
@@ -43,4 +41,4 @@ def validate_protonmail(user: str) -> Result:
 
         return Result.error(f"Unexpected Proton response code: {code}")
 
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(url, process, show_url=show_url, headers=headers, params=params)

--- a/user_scanner/user_scan/finance/niftygateway.py
+++ b/user_scanner/user_scan/finance/niftygateway.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_niftygateway(user):
-    url = f"https://api.niftygateway.com/user/profile-and-offchain-nifties-by-url/?profile_url={user}"
+    url = "https://api.niftygateway.com/user/profile-and-offchain-nifties-by-url/"
     show_url = f"https://niftygateway.com/profile/{user}"
 
     def process(response):
@@ -32,4 +32,6 @@ def validate_niftygateway(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"profile_url": user}
+    )

--- a/user_scanner/user_scan/gaming/roblox.py
+++ b/user_scanner/user_scan/gaming/roblox.py
@@ -120,9 +120,10 @@ def validate_roblox(user: str) -> Result:
 
     # If rate limited, uses a simple status validation
     return status_validate(
-        f"https://www.roblox.com/user.aspx?username={user}",
+        "https://www.roblox.com/user.aspx",
         404,
         [200, 302],
         show_url="https://roblox.com",
         follow_redirects=True,
+        params={"username": user},
     )

--- a/user_scanner/user_scan/learning/dblp.py
+++ b/user_scanner/user_scan/learning/dblp.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_dblp(user: str) -> Result:
     """Validate an author/researcher username on DBLP (dblp.org)."""
-    url = f"https://dblp.org/search/author/api?q={user}&format=json"
+    url = "https://dblp.org/search/author/api"
     show_url = f"https://dblp.org/search/author?q={user}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -49,4 +49,7 @@ def validate_dblp(user: str) -> Result:
         # 3. Graceful error for unexpected status codes or unhandled responses (No bare else!)
         return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
 
-    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)
+    return generic_validate(
+        url, process, headers=headers, show_url=show_url, follow_redirects=True,
+        params={"q": user, "format": "json"},
+    )

--- a/user_scanner/user_scan/learning/duolingo.py
+++ b/user_scanner/user_scan/learning/duolingo.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_duolingo(user):
-    url = f"https://www.duolingo.com/2017-06-30/users?username={user}"
+    url = "https://www.duolingo.com/2017-06-30/users"
     show_url = f"https://www.duolingo.com/profile/{user}"
 
     def process(response):
@@ -33,4 +33,6 @@ def validate_duolingo(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"username": user}
+    )

--- a/user_scanner/user_scan/learning/openalex.py
+++ b/user_scanner/user_scan/learning/openalex.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_openalex(user: str) -> Result:
     """Validate a researcher/author on OpenAlex (openalex.org)."""
-    url = f"https://api.openalex.org/authors?filter=display_name.search:{user}"
+    url = "https://api.openalex.org/authors"
     show_url = f"https://openalex.org/authors?search={user}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -53,4 +53,7 @@ def validate_openalex(user: str) -> Result:
         # 3. Graceful error for unexpected status codes or unhandled responses (No bare else!)
         return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
 
-    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)
+    return generic_validate(
+        url, process, headers=headers, show_url=show_url, follow_redirects=True,
+        params={"filter": f"display_name.search:{user}"},
+    )

--- a/user_scanner/user_scan/learning/orcid.py
+++ b/user_scanner/user_scan/learning/orcid.py
@@ -5,7 +5,7 @@ from user_scanner.core.result import Result
 
 def validate_orcid(user: str) -> Result:
     """Validate a researcher on ORCID (orcid.org)."""
-    url = f"https://pub.orcid.org/v3.0/expanded-search/?q={user}&start=0&rows=5"
+    url = "https://pub.orcid.org/v3.0/expanded-search/"
     show_url = f"https://orcid.org/orcid-search/search?searchQuery={user}"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -58,4 +58,7 @@ def validate_orcid(user: str) -> Result:
         # 3. Graceful error for unexpected status codes or unhandled responses (No bare else!)
         return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
 
-    return generic_validate(url, process, headers=headers, show_url=show_url, follow_redirects=True)
+    return generic_validate(
+        url, process, headers=headers, show_url=show_url, follow_redirects=True,
+        params={"q": user, "start": 0, "rows": 5},
+    )

--- a/user_scanner/user_scan/music/allthelyrics.py
+++ b/user_scanner/user_scan/music/allthelyrics.py
@@ -1,14 +1,15 @@
 from user_scanner.core.orchestrator import Result, make_request
 
 def validate_allthelyrics(user):
-    url = f"https://www.allthelyrics.com/forum/member.php?username={user}"
+    url = "https://www.allthelyrics.com/forum/member.php"
     show_url = f"https://www.allthelyrics.com/forum/members/{user}.html"
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     }
-    
+
     try:
-        response = make_request(url, headers=headers, follow_redirects=True)
+        response = make_request(
+            url, params={"username": user}, headers=headers, follow_redirects=True)
         html = response.text
         
         if "The server is too busy" in html:

--- a/user_scanner/user_scan/music/yandexmusic.py
+++ b/user_scanner/user_scan/music/yandexmusic.py
@@ -4,16 +4,17 @@ from user_scanner.core.orchestrator import Result, make_request
 
 def validate_yandexmusic(user: str) -> Result:
     url = f"https://music.yandex.ru/users/{user}"
-    api_url = f"https://music.yandex.ru/handlers/library.jsx?owner={user}"
-    
+    api_url = "https://music.yandex.ru/handlers/library.jsx"
+
     headers = {
         "User-Agent": get_random_user_agent(),
         "Referer": f"{url}/playlists",
         "Accept": "application/json",
     }
-    
+
     try:
-        response = make_request(api_url, headers=headers, follow_redirects=True)
+        response = make_request(
+            api_url, params={"owner": user}, headers=headers, follow_redirects=True)
         if response.status_code == 200:
             try:
                 data = response.json()

--- a/user_scanner/user_scan/other/freelancer.py
+++ b/user_scanner/user_scan/other/freelancer.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_freelancer(user):
-    url = f"https://www.freelancer.com/api/users/0.1/users?usernames%5B%5D={user}&compact=true"
+    url = "https://www.freelancer.com/api/users/0.1/users"
     show_url = f"https://www.freelancer.com/u/{user}"
 
     def process(response):
@@ -32,4 +32,7 @@ def validate_freelancer(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers,
+        params={"usernames[]": user, "compact": "true"},
+    )

--- a/user_scanner/user_scan/other/issuu.py
+++ b/user_scanner/user_scan/other/issuu.py
@@ -4,16 +4,26 @@ from user_scanner.core.orchestrator import Result, make_request
 
 def validate_issuu(user: str) -> Result:
     url = f"https://issuu.com/{user}"
-    api_url = f"https://issuu.com/query?format=json&_=3210224608766&profileUsername={user}&action=issuu.user.get_anonymous"
-    
+    api_url = "https://issuu.com/query"
+
     headers = {
         "User-Agent": get_random_user_agent(),
         "Accept": "application/json",
         "Referer": url,
     }
-    
+
     try:
-        response = make_request(api_url, headers=headers, follow_redirects=True)
+        response = make_request(
+            api_url,
+            params={
+                "format": "json",
+                "_": "3210224608766",
+                "profileUsername": user,
+                "action": "issuu.user.get_anonymous",
+            },
+            headers=headers,
+            follow_redirects=True,
+        )
         text = response.text
         
         if response.status_code == 200 and "displayName" in text:

--- a/user_scanner/user_scan/social/fotka.py
+++ b/user_scanner/user_scan/social/fotka.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_fotka(user):
-    url = f"https://api.fotka.com/v2/user/dataStatic?login={user}"
+    url = "https://api.fotka.com/v2/user/dataStatic"
     show_url = f"https://fotka.com/profil/{user}"
 
     def process(response):
@@ -35,4 +35,6 @@ def validate_fotka(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"login": user}
+    )

--- a/user_scanner/user_scan/social/instagram.py
+++ b/user_scanner/user_scan/social/instagram.py
@@ -13,7 +13,7 @@ def validate_instagram(user: str) -> Result:
         )
 
     show_url = f"https://www.instagram.com/{user}/"
-    api_url = f"https://www.instagram.com/api/v1/users/web_profile_info/?username={user}"
+    api_url = "https://www.instagram.com/api/v1/users/web_profile_info/"
 
     headers = {
         "User-Agent": get_random_user_agent(),
@@ -24,7 +24,7 @@ def validate_instagram(user: str) -> Result:
 
     try:
         response = make_request(
-            api_url, headers=headers, http2=True, timeout=10)
+            api_url, params={"username": user}, headers=headers, http2=True, timeout=10)
 
         if response.status_code == 200:
             try:

--- a/user_scanner/user_scan/social/keybase.py
+++ b/user_scanner/user_scan/social/keybase.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_keybase(user):
-    url = f"https://keybase.io/_/api/1.0/user/lookup.json?usernames={user}"
+    url = "https://keybase.io/_/api/1.0/user/lookup.json"
     show_url = f"https://keybase.io/{user}"
 
     def process(response):
@@ -45,4 +45,6 @@ def validate_keybase(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"usernames": user}
+    )

--- a/user_scanner/user_scan/social/mastodon.py
+++ b/user_scanner/user_scan/social/mastodon.py
@@ -16,7 +16,7 @@ def validate_mastodon(user: str) -> Result:
     if not re.match(r"^[a-zA-Z0-9].*[a-zA-Z0-9]$", user):
         return Result.error("Username must start and end with a letter or number")
 
-    url = f"https://mastodon.social/api/v1/accounts/lookup?acct={user}"
+    url = "https://mastodon.social/api/v1/accounts/lookup"
     show_url = f"https://mastodon.social/@{user}"
 
     def process(response):
@@ -50,5 +50,6 @@ def validate_mastodon(user: str) -> Result:
             return Result.error(f"HTTP {response.status_code}")
 
     return generic_validate(
-        url, process, show_url=show_url, follow_redirects=True
+        url, process, show_url=show_url, follow_redirects=True,
+        params={"acct": user},
     )

--- a/user_scanner/user_scan/social/warpcast.py
+++ b/user_scanner/user_scan/social/warpcast.py
@@ -1,7 +1,7 @@
 from user_scanner.core.orchestrator import generic_validate, Result
 
 def validate_warpcast(user):
-    url = f"https://client.warpcast.com/v2/user-by-username?username={user}"
+    url = "https://client.warpcast.com/v2/user-by-username"
     show_url = f"https://warpcast.com/{user}"
 
     def process(response):
@@ -31,4 +31,6 @@ def validate_warpcast(user):
         return Result.error("Unexpected response body, report it via GitHub issues.")
 
     headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0"}
-    return generic_validate(url, process, show_url=show_url, headers=headers)
+    return generic_validate(
+        url, process, show_url=show_url, headers=headers, params={"username": user}
+    )


### PR DESCRIPTION
Fixes #574 (batch 2)

Continuing from #602 (batch 1). Same fix applied to the remaining 26 modules that were building request URLs by interpolating user-controlled values directly into an f-string query parameter instead of using httpx's `params=`.

Changes
Batch 2 of the affected files:

- user_scanner/user_scan/community/disqus.py
- user_scanner/user_scan/creative/civitai.py
- user_scanner/user_scan/creative/px500.py
- user_scanner/user_scan/creator/devto.py
- user_scanner/user_scan/creator/fansly.py
- user_scanner/user_scan/dev/atcoder.py
- user_scanner/user_scan/dev/codeforces.py
- user_scanner/user_scan/dev/gitlab.py
- user_scanner/user_scan/dev/googleplaystore.py
- user_scanner/user_scan/dev/tryhackme.py
- user_scanner/user_scan/email/protonmail.py
- user_scanner/user_scan/finance/niftygateway.py
- user_scanner/user_scan/gaming/roblox.py
- user_scanner/user_scan/learning/dblp.py
- user_scanner/user_scan/learning/duolingo.py
- user_scanner/user_scan/learning/openalex.py
- user_scanner/user_scan/learning/orcid.py
- user_scanner/user_scan/music/allthelyrics.py
- user_scanner/user_scan/music/yandexmusic.py
- user_scanner/user_scan/other/freelancer.py
- user_scanner/user_scan/other/issuu.py
- user_scanner/user_scan/social/fotka.py
- user_scanner/user_scan/social/instagram.py
- user_scanner/user_scan/social/keybase.py
- user_scanner/user_scan/social/mastodon.py
- user_scanner/user_scan/social/warpcast.py

For modules that show a user-facing profile URL (e.g. `googleplaystore.py`), the display URL is kept separate from the request URL, so the display string still reads naturally while the actual outgoing request uses `params=`.

Also updates CONTRIBUTING.md to document the `params=` convention for future contributors, per feedback on #602.

This covers the remaining files from #574 — no more f-string-interpolated user input into request URLs across the codebase after this lands.

Testing
Verified each modified module's actual outgoing request (mocking the underlying transport) to confirm the target is passed via `params` rather than baked into the URL, using inputs with special characters (`&`, `#`, `%`, `+`, whitespace) to confirm no mangling. Full suite passing, `ruff check .` and `mypy user_scanner` clean.