### PR TITLE
feat: add Threadless email and username modules

### DIFF
--- a/user_scanner/email_scan/creator/threadless.py
+++ b/user_scanner/email_scan/creator/threadless.py
@@ -1,0 +1,55 @@
+"""Threadless email registration check via the public Artist Shops signup form."""
+
+import re
+
+from curl_cffi.requests.exceptions import RequestException
+
+from user_scanner.core.impersonate import impersonate_request_async
+from user_scanner.core.result import Result
+
+SIGNUP_URL = "https://profile.threadless.com/artist/shops/"
+CSRF_RE = re.compile(r"name=['\"]csrfmiddlewaretoken['\"]\s+value=['\"]([^'\"]+)")
+
+
+async def validate_threadless(email: str) -> Result:
+    """Check Threadless without creating an account or sending email."""
+    show_url = "https://www.threadless.com"
+
+    try:
+        page = await impersonate_request_async(SIGNUP_URL, allow_redirects=True)
+        token = CSRF_RE.search(page.text)
+        if page.status_code != 200 or not token:
+            return Result.error(
+                f"Could not read Threadless signup form (HTTP {page.status_code})",
+                url=show_url,
+            )
+
+        response = await impersonate_request_async(
+            SIGNUP_URL,
+            "POST",
+            headers={"x-requested-with": "XMLHttpRequest"},
+            data={
+                "validate": "true",
+                "email": email,
+                "csrfmiddlewaretoken": token.group(1),
+            },
+        )
+        if response.status_code != 200:
+            return Result.error(
+                f"Unexpected Threadless response: HTTP {response.status_code}",
+                url=show_url,
+            )
+
+    except RequestException as exc:
+        return Result.error(exc, url=show_url)
+
+    try:
+        data = response.json()
+    except ValueError:
+        return Result.error("Invalid Threadless response", url=show_url)
+
+    if data.get("is_valid") is False:
+        return Result.taken(url=show_url)
+    if data.get("is_valid") is True:
+        return Result.available(url=show_url)
+    return Result.error("Unexpected Threadless response", url=show_url)

