### PR TITLE
fix(user_scan): reject false-positive username checks in PH and mssg.me modules

### DIFF
--- a/user_scanner/user_scan/adult/pornhub.py
+++ b/user_scanner/user_scan/adult/pornhub.py
@@ -1,65 +1,43 @@
-import re
 import html
+import re
 
-from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.impersonate import impersonate_validate
 from user_scanner.core.result import Result
-
-BASE_URL = "https://www.pornhub.com"
 
 
 def validate_pornhub(user):
-    url = f"{BASE_URL}/users/{user}"
-    show_url = url
+    url = f"https://www.pornhub.com/users/{user}"
 
     def process(response):
-        if response.status_code == 404:
-            return Result.available(url=show_url)
-
-        # A vanity handle that resolves to a real profile — a renamed handle
-        # (/users/<id>) or a promoted model/pornstar page — 301-redirects; a
-        # genuinely missing user just 404s. The target namespace tells us the
-        # account type, and we follow it to enrich the metadata.
-        if response.status_code in (301, 302):
-            location = response.headers.get("location", "")
-            account_type = _account_type(location)
-            if account_type:
-                return Result.taken(extra={"type": account_type, **_follow(location)}, url=show_url)
-            return Result.error(f"Unexpected redirect: {location}", url=show_url)
+        if (
+            response.status_code == 404
+            and "Error Page Not Found" in response.text
+        ):
+            return Result.available()
 
         if response.status_code != 200:
-            return Result.error(f"Unexpected status: {response.status_code}", url=show_url)
+            return Result.error(f"Unexpected status: {response.status_code}")
 
-        # A direct 200 on /users/<name> is always a viewer account (models and
-        # pornstars redirect); the not-found page is titled "Page Not Found".
-        if "profile - pornhub" in _title(response.text).lower():
-            return Result.taken(extra={"type": "viewer", **_extract_profile(response.text)}, url=show_url)
+        account_type = _account_type(str(response.url))
+        extra = _extract_profile(response.text)
+        confirmed = (
+            account_type in ("viewer", "model", "pornstar") and "name" in extra
+            or account_type == "channel"
+            and "xxx videos" in _title(response.text).lower()
+        )
+        if confirmed:
+            return Result.taken(extra={"type": account_type, **extra})
 
-        return Result.error("Profile confirmation not found", url=show_url)
+        return Result.error("Profile confirmation not found")
 
-    return impersonate_validate(url, process, show_url=show_url)
+    return impersonate_validate(url, process, allow_redirects=True)
 
 
 def _account_type(location: str) -> str | None:
-    # Map the redirect target's namespace to an account type; None means the
-    # redirect is not a recognised profile path.
-    for namespace, label in (("pornstar", "pornstar"), ("model", "model"),
-                             ("channels", "channel"), ("users", "viewer")):
-        if re.search(rf"/{namespace}/", location, re.IGNORECASE):
-            return label
+    if match := re.search(r"/(pornstar|model|channels|users)/", location, re.IGNORECASE):
+        namespace = match.group(1).lower()
+        return {"channels": "channel", "users": "viewer"}.get(namespace, namespace)
     return None
-
-
-def _follow(location: str) -> dict:
-    # Model/pornstar pages hold far richer metadata than the viewer profile that
-    # redirected here; the enrichment is best-effort and never fatal.
-    url = location if location.startswith("http") else BASE_URL + location
-    try:
-        response = impersonate_request(url, allow_redirects=True)
-        if response.status_code != 200:
-            return {}
-        return _extract_profile(response.text)
-    except Exception:
-        return {}
 
 
 def _extract_profile(html_text: str) -> dict:

--- a/user_scanner/user_scan/social/mssg_me.py
+++ b/user_scanner/user_scan/social/mssg_me.py
@@ -4,19 +4,21 @@ from user_scanner.core.result import Result
 
 def validate_mssg_me(user: str) -> Result:
     url = f"https://mssg.me/{user}"
-    show_url = f"https://mssg.me/{user}"
 
     def process(r):
-        # Claimed user redirects to a subdomain, but since we set follow_redirects=False,
-        # it returns 302 Found (or 301, 307). Unclaimed user returns 404.
-        if r.status_code == 404:
+        # Missing handles end on the site's explicit 404 template.
+        if r.status_code == 404 and 'id="page_404"' in r.text:
             return Result.available()
 
-        if r.status_code in (200, 301, 302, 307, 308):
+        # Reserved routes use the main site's manifest, not a profile.
+        if r.status_code == 200 and 'href="/manifest.webmanifest"' in r.text:
+            return Result.available()
+
+        # Published profiles use a separate profile-page manifest.
+        if r.status_code == 200 and 'href="/favicons/site.webmanifest"' in r.text:
             return Result.taken()
 
-        return Result.error(f"HTTP {r.status_code}")
+        # Blocks and template changes must not become verdicts.
+        return Result.error(f"Unexpected response: HTTP {r.status_code}")
 
-    return generic_validate(
-        url, process, show_url=show_url, follow_redirects=False
-    )
+    return generic_validate(url, process, show_url=url, follow_redirects=True)


### PR DESCRIPTION
These two modules suffered from false positives with inputs that contained upper-case characters - the sites redirected to the lower-case version of the route, which the modules considered a signal that an account exists.

>  Checking username: Testgdfgdfg
> 
> == SOCIAL SITES ==
>   [✔] Mssg.me [https://mssg.me/Testgdfgdfg] (Testgdfgdfg): Found
> 
> == ADULT SITES ==
>   [✔] Pornhub [https://www.pornhub.com/users/Testgdfgdfg] (Testgdfgdfg): Found
>       └── type: viewer