### PR TITLE
feat(email_scan): add Canva, Figma, Atlassian, and Start.me modules

### DIFF
--- a/user_scanner/email_scan/creator/canva.py
+++ b/user_scanner/email_scan/creator/canva.py
@@ -1,0 +1,58 @@
+import json
+
+from user_scanner.core.impersonate import impersonate_request_async
+from user_scanner.core.result import Result
+
+async def _check(email: str) -> Result:
+    url = "https://www.canva.com/_ajax/authnflow/user-authentication-methods"
+    show_url = "https://www.canva.com/"
+
+    headers = {
+        "Referer": "https://www.canva.com/login",
+        "X-Requested-With": "XMLHttpRequest",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/plain, */*",
+    }
+
+    payload = {
+        "C": "Linux / Chrome",
+        "A?": "E",
+        "L": email,
+    }
+
+    try:
+        response = await impersonate_request_async(
+            url, "POST", data=json.dumps(payload), headers=headers, impersonate="chrome120"
+        )
+
+        if response.status_code == 403:
+            return Result.error("Access forbidden / WAF blocked (403)")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Canva (429)")
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status (HTTP {response.status_code})")
+
+        raw_text = response.text
+        start_idx = raw_text.find("{")
+        end_idx = raw_text.rfind("}")
+        if start_idx == -1 or end_idx == -1:
+            return Result.error("Invalid JSON response from Canva")
+
+        data = json.loads(raw_text[start_idx : end_idx + 1])
+        action_type = data.get("B", {}).get("A?")
+
+        # Action "A" corresponds to Login / Authenticate for existing users
+        if action_type == "A":
+            return Result.taken(url=show_url)
+
+        # Action "B" corresponds to Sign up / Create account for new users
+        if action_type == "B":
+            return Result.available(url=show_url)
+
+        return Result.error("Unknown response payload format")
+
+    except Exception as e:
+        return Result.error(str(e))
+
+async def validate_canva(email: str) -> Result:
+    return await _check(email)

--- a/user_scanner/email_scan/creator/figma.py
+++ b/user_scanner/email_scan/creator/figma.py
@@ -1,0 +1,49 @@
+import urllib.parse
+
+from user_scanner.core.impersonate import impersonate_request_async
+from user_scanner.core.result import Result
+
+async def _check(email: str) -> Result:
+    encoded_email = urllib.parse.quote(email)
+    url = f"https://www.figma.com/api/session/available_auth_methods?email={encoded_email}&form_intent=sign_up"
+    show_url = "https://www.figma.com/"
+
+    headers = {
+        "Referer": "https://www.figma.com/signup",
+        "Accept": "application/json, text/plain, */*",
+    }
+
+    try:
+        response = await impersonate_request_async(
+            url, "GET", headers=headers, impersonate="chrome120"
+        )
+
+        if response.status_code == 403:
+            return Result.error("Access forbidden / WAF blocked (403)")
+        if response.status_code == 429:
+            return Result.error("Rate limited by Figma (429)")
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status (HTTP {response.status_code})")
+
+        data = response.json()
+        if data.get("error") is True:
+            return Result.error(f"Figma API returned error: {data.get('message')}")
+
+        meta = data.get("meta", {})
+        available_methods = meta.get("available_methods", [])
+
+        # When the user is already registered, "sign_in" is listed in available_methods
+        if "sign_in" in available_methods:
+            return Result.taken(url=show_url)
+
+        # When the user is not registered, "sign_up" is listed in available_methods
+        if "sign_up" in available_methods:
+            return Result.available(url=show_url)
+
+        return Result.error("Unknown response payload format")
+
+    except Exception as e:
+        return Result.error(str(e))
+
+async def validate_figma(email: str) -> Result:
+    return await _check(email)