--- a/user_scanner/user_scan/creator/threadless.py
+++ b/user_scanner/user_scan/creator/threadless.py
@@ -1,0 +1,140 @@
+import html
+import re
+from urllib.parse import quote, urljoin
+
+from curl_cffi.requests.exceptions import RequestException
+
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.result import Result
+
+SIGNUP_URL = "https://profile.threadless.com/artist/shops/"
+CSRF_RE = re.compile(r"name=['\"]csrfmiddlewaretoken['\"]\s+value=['\"]([^'\"]+)")
+
+
+def validate_threadless(user: str) -> Result:
+    show_url = f"https://www.threadless.com/@{user}"
+
+    def process(page):
+        token = CSRF_RE.search(page.text)
+        if page.status_code != 200 or not token:
+            return Result.error(
+                f"Could not read Threadless signup form (HTTP {page.status_code})"
+            )
+
+        response = impersonate_request(
+            SIGNUP_URL,
+            "POST",
+            headers={"x-requested-with": "XMLHttpRequest"},
+            data={
+                "validate": "true",
+                "username": user,
+                "csrfmiddlewaretoken": token.group(1),
+            },
+        )
+        if response.status_code != 200:
+            return Result.error(
+                f"Unexpected Threadless response: HTTP {response.status_code}"
+            )
+
+        match response.json():
+            case {"is_valid": False}:
+                extra, media = _profile(user)
+                return Result.taken(extra=extra, media=media)
+            case {"is_valid": True}:
+                return Result.available()
+            case _:
+                return Result.error("Unexpected Threadless response")
+
+    return impersonate_validate(
+        SIGNUP_URL,
+        process,
+        show_url=show_url,
+        allow_redirects=True,
+    )
+
+
+def _profile(user: str) -> tuple[dict, dict]:
+    try:
+        response = impersonate_request(
+            f"https://www.threadless.com/@{quote(user, safe='')}",
+            allow_redirects=True,
+        )
+    except RequestException:
+        return {}, {}
+
+    if response.status_code != 200:
+        return {}, {}
+
+    document = response.text
+    username = _text(r'var userName = "([^"]+)"', document)
+    if not username or username.casefold() != user.casefold():
+        return {}, {}
+
+    shop = _text(r'<div class="artist-shop">(.*?)</div>', document) or ""
+    shop_url = _text(r'<a href="([^"]+)" title="Visit my Artist Shop"', shop)
+    links = re.findall(
+        r'<a href="(https?://[^"]+)" target="_blank" title="[^"]+" rel="nofollow"',
+        document,
+    )
+    website = _text(
+        r'<div class="website">(?:(?!</div>).)*?<a href="([^"]+)"', document
+    )
+    shop_preview = _text(r'<img src="([^"]+)"', shop)
+    return (
+        {
+            "id": _text(r"var profileId = (\d+);", document),
+            "name": _text(r'<span class="name">\s*([^<]+)', document),
+            "bio": _text(r'<div class="cover-statement">\s*<p>(.*?)</p>', document),
+            "location": _text(
+                r'<div class="location">\s*<h3>Location</h3>\s*([^<]+)', document
+            ),
+            "following": _text(r'/following"[^>]*>\s*<span>(\d+)</span>', document),
+            "followers": _text(r'/followers"[^>]*>\s*<span>(\d+)</span>', document),
+            "member_since": _text(r"Member since ([^<]+)", document),
+            "artist_shop": urljoin("https://www.threadless.com", shop_url)
+            if shop_url
+            else None,
+            "artist_shop_slug": _text(r'var artistSlug = "([^"]+)";', document),
+            "artist_shop_name": _text(
+                r'title="Visit my Artist Shop"[^>]*>\s*([^<]+)</a>',
+                shop,
+            ),
+            "website": website,
+            "links": ", ".join(map(html.unescape, links)),
+            "threads_started": _number(r"([\d,]+) threads started", document),
+            "designs_submitted": _number(r"([\d,]+) designs submitted", document),
+            "designs_scored": _number(r"([\d,]+) designs scored", document),
+            "avg_score_given": _text(r"Avg Score Given:\s*([\d.]+)", document),
+            "is_printed_artist": _flag("isPrintedArtist", document),
+            "is_submitted_artist": _flag("isSubmittedArtist", document),
+            "is_shop_owner": _flag("isShopOwner", document),
+            "facebook_connected": _flag("fbConnected", document),
+            "is_hifiver": _flag("isHifiver", document),
+            "is_shop_published": _flag("isShopPublished", document),
+            "open_submissions": _flag("openSubs", document),
+            "is_alumni": "is-alumni" in document,
+        },
+        {
+            "avatar": _text(r'<meta property="og:image" content="([^"]+)"', document),
+            "cover": _text(
+                r'<header id="header" style="background-image: url\([\'\"]([^\'\"]+)',
+                document,
+            ),
+            "artist_shop_preview": shop_preview,
+        },
+    )
+
+
+def _text(pattern: str, document: str) -> str | None:
+    match = re.search(pattern, document, re.DOTALL)
+    return html.unescape(match.group(1)).strip() if match else None
+
+
+def _number(pattern: str, document: str) -> int | None:
+    value = _text(pattern, document)
+    return int(value.replace(",", "")) if value else None
+
+
+def _flag(name: str, document: str) -> bool | None:
+    value = _text(rf"var {name} = (true|false);", document)
+    return value == "true" if value else None

