### PR TITLE
fix(email_scan): tolerate attributes on screener's errorlist markup

### DIFF
--- a/user_scanner/email_scan/other/screener.py
+++ b/user_scanner/email_scan/other/screener.py
@@ -2,6 +2,16 @@ import httpx
 import re
 from user_scanner.core.result import Result
 
+# screener.in renders its "field required" error with Django's errorlist markup.
+# Django now emits an id on that <ul> (id="id_<field>_error"), so the previous
+# exact-tag string match stopped matching and every address fell through to the
+# "unexpected response body structure" error. Match on the class and the message
+# it wraps instead, so the check survives further attribute changes.
+_REQUIRED_FIELD_ERROR = re.compile(
+    r'<ul[^>]*\sclass="[^"]*\berrorlist\b[^"]*"[^>]*>\s*<li>\s*This field is required\.\s*</li>',
+    re.IGNORECASE,
+)
+
 
 async def _check(email: str) -> Result:
     url = "https://www.screener.in/register/"
@@ -65,7 +75,7 @@ async def _check(email: str) -> Result:
             if "User account with this Email already exists" in res_text:
                 return Result.taken(url=show_url)
 
-            if '<ul class="errorlist"><li>This field is required.</li>' in res_text:
+            if _REQUIRED_FIELD_ERROR.search(res_text):
                 return Result.available(url=show_url)
 
             return Result.error("Unexpected response body structure, report it via GitHub issues")


### PR DESCRIPTION
Fixes #611

`email_scan/other/screener.py` returned `Unexpected response body structure` for every address, because the availability check matched the Django error list by exact tag text:

```python
if '<ul class="errorlist"><li>This field is required.</li>' in res_text:
```

screener.in now renders that list with an id:

```html
<ul class="errorlist" id="id_password_error"><li>This field is required.</li></ul>
```

`<ul class="errorlist"` is no longer immediately followed by `>`, so the substring test fails and every scan falls through to the error branch.

## Fix

Match the tag by its class and the message it wraps, rather than verbatim:

```python
_REQUIRED_FIELD_ERROR = re.compile(
    r'<ul[^>]*\sclass="[^"]*\berrorlist\b[^"]*"[^>]*>\s*<li>\s*This field is required\.\s*</li>',
    re.IGNORECASE,
)
```

This is slightly broader than the regex suggested in the issue: it also tolerates **attribute reordering** (`<ul id="..." class="errorlist">`), **extra classes** (`class="errorlist nonfield"`), and **pretty-printed whitespace** between the `<ul>` and its `<li>` — so the next markup change doesn't reopen this.

It stays narrow in the ways that matter: the message text is still required, and the `errorlist` class is matched with `\b` boundaries, so a different error (`Enter a valid email address.`) or a different list (`class="helptext"`) is not read as available.

The `taken` branch matches plain text (`User account with this Email already exists`) and is untouched.

## Verification

Live against screener.in, with an unregistered address:

```
before:  [!] Screener: Error (Unexpected response body structure, report it via GitHub issues)
after:   [✘] Screener: Not Registered
```

Local gates from AGENTS.md, all clean:

```
ruff check .        All checks passed!
mypy user_scanner   Success: no issues found in 529 source files
pytest              380 passed, 3 skipped
```

Note on the `taken` path: I verified the `available` path live, but didn't probe a real registered account to exercise `taken`, since that means testing against someone's actual email. That branch isn't touched by this diff — happy to confirm it another way if you'd prefer.

I did initially write a mocked regression test for the marker, then dropped it after re-reading AGENTS.md ("Do not add unit tests for individual scan modules"). Let me know if a test would be welcome here as an exception, since this is a detection-regression rather than a new module — I have it ready.