--- a/user_scanner/email_scan/dev/atlassian.py
+++ b/user_scanner/email_scan/dev/atlassian.py
@@ -1,0 +1,59 @@
+import json
+
+from user_scanner.core.impersonate import impersonate_request_async
+from user_scanner.core.result import Result
+
+
+async def validate_atlassian(email: str) -> Result:
+    """Validate whether an email is registered on Atlassian (Jira, Confluence, Bitbucket, Trello)."""
+    url = "https://id.atlassian.com/rest/check-username"
+    show_url = "https://id.atlassian.com"
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Referer": "https://id.atlassian.com/login",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    payload = json.dumps({"username": email})
+
+    try:
+        response = await impersonate_request_async(
+            url,
+            method="POST",
+            data=payload,
+            headers=headers,
+            impersonate="chrome",
+        )
+
+        if response.status_code == 403:
+            return Result.error("Caught by WAF (403)", url=show_url)
+
+        if response.status_code == 429:
+            return Result.error("Rate limited by Atlassian (429)", url=show_url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+        data = response.json()
+        if not isinstance(data, dict):
+            return Result.error("Unexpected response body format", url=show_url)
+
+        action = data.get("action")
+        if action == "signup":
+            return Result.available(url=show_url)
+
+        if action in ("no_action", "redirect"):
+            extra = {}
+            if action == "redirect":
+                extra["auth_type"] = "SSO / SAML"
+                if redirect_type := data.get("redirect_type"):
+                    extra["sso_type"] = redirect_type
+            elif action == "no_action":
+                extra["auth_type"] = "Password / Social"
+
+            return Result.taken(extra=extra, url=show_url)
+
+        return Result.error(f"Unknown action response: {action}", url=show_url)
+
+    except Exception as e:
+        return Result.error(f"Unexpected exception: {e}", url=show_url)

--- a/user_scanner/email_scan/other/start_me.py
+++ b/user_scanner/email_scan/other/start_me.py
@@ -1,0 +1,49 @@
+from user_scanner.core.impersonate import impersonate_request_async
+from user_scanner.core.result import Result
+
+
+async def validate_start_me(email: str) -> Result:
+    """Validate whether an email is registered on Start.me (start.me)."""
+    url = f"https://start.me/users/check_email?email={email}"
+    show_url = "https://start.me"
+    headers = {
+        "Accept": "application/json",
+        "Referer": "https://start.me/users/sign_up",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+
+    try:
+        response = await impersonate_request_async(
+            url,
+            method="GET",
+            headers=headers,
+            impersonate="chrome",
+        )
+
+        if response.status_code == 403:
+            return Result.error("Caught by Cloudflare WAF (403)", url=show_url)
+
+        if response.status_code == 429:
+            return Result.error("Rate limited by Start.me (429)", url=show_url)
+
+        if response.status_code != 200:
+            return Result.error(f"Unexpected response status: {response.status_code}", url=show_url)
+
+        data = response.json()
+        if not isinstance(data, dict):
+            return Result.error("Unexpected response body format", url=show_url)
+
+        exists = data.get("exists")
+        if exists is True:
+            extra = {}
+            if data.get("locked") is True:
+                extra["account_locked"] = True
+            return Result.taken(extra=extra, url=show_url)
+
+        if exists is False:
+            return Result.available(url=show_url)
+
+        return Result.error("Missing 'exists' key in Start.me response", url=show_url)
+
+    except Exception as e:
+        return Result.error(f"Unexpected exception: {e}", url=show_url)


### PR DESCRIPTION
## Summary

Adds 4 new `email_scan` modules:

1. **Canva** (`user_scanner/email_scan/creator/canva.py`):
   - Reverse-engineered authentication flow endpoint: `POST https://www.canva.com/_ajax/authnflow/user-authentication-methods`
   - Deterministic Action: `"A"` (Login/Password $\rightarrow$ `Taken`), `"B"` (Signup $\rightarrow$ `Available`).

2. **Figma** (`user_scanner/email_scan/creator/figma.py`):
   - Available auth methods lookup: `GET https://www.figma.com/api/session/available_auth_methods?email={email}&form_intent=sign_up`
   - Deterministic method: `"sign_in"` in `available_methods` $\rightarrow$ `Taken`, `"sign_up"` in `available_methods` $\rightarrow$ `Available`.

3. **Atlassian** (`user_scanner/email_scan/dev/atlassian.py`):
   - Account identifier check across Jira, Confluence, Bitbucket, and Trello: `POST https://id.atlassian.com/rest/check-username`
   - Deterministic Action: `"no_action"` / `"redirect"` $\rightarrow$ `Taken`, `"signup"` $\rightarrow$ `Available`.

4. **Start.me** (`user_scanner/email_scan/other/start_me.py`):
   - Live email validation endpoint: `GET https://start.me/users/check_email?email={email}`
   - Deterministic flag: `"exists": true` $\rightarrow$ `Taken`, `"exists": false` $\rightarrow$ `Available`.