--- a/user_scanner/user_scan/creator/threadless_shop.py
+++ b/user_scanner/user_scan/creator/threadless_shop.py
@@ -1,0 +1,182 @@
+import html
+import re
+
+from curl_cffi.requests.exceptions import RequestException
+
+from user_scanner.core.impersonate import impersonate_request, impersonate_validate
+from user_scanner.core.result import Result
+
+SIGNUP_URL = "https://profile.threadless.com/artist/shops/"
+CSRF_RE = re.compile(r"name=['\"]csrfmiddlewaretoken['\"]\s+value=['\"]([^'\"]+)")
+
+
+def validate_threadless_shop(user: str) -> Result:
+    shop = user.lower()
+    show_url = f"https://{shop}.threadless.com/"
+    if not re.fullmatch(r"[a-z0-9]{1,63}", shop):
+        return Result.error(
+            "Shop name must contain only lowercase letters and numbers",
+            url=show_url,
+        )
+
+    def process(page):
+        token = CSRF_RE.search(page.text)
+        if page.status_code != 200 or not token:
+            return Result.error(
+                f"Could not read Threadless signup form (HTTP {page.status_code})"
+            )
+
+        response = impersonate_request(
+            SIGNUP_URL,
+            "POST",
+            headers={"x-requested-with": "XMLHttpRequest"},
+            data={
+                "validate": "true",
+                "shop_name": shop,
+                "csrfmiddlewaretoken": token.group(1),
+            },
+        )
+        if response.status_code != 200:
+            return Result.error(
+                f"Unexpected Threadless response: HTTP {response.status_code}"
+            )
+
+        match response.json():
+            case {"is_valid": True}:
+                return Result.available()
+            case {"is_valid": False}:
+                profile = _shop_profile(shop)
+                if profile:
+                    extra, media = profile
+                    return Result.taken(extra=extra, media=media)
+                return Result.error(
+                    "Shop name is unavailable but no public shop was found"
+                )
+            case _:
+                return Result.error("Unexpected Threadless response")
+
+    return impersonate_validate(
+        SIGNUP_URL,
+        process,
+        show_url=show_url,
+        allow_redirects=True,
+    )
+
+
+def _shop_profile(shop: str) -> tuple[dict, dict] | None:
+    try:
+        response = impersonate_request(
+            f"https://{shop}.threadless.com/", allow_redirects=True
+        )
+    except RequestException:
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    document = response.text
+    brand = _text(r'data-artist-brand="([^"]+)"', document)
+    if not brand or brand.casefold() != shop.casefold():
+        return None
+
+    about = ""
+    try:
+        about_response = impersonate_request(
+            f"https://{shop}.threadless.com/about", allow_redirects=True
+        )
+        if about_response.status_code == 200:
+            about_brand = _text(r'data-artist-brand="([^"]+)"', about_response.text)
+            if about_brand and about_brand.casefold() == shop.casefold():
+                about = about_response.text
+    except RequestException:
+        pass
+
+    social_links = []
+    website = None
+    for url, kind in re.findall(
+        r'<a class="aboutSocial-cta" href="([^"]+)".*?'
+        r'<em class="aboutSocial-title">\s*([^<]+)',
+        about,
+        re.DOTALL,
+    ):
+        url, kind = html.unescape(url), kind.strip().lower()
+        if kind == "website":
+            website = url
+        else:
+            social_links.append(f"{kind}: {url}")
+
+    title = _text(r'<meta property="og:title"\s+content="([^"]+)"', document)
+    name = title.split(" | ", 1)[0].removesuffix("'s Artist Shop") if title else None
+    return (
+        {
+            "name": name,
+            "description": _text(
+                r'<meta property="og:description"\s+content="([^"]+)"',
+                document,
+            ),
+            "owner_id": _number(r'data-to-follow="(\d+)"', document)
+            or _number(r'data-shop-user-id="(\d+)"', document),
+            "owner_name": _text(
+                r'<strong class="aboutProfile-title">(.*?)</strong>', about
+            ),
+            "location": _text(r'<p class="aboutProfile-subtitle">(.*?)</p>', about),
+            "headline": _clean(
+                r'<h2 class="(?=[^"]*\baboutTitle\b)'
+                r'(?![^"]*\b_is-hidden\b)[^"]*">(.*?)</h2>',
+                about,
+            ),
+            "biography": _clean(r'<div class="aboutContent-bio">(.*?)</div>', about),
+            "website": website,
+            "social_links": ", ".join(social_links),
+            "search_enabled": _has_link("search", document),
+            "gift_cards_enabled": _has_link("gift-cards", document),
+            "wholesale_enabled": _has_link("wholesale", document),
+            "self_reported_shop_profiles": ", ".join(
+                _clean_text(badge)
+                for badge in re.findall(r'<div class="badge-title">\s*([^<]+)', about)
+            ),
+        },
+        {
+            "logo": _text(r'<img src="([^"]+)" alt="A logo image for', document),
+            "cover": _text(
+                r'<link rel="preload" media="\(min-width: 651px\)" href="([^"]+)"',
+                document,
+            ),
+            "preview": _text(
+                r'<meta property="og:image"\s+content="([^"]+)"', document
+            ),
+            "bio_photo": _text(
+                r'<img class="aboutProfile aboutProfile--img" src="([^"]+)"',
+                about,
+            ),
+        },
+    )
+
+
+def _text(pattern: str, document: str) -> str | None:
+    match = re.search(pattern, document, re.DOTALL)
+    return html.unescape(match.group(1)).strip() if match else None
+
+
+def _number(pattern: str, document: str) -> int | None:
+    value = _text(pattern, document)
+    return int(value) if value else None
+
+
+def _has_link(path: str, document: str) -> bool:
+    return bool(
+        re.search(
+            rf'<a\b[^>]*\bhref="(?:https?://[^/"]+)?/{re.escape(path)}/?'
+            r'(?:\?[^"]*)?"',
+            document,
+        )
+    )
+
+
+def _clean(pattern: str, document: str) -> str | None:
+    value = _text(pattern, document)
+    return _clean_text(value) if value else None
+
+
+def _clean_text(value: str) -> str:
+    return " ".join(html.unescape(re.sub(r"<[^>]+>", " ", value)).split())


### PR DESCRIPTION
Username and email modules for the indie creator site [Threadless](https://www.threadless.com/). There are two separate username modules - one for individual users, the other for shop names.