### PR TITLE
feat: add Rumble new username module, rename current module to rumble_channel

### DIFF
--- a/user_scanner/user_scan/creator/rumble.py
+++ b/user_scanner/user_scan/creator/rumble.py
@@ -20,7 +20,10 @@ IMAGE_RE = re.compile(
     r'class="channel-header--(img|backsplash-img)"[^>]+src="([^"]+)"',
     re.IGNORECASE,
 )
-NOT_FOUND_MARKER = "<title>404 Not found</title>"
+NOT_FOUND_MARKERS = {
+    404: "<title>404 Not found</title>",
+    410: "<title>410 Gone</title>",
+}
 SOCIAL_RE = re.compile(r'<a href="([^"]+)" class="channel-subheader--socials-item"')
 STAT_RE = re.compile(r"([\d,]+)\s+(views|videos)\s*</p>", re.IGNORECASE)
 VERIFIED_RE = re.compile(r'<svg class="channel-header--verified\b')
@@ -31,19 +34,23 @@ def validate_rumble(user: str) -> Result:
     url = f"https://rumble.com/user/{quote(user, safe='')}"
 
     def process(response):
-        if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
+        marker = NOT_FOUND_MARKERS.get(response.status_code)
+        if marker and marker in response.text:
             return Result.available()
 
         if response.status_code != 200:
             return Result.error(f"Unexpected response status: {response.status_code}")
 
         canonical = CANONICAL_RE.search(response.text)
-        if not canonical or canonical.group(1).casefold() != url.casefold():
-            return Result.error("Canonical URL does not match the requested Rumble user")
+        creator_id = re.search(r'"creator_id":\s*"(\d+)"', response.text)
+        if (
+            not canonical
+            or canonical.group(1).casefold() != str(response.url).casefold()
+            or not creator_id
+        ):
+            return Result.error("Rumble user markers do not match the response")
 
-        extra = {}
-        if creator_id := re.search(r'"creator_id":\s*"(\d+)"', response.text):
-            extra["creator_id"] = creator_id.group(1)
+        extra = {"creator_id": creator_id.group(1)}
 
         profile = {}
         profile_start = re.search(

--- a/user_scanner/user_scan/creator/rumble_channel.py
+++ b/user_scanner/user_scan/creator/rumble_channel.py
@@ -20,18 +20,21 @@ IMAGE_RE = re.compile(
     r'class="channel-header--(img|backsplash-img)"[^>]+src="([^"]+)"',
     re.IGNORECASE,
 )
-NOT_FOUND_MARKER = "<title>404 Not found</title>"
 SOCIAL_RE = re.compile(r'<a href="([^"]+)" class="channel-subheader--socials-item"')
 STAT_RE = re.compile(r"([\d,]+)\s+(views|videos)\s*</p>", re.IGNORECASE)
+TITLE_RE = re.compile(r"<title>([^<]*)</title>", re.IGNORECASE)
 VERIFIED_RE = re.compile(r'<svg class="channel-header--verified\b')
 
 
-def validate_rumble(user: str) -> Result:
-    """Validate a Rumble user account."""
-    url = f"https://rumble.com/user/{quote(user, safe='')}"
+def validate_rumble_channel(user: str) -> Result:
+    """Validate a Rumble channel."""
+    url = f"https://rumble.com/c/{quote(user, safe='')}"
 
     def process(response):
-        if response.status_code == 404 and NOT_FOUND_MARKER in response.text:
+        title_match = TITLE_RE.search(response.text)
+        title = html.unescape(title_match.group(1)).strip() if title_match else ""
+
+        if response.status_code == 404 and title.casefold() == "404 not found":
             return Result.available()
 
         if response.status_code != 200:
@@ -39,15 +42,17 @@ def validate_rumble(user: str) -> Result:
 
         canonical = CANONICAL_RE.search(response.text)
         if not canonical or canonical.group(1).casefold() != url.casefold():
-            return Result.error("Canonical URL does not match the requested Rumble user")
+            return Result.error("Canonical URL does not match the requested Rumble channel")
 
-        extra = {}
+        extra = {"name": title}
         if creator_id := re.search(r'"creator_id":\s*"(\d+)"', response.text):
             extra["creator_id"] = creator_id.group(1)
+        if channel_id := re.search(r'"channel_id":\s*"(\d+)"', response.text):
+            extra["channel_id"] = channel_id.group(1)
 
         profile = {}
         profile_start = re.search(
-            rf'\{{"type":"user","url":"{re.escape(canonical.group(1))}"',
+            rf'\{{"type":"channel","url":"{re.escape(canonical.group(1))}"',
             response.text,
             re.IGNORECASE,
         )

--- a/user_scanner/user_scan/creator/rumble_channel.py
+++ b/user_scanner/user_scan/creator/rumble_channel.py
@@ -20,6 +20,7 @@ IMAGE_RE = re.compile(
     r'class="channel-header--(img|backsplash-img)"[^>]+src="([^"]+)"',
     re.IGNORECASE,
 )
+NOT_FOUND_TITLES = {404: "404 not found", 410: "410 gone"}
 SOCIAL_RE = re.compile(r'<a href="([^"]+)" class="channel-subheader--socials-item"')
 STAT_RE = re.compile(r"([\d,]+)\s+(views|videos)\s*</p>", re.IGNORECASE)
 TITLE_RE = re.compile(r"<title>([^<]*)</title>", re.IGNORECASE)
@@ -34,21 +35,28 @@ def validate_rumble_channel(user: str) -> Result:
         title_match = TITLE_RE.search(response.text)
         title = html.unescape(title_match.group(1)).strip() if title_match else ""
 
-        if response.status_code == 404 and title.casefold() == "404 not found":
+        if title.casefold() == NOT_FOUND_TITLES.get(response.status_code):
             return Result.available()
 
         if response.status_code != 200:
             return Result.error(f"Unexpected response status: {response.status_code}")
 
         canonical = CANONICAL_RE.search(response.text)
-        if not canonical or canonical.group(1).casefold() != url.casefold():
-            return Result.error("Canonical URL does not match the requested Rumble channel")
+        creator_id = re.search(r'"creator_id":\s*"(\d+)"', response.text)
+        channel_id = re.search(r'"channel_id":\s*"(\d+)"', response.text)
+        if (
+            not canonical
+            or canonical.group(1).casefold() != str(response.url).casefold()
+            or not creator_id
+            or not channel_id
+        ):
+            return Result.error("Rumble channel markers do not match the response")
 
-        extra = {"name": title}
-        if creator_id := re.search(r'"creator_id":\s*"(\d+)"', response.text):
-            extra["creator_id"] = creator_id.group(1)
-        if channel_id := re.search(r'"channel_id":\s*"(\d+)"', response.text):
-            extra["channel_id"] = channel_id.group(1)
+        extra = {
+            "name": title,
+            "creator_id": creator_id.group(1),
+            "channel_id": channel_id.group(1),
+        }
 
         profile = {}
         profile_start = re.search(


### PR DESCRIPTION
Rumble has two namespaces for usernames: users and channels, and channels don't necessarily need to be owned by an user with the same name. For example, https://rumble.com/c/ChadPrather is owned by an user different than https://rumble.com/user/chadprather (can be confirmed by comparing `creator_id` fields in module outputs). This PR adds support for both, renaming the current rumble module to rumble_channel and adding a new rumble module for users. It also adds additional enrichments to both modules.