### PR TITLE
fix(user_scan): reject dotted Ko-fi usernames

### DIFF
--- a/user_scanner/user_scan/donation/kofi.py
+++ b/user_scanner/user_scan/donation/kofi.py
@@ -10,6 +10,8 @@ def _text(value: str) -> str:
 
 def validate_kofi(user: str) -> Result:
     url = f"https://ko-fi.com/{user}"
+    if "." in user:
+        return Result.available("Username cannot contain periods", url=url)
 
     def process(response):
         if response.status_code != 200:


### PR DESCRIPTION
Ko-fi does not allow dots in its usernames and the profile page only treats the part after the first dot as the username, producing false positives in the module. Random test case: https://ko-fi.com/klickpin.fgfggfdfgdgrfdg