### PR TITLE
fix(stackb): tolerate reordered and attributed markup

### DIFF
--- a/user_scanner/email_scan/gaming/stackb.py
+++ b/user_scanner/email_scan/gaming/stackb.py
@@ -34,7 +34,7 @@ async def _check(email: str) -> Result:
                 login_response.text,
             )
             snapshot_match = re.search(
-                r'<div wire:snapshot="([^"]+)"[^>]*wire:id="[^"]+"'
+                r'<div[^>]*wire:snapshot="([^"]+)"'
                 r'[^>]*x-data="loginFormCaptcha',
                 login_response.text,
             )

--- a/user_scanner/user_scan/gaming/stackb.py
+++ b/user_scanner/user_scan/gaming/stackb.py
@@ -27,7 +27,7 @@ def validate_stackb(user: str) -> Result:
         login_text = login_response.text
         csrf_match = re.search(r'<meta name="csrf-token" content="([^"]+)"', login_text)
         snapshot_match = re.search(
-            r'<div wire:snapshot="([^"]+)"[^>]*wire:id="([^"]+)"[^>]*x-data="loginFormCaptcha',
+            r'<div[^>]*wire:snapshot="([^"]+)"[^>]*x-data="loginFormCaptcha',
             login_text,
         )
         if not csrf_match or not snapshot_match:
@@ -98,7 +98,7 @@ def validate_stackb(user: str) -> Result:
             )
             response_text = profile_response.text
             profile = {}
-            for json_match in re.finditer(r'<script type="application/ld\+json">(.*?)</script>', response_text, re.DOTALL):
+            for json_match in re.finditer(r'<script[^>]*type="application/ld\+json"[^>]*>(.*?)</script>', response_text, re.DOTALL):
                 try:
                     data = json.loads(html.unescape(json_match.group(1)))
                 except json.JSONDecodeError:


### PR DESCRIPTION
- Relax StackB login and profile HTML parsing in email and username modules

A recent (possibly today's) change broke the username and email modules.