### PR TITLE
feat: add Leanpub email and username modules

### DIFF
--- a/user_scanner/email_scan/creator/leanpub.py
+++ b/user_scanner/email_scan/creator/leanpub.py
@@ -1,0 +1,67 @@
+import html
+import re
+
+import httpx
+
+from user_scanner.core.result import Result
+
+_REGISTRATION_URL = "https://leanpub.com/authors/create/book"
+# Leanpub's default publisher; this decodes to gid://leanpub/Org::Publisher/1.
+_PUBLISHER_ID = "Z2lkOi8vbGVhbnB1Yi9Pcmc6OlB1Ymxpc2hlci8x"
+_ENGLISH_ID = "Z2lkOi8vbGVhbnB1Yi9TaGFyZWQ6Okxhbmd1YWdlLzEyNA"
+_PASSWORD_ERROR = (
+    "Password must be at least 8 characters long, be no longer than 140 "
+    "characters, contain at least one letter, and contain at least one "
+    "non-letter character."
+)
+_EMAIL_TAKEN = (
+    "Email This email address can not be used to create a new account. "
+    "If this is your email address, try signing in instead."
+)
+
+
+async def validate_leanpub(email: str) -> Result:
+    """Probe registration without creating an account or sending email."""
+    show_url = "https://leanpub.com"
+    try:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+            response = await client.post(
+                _REGISTRATION_URL,
+                data={
+                    "title": "Email availability probe",
+                    "publisherId": _PUBLISHER_ID,
+                    "slug": "user-scanner-email-probe",
+                    "languageId": _ENGLISH_ID,
+                    "syncMode": "lexical",
+                    "name": "Email Probe",
+                    "username": "user-scanner-email-probe",
+                    "email": email,
+                    "password": "x",  # Intentionally too short; creation is impossible.
+                },
+            )
+    except httpx.HTTPError as exc:
+        return Result.error(exc, url=show_url)
+
+    if response.status_code != 200 or _PASSWORD_ERROR not in response.text:
+        return Result.error(
+            f"Unexpected Leanpub registration response: {response.status_code}",
+            url=show_url,
+        )
+
+    email_input = re.search(
+        r'<input\b(?=[^>]*\bname="email")[^>]*>', response.text, re.IGNORECASE
+    )
+    email_tag = email_input.group() if email_input else ""
+    value = re.search(r'\bvalue="([^"]*)"', email_tag, re.IGNORECASE)
+    if not value or html.unescape(value.group(1)).casefold() != email.casefold():
+        return Result.error("Leanpub did not echo the requested email", url=show_url)
+
+    if _EMAIL_TAKEN in response.text:
+        return Result.taken(url=show_url)
+
+    if 'aria-invalid="true"' not in email_tag:
+        return Result.available(url=show_url)
+
+    return Result.error(
+        "Leanpub returned an unknown email validation error", url=show_url
+    )

--- a/user_scanner/user_scan/creator/leanpub.py
+++ b/user_scanner/user_scan/creator/leanpub.py
@@ -1,0 +1,121 @@
+import html
+import json
+import re
+from urllib.parse import quote, unquote, urlsplit
+
+from user_scanner.core.orchestrator import generic_validate
+from user_scanner.core.result import Result
+
+_REGISTRATION_URL = "https://leanpub.com/authors/create/book"
+# Leanpub's default publisher; this decodes to gid://leanpub/Org::Publisher/1.
+_PUBLISHER_ID = "Z2lkOi8vbGVhbnB1Yi9Pcmc6OlB1Ymxpc2hlci8x"
+_ENGLISH_ID = "Z2lkOi8vbGVhbnB1Yi9TaGFyZWQ6Okxhbmd1YWdlLzEyNA"
+_PASSWORD_ERROR = (
+    "Password must be at least 8 characters long, be no longer than 140 "
+    "characters, contain at least one letter, and contain at least one "
+    "non-letter character."
+)
+_USERNAME_TAKEN = "Username has already been taken"
+_PROFILE = re.compile(
+    r'<script\b[^>]*\btype=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def validate_leanpub(user: str) -> Result:
+    profile_url = f"https://leanpub.com/u/{quote(user, safe='')}"
+
+    def process(response):
+        if response.status_code != 200 or _PASSWORD_ERROR not in response.text:
+            return Result.error(
+                f"Unexpected Leanpub registration response: {response.status_code}"
+            )
+
+        username_input = re.search(
+            r'<input\b(?=[^>]*\bname="username")[^>]*>',
+            response.text,
+            re.IGNORECASE,
+        )
+        value = (
+            re.search(r'\bvalue="([^"]*)"', username_input.group(), re.IGNORECASE)
+            if username_input
+            else None
+        )
+        if not value or html.unescape(value.group(1)) != user:
+            return Result.error("Leanpub did not echo the requested username")
+
+        if _USERNAME_TAKEN in response.text:
+            enrichment = generic_validate(
+                profile_url,
+                lambda profile_response: _profile_result(profile_response, user),
+                follow_redirects=True,
+            )
+            return enrichment if enrichment.extra else Result.taken()
+
+        if 'aria-invalid="true"' not in username_input.group():
+            return Result.available()
+
+        return Result.error("Leanpub returned an unknown username validation error")
+
+    return generic_validate(
+        _REGISTRATION_URL,
+        process,
+        method="POST",
+        data={
+            "title": "Username availability probe",
+            "publisherId": _PUBLISHER_ID,
+            "slug": "user-scanner-username-probe",
+            "languageId": _ENGLISH_ID,
+            "syncMode": "lexical",
+            "name": "Username Probe",
+            "username": user,
+            "email": "user-scanner@example.com",
+            "password": "x",  # Intentionally invalid; the probe cannot create an account.
+        },
+        show_url=profile_url,
+        follow_redirects=True,
+    )
+
+
+def _profile_result(response, user: str) -> Result:
+    if response.status_code != 200:
+        return Result.error(f"Unexpected profile response: {response.status_code}")
+
+    profile = None
+    books = None
+    for block in _PROFILE.findall(response.text):
+        try:
+            data = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        if data.get("@type") == "Person":
+            profile = data
+        elif data.get("@type") == "ItemList" and str(data.get("@id", "")).endswith(
+            "#books"
+        ):
+            books = data
+
+    if profile is None:
+        return Result.error("Leanpub profile markers were missing")
+
+    parsed_url = urlsplit(str(profile.get("url", "")))
+    username = unquote(parsed_url.path.rstrip("/").rsplit("/", 1)[-1])
+    if parsed_url.hostname != "leanpub.com" or username.casefold() != user.casefold():
+        return Result.error("Leanpub profile did not match the requested username")
+
+    book_count = books.get("numberOfItems") if books else None
+    if type(book_count) is not int or book_count < 0:
+        book_count = None
+
+    return Result.taken(
+        extra={
+            "username": username,
+            "name": profile.get("name"),
+            "bio": profile.get("description"),
+            "social_links": profile.get("sameAs") or None,
+            "book_count": book_count,
+        },
+        media={"avatar": profile.get("image")},
+    )


### PR DESCRIPTION
Username and email modules for the self-publishing site Leanpub. Uses the book creation endpoint, which also registers an account, but is not protected by a captcha, unlike the dedicated registration endpoint. An account is never actually created as the provided password does not match the requirements.